### PR TITLE
Use Vagrant to standardize build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ vmbuild/vmbuild
 .DS_Store
 
 /.vagrant
+/examples/demo_service/IncludeOS_Demo_Service

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ vmbuild/vmbuild
 *.gz
 
 .DS_Store
+
+/.vagrant

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ Here is a video showing how to set it up and get started with IncludeOS:
 
 [![Getting started with IncludeOS video](http://img.youtube.com/vi/b2D6loApw3o/0.jpg)](http://www.youtube.com/watch?v=b2D6loApw3o)
 
+## Building with Vagrant
+
+You can use
+[Vagrant](https://github.com/hioa-cs/IncludeOS/wiki/Vagrant) to set up
+a virtual machine with the correct environment for building
+IncludeOS. The following commands will build and install IncludeOS
+into your home directory (`~/IncludeOS_install/`).
+
+```
+     $ git clone https://github.com/hioa-cs/IncludeOS.git
+     $ cd IncludeOS
+     $ vagrant up
+     $ vagrant ssh --command=/IncludeOS/etc/install_from_bundle.sh
+```
+
 ## Prerequisites for building IncludeOS VM's
   * **Ubuntu 14.04 LTS x86_64**, Vanilla, either on a physical or virtual machine (A virtualbox VM works fine)
      * For the full source build, you'll need at least 1024 MB memory
@@ -56,7 +71,6 @@ Here is a video showing how to set it up and get started with IncludeOS:
      * The install scripts may very well work on other flavours on Linux, but we haven't tried. Please let us know if you do.
      * **Building on a Mac:** we have done a successful build from bundle, directly on a Mac. It's a work in progress, but see [./etc/install_osx.sh](./etc/install_osx.sh) for details.
   * You'll need `git` to clone from github.
-
 
 Once you have a system with the prereqs (virtual or not), you can choose a full build from source, or a fast build from binaries:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.define "IncludeOS" do |config|
+    config.vm.box = "ubuntu/trusty64"
+    config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    config.vm.provider :virtualbox do |vb|
+      vb.name = "IncludeOS"
+    end
+
+    config.vm.synced_folder ".", "/vagrant", disable: true
+
+    config.vm.synced_folder ".", "/IncludeOS", create: true
+    config.vm.provision "shell",
+                        inline: "echo cd /IncludeOS >> /home/vagrant/.bashrc"
+
+    config.vm.synced_folder "~/IncludeOS_install",
+                            "/home/vagrant/IncludeOS_install", create: true
+
+    config.vm.provision "shell", inline: "apt-get update && apt-get install -qq git"
+  end
+end

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -12,7 +12,7 @@
 # Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
 # $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e. 
 
-[ ! -v INCLUDEOS_SRC ] && export INCLUDEOS_SRC=`pwd`
+[ ! -v INCLUDEOS_SRC ] && export INCLUDEOS_SRC=$(readlink -f "$(dirname "$0")/..")
 [ ! -v INCLUDEOS_INSTALL_LOC ] && export INCLUDEOS_INSTALL_LOC=$HOME
 export INCLUDEOS_HOME=$INCLUDEOS_INSTALL_LOC/IncludeOS_install
 

--- a/seed/run.sh
+++ b/seed/run.sh
@@ -1,11 +1,16 @@
 #! /bin/bash
 
-# Start as a GDB service, for debugging
-# (0 means no, anything else yes.)
+if [[ $# -lt 1 ]]; then
+    echo "Usage: IMAGE.img [debug]"
+    exit $1
+fi
+
 export IMAGE=$1
 
 [ ! -v INCLUDEOS_HOME ] && INCLUDEOS_HOME=$HOME/IncludeOS_install
 
+# Start as a GDB service, for debugging
+# (0 means no, anything else yes.)
 DEBUG=0
 
 [[ $2 = "debug" ]] && DEBUG=1 


### PR DESCRIPTION
These commits also fix two minor snags I encountered while setting up IncludeOS for the first time.