### PR TITLE
Added llvm to install_osx script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![IncludeOS](./doc/IncludeOS_logo.png)
 ================================================
-IncludeOS is a [Unikernel](https://en.wikipedia.org/wiki/Unikernel) written from scratch in C++, designed x86 hardware virtualization, with no dependencies except for the virtual hardware. [Read more on the wiki](https://github.com/hioa-cs/IncludeOS/wiki). 
+IncludeOS is a [Unikernel](https://en.wikipedia.org/wiki/Unikernel) written from scratch in C++, designed for x86 hardware virtualization, with no dependencies except for the virtual hardware. [Read more on the wiki](https://github.com/hioa-cs/IncludeOS/wiki). 
 
 ## It's a research prototype!
 IncludeOS is not production ready, not feature complete, and very much a work in progress. However, it has been shown to outperform Linux virtual machines in terms of CPU usage by 5-20%, and memory usage by orders of magnitude, running a simple DNS service (both platforms ran the same binary). Preliminary performance results and a (now outdated) overview of IncludeOS will appear in an [IEEE CloudCom 2015](http://2015.cloudcom.org/) paper, titled *IncludeOS: A resource efficient unikernel for cloud services*. A [preprint is available here](doc/papers/IncludeOS_IEEE_CloudCom2015_PREPRINT.pdf), but for any [citations please refer to the publications seciton](https://github.com/hioa-cs/IncludeOS/wiki/Publications) in the [Wiki](https://github.com/hioa-cs/IncludeOS/wiki). 

--- a/etc/install_osx.sh
+++ b/etc/install_osx.sh
@@ -30,10 +30,10 @@ echo -e "\n\n# Dependencies"
 echo -e "\nllvm (clang/clang++ 3.6) - required for compiling"
 DEPENDENCY_LLVM=false
 
-BREW_LLVM=llvm
-BREW_LLVM_DIR=/usr/local/opt/$BREW_LLVM
-BREW_CLANG_CC=$BREW_LLVM_DIR/bin/clang
-BREW_CLANG_CPP=$BREW_LLVM_DIR/bin/clang++
+BREW_LLVM=llvm36
+#BREW_LLVM_DIR=/usr/local/opt/$BREW_LLVM
+BREW_CLANG_CC=/usr/local/bin/clang-3.6
+BREW_CLANG_CPP=/usr/local/bin/clang++-3.6
 
 [ -e $BREW_CLANG_CPP ] && DEPENDENCY_LLVM=true
 if ($DEPENDENCY_LLVM); then echo -e "> Found"; else echo -e "> Not Found"; fi
@@ -114,7 +114,6 @@ function install_nasm {
     echo -e "\n>>> Done installing: nasm"
 }
 
-## BINARY RELEASE ##
 
 ### INSTALL ###
 echo
@@ -187,8 +186,8 @@ gzip -c $filename | tar xopf - -C $INCLUDEOS_INSTALL_LOC
 ### Define compiler, linker and archiver
 
 # Brew clang
-export CC_INC=$BREW_CLANG_CC
-export CPP_INC=$BREW_CLANG_CPP
+#export CC_INC=$BREW_CLANG_CC
+#export CPP_INC=$BREW_CLANG_CPP
 
 # Binutils ld & ar
 export LD=$BINUTILS_LD

--- a/vmbuild/Makefile
+++ b/vmbuild/Makefile
@@ -1,14 +1,16 @@
-CPP=clang++-3.6
+ifndef CPP_INC
+	CPP_INC=clang++-3.6
+endif
 CPPOPTS = -std=c++11 -c -Wall -Wextra -O3
 OBJS = vmbuild.o
 OUT = vmbuild
 
 .cpp.o:
-	@ $(CPP) $(CPPOPTS) $< -o $@
+	@ $(CPP_INC) $(CPPOPTS) $< -o $@
 
 all: $(OBJS)
 	@ echo ">>> Building vmbuilder"
-	@ $(CPP) $(OBJS) -o $(OUT)
+	@ $(CPP_INC) $(OBJS) -o $(OUT)
 	@ echo "  * Done \n"
 
 clean:


### PR DESCRIPTION
For issue #319. Introduced [homebrew](https://brew.sh) as dependency. It will now install llvm with brew, and use the clang/clang++ compiler from that installation. Also includes some cleanup inside script, and changes to reflect the changes made in `src/Makefile` (CC => CC_INC)