### PR TITLE
Added new project_template

### DIFF
--- a/examples/project_template/Makefile
+++ b/examples/project_template/Makefile
@@ -1,0 +1,134 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# The name of your service
+SERVICE = TEMPLATE
+
+# Your service parts
+FILES = START_FILE
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+	INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+endif
+
+# Shorter name
+INSTALL = $(INCLUDEOS_INSTALL)
+
+# Compiler/Linker
+###################################################
+
+OPTIONS = -Ofast -msse3 -Wall -Wextra -mstackrealign 
+
+# External Libraries
+###################################################
+LIBC_OBJ = $(INSTALL)/newlib/libc.a
+LIBG_OBJ = $(INSTALL)/newlib/libg.a
+LIBM_OBJ = $(INSTALL)/newlib/libm.a 
+
+LIBGCC = $(INSTALL)/libgcc/libgcc.a
+LIBCXX = $(INSTALL)/libcxx/libc++.a $(INSTALL)/libcxx/libc++abi.a
+
+
+INC_NEWLIB=$(INSTALL)/newlib/include
+INC_LIBCXX=$(INSTALL)/libcxx/include
+
+DEBUG_OPTS = -ggdb3 -v
+
+CPP = clang++-3.6 -target i686-elf
+LD  = ld 
+
+INCLUDES = -I$(INC_LIBCXX) -I$(INSTALL)/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/api 
+
+CAPABS_COMMON = -msse3 -mstackrealign # Needed for 16-byte stack alignment (SSE)
+
+all: CAPABS  =  $(CAPABS_COMMON) -O2  
+debug: CAPABS = $(CAPABS_COMMON) -O0
+stripped: CAPABS = $(CAPABS_COMMON) -Oz
+
+WARNS   = -Wall -Wextra #-pedantic
+CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 -fno-stack-protector $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 #-flto -fno-exceptions
+
+LDOPTS = -nostdlib -melf_i386 -N  --script=$(INSTALL)/linker.ld -flto
+
+
+# Objects
+###################################################
+
+CRTBEGIN_OBJ = $(INSTALL)/crt/crtbegin.o
+CRTEND_OBJ = $(INSTALL)/crt/crtend.o
+CRTI_OBJ = $(INSTALL)/crt/crti.o
+CRTN_OBJ = $(INSTALL)/crt/crtn.o
+
+# Full link list
+OBJS  = $(FILES:.cpp=.o) .service_name.o
+LIBS =  $(INSTALL)/os.a $(LIBCXX) $(INSTALL)/os.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
+
+OS_PRE = $(CRTBEGIN_OBJ) $(CRTI_OBJ)
+OS_POST = $(CRTEND_OBJ) $(CRTN_OBJ)
+
+DEPS = $(OBJS:.o=.d)
+
+# Complete bulid
+###################################################
+# A complete build includes:
+# - a "service", to be linked with OS-objects (OS included)
+
+all: service
+
+stripped: LDOPTS  += -S #strip all
+stripped: CPPOPTS += -Oz
+stripped: service
+
+
+# The same, but with debugging symbols (OBS: Dramatically increases binary size)
+debug: CCOPTS  += $(DEBUG_OPTS)
+debug: CPPOPTS += $(DEBUG_OPTS)
+debug: LDOPTS  += -M --verbose
+
+debug: OBJS += $(LIBG_OBJ)
+
+debug: service #Don't wanna call 'all', since it strips debug info
+
+# Service
+###################################################
+service.o: service.cpp
+	@echo "\n>> Compiling the service"
+	$(CPP) $(CPPOPTS) -o $@ $<
+
+.service_name.o: $(INSTALL)/service_name.cpp
+	$(CPP) $(CPPOPTS) -DSERVICE_NAME="\"$(SERVICE)\"" -o $@ $<
+
+# Link the service with the os
+service: $(OBJS) $(LIBS) 
+	@echo "\n>> Linking service with OS"
+	$(LD) $(LDOPTS) $(OS_PRE) $(OBJS) $(LIBS) $(OS_POST) -o $(SERVICE)
+	@echo "\n>> Building image " $(SERVICE).img
+	$(INSTALL)/vmbuild $(INSTALL)/bootloader $(SERVICE)
+
+# Object files
+###################################################
+
+# Runtime
+crt%.o: $(INSTALL)/crt/crt%.s
+	@echo "\n>> Assembling C runtime:" $@
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# General C++-files to object files
+%.o: %.cpp
+	@echo "\n>> Compiling OS object without header"
+	$(CPP) $(CPPOPTS) -o $@ $< 
+
+# AS-assembled object files
+%.o: %.s
+	@echo "\n>> Assembling GNU 'as' files"
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# Cleanup
+###################################################
+clean: 
+	$(RM) $(OBJS) $(DEPS) $(SERVICE) 
+	$(RM) $(SERVICE).img
+
+-include $(DEPS)

--- a/examples/project_template/README.md
+++ b/examples/project_template/README.md
@@ -1,0 +1,31 @@
+## Template files for new IncludeOS projects
+
+This folder is a base folder you can use for new IncludeOS projects.
+It contains three files: 
+
+* new.sh
+Use this file to initialize the files for your new project. Simply
+run: ./new.sh my_project
+This command will modify Makefile and run.sh as well as create a
+ready-to-compile file my_project.cpp with "Hello World!" code. 
+
+* Makefile
+The Makefile will be modified with the new name of the project. When
+running the make command, you'll end up with a bootable IncludeOS
+image with the same name of your project, like "my_project.img" in the
+case above.
+
+* run.sh
+Use this file to boot your image. It will get the name of the image
+automatically from the ./new.sh script.
+
+## Quick start
+
+(Assuming you have installed IncludeOS earlier)
+
+   cp -r IncludeOS/examples/project_template ~/my_project
+   cd ~/my_project
+   ./new.sh my_project
+   make
+   ./run.sh
+   [ ctrl+a x ] to exit VM

--- a/examples/project_template/README.md
+++ b/examples/project_template/README.md
@@ -3,19 +3,19 @@
 This folder is a base folder you can use for new IncludeOS projects.
 It contains three files: 
 
-* new.sh
+### `new.sh`
 Use this file to initialize the files for your new project. Simply
-run: ./new.sh my_project
+run: `./new.sh my_project`
 This command will modify Makefile and run.sh as well as create a
 ready-to-compile file my_project.cpp with "Hello World!" code. 
 
-* Makefile
+### `Makefile`
 The Makefile will be modified with the new name of the project. When
 running the make command, you'll end up with a bootable IncludeOS
 image with the same name of your project, like "my_project.img" in the
 case above.
 
-* run.sh
+### `run.sh`
 Use this file to boot your image. It will get the name of the image
 automatically from the ./new.sh script.
 
@@ -23,9 +23,9 @@ automatically from the ./new.sh script.
 
 (Assuming you have installed IncludeOS earlier)
 
-   cp -r IncludeOS/examples/project_template ~/my_project
-   cd ~/my_project
-   ./new.sh my_project
-   make
-   ./run.sh
-   [ ctrl+a x ] to exit VM
+    cp -r IncludeOS/examples/project_template ~/my_project
+    cd ~/my_project
+    ./new.sh my_project
+    make
+    ./run.sh
+    [ ctrl+a x ] to exit VM

--- a/examples/project_template/new.sh
+++ b/examples/project_template/new.sh
@@ -1,0 +1,29 @@
+#!/bin/bash 
+
+if [ -z "$1" ]; then
+echo "At least a new project name has to be given as a parameter: "
+echo "./new.sh new_project"
+exit 2
+fi
+
+TEMPLATE=$1
+TEMPLATE=$(echo $TEMPLATE | tr ' ' '_')
+
+FILENAME=${2:-$TEMPLATE}
+
+echo "Modifying Makefile and run.sh with new project name"
+
+sed -i "s/TEMPLATE/$TEMPLATE/g" Makefile
+sed -i "s/START_FILE/${FILENAME}.cpp/g" Makefile
+sed -i "s/TEMPLATE/$TEMPLATE/g" run.sh
+
+if [ ! -f ${FILENAME}.cpp ]; then 
+echo "Creating ${FILENAME}.cpp with default content"
+echo "
+#include <os>
+
+void Service::start() {
+  printf(\"Hello World from ${TEMPLATE}!\\n\");
+}
+" > $FILENAME.cpp
+fi

--- a/examples/project_template/run.sh
+++ b/examples/project_template/run.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# Start as a GDB service, for debugging
+# (0 means no, anything else yes.)
+
+export IMAGE=${1:-TEMPLATE.img}
+
+[ ! -v INCLUDEOS_HOME ] && INCLUDEOS_HOME=$HOME/IncludeOS_install
+
+DEBUG=0
+
+[[ $2 = "debug" ]] && DEBUG=1 
+
+# Get the Qemu-command (in-source, so we can use it elsewhere)
+. $INCLUDEOS_HOME/etc/qemu_cmd.sh
+
+# Qemu with gdb debugging:
+
+if [ $DEBUG -ne 0 ]
+then
+    echo "Building system..."
+    make -B debug
+    echo "Starting VM: '$IMAGE'"
+    echo "Command: $QEMU $QEMU_OPTS"
+    echo "------------------------------------------------------------"    
+    echo "VM started in DEBUG mode. Connect with gdb/emacs:"
+    echo " - M+x gdb, Enter, then start with command"
+    echo "   gdb -i=mi service -x service.gdb"
+    echo "------------------------------------------------------------"    
+
+    sudo $QEMU -s -S $QEMU_OPTS
+else    
+
+    echo "------------------------------------------------------------"    
+    echo "Starting VM: '$IMAGE'"
+    echo "------------------------------------------------------------"        
+    sudo $QEMU $QEMU_OPTS 
+fi
+
+echo "NOTE: To run you image on another platform such as virtualbox, check out IncludeOS/etc/convert_image.sh"


### PR DESCRIPTION
A new template for IncludeOS projects in examples folder with extra script new.sh that will initialize the folder with a "hello world" example and prepare the Makefile as well as run.sh. There is also documentation in README.md.