### PR TITLE
vbox script replaces disk so changes gets updated in VM

### DIFF
--- a/etc/vboxrun.sh
+++ b/etc/vboxrun.sh
@@ -36,15 +36,26 @@ targetImg="$homeDir/IncludeOS/seed/My_IncludeOS_Service.vdi"
 diskname="${disk%.*}"
 targetLoc=$diskname.vdi
 
-# Remove disk if already exists
-if [[ -e $targetLoc ]]
+# Exit script if disk can not be found.
+if [[ ! -e $disk ]]
 then
-    echo -e "\n>>> Disk already exists, removing...\n"
-    rm $diskname.vdi
+    echo -e "\n>>> '$disk' does not exist. Exiting... "
+    exit 1
 fi
 
-# Convert the disk to .vdi
-$VB convertfromraw $disk $targetLoc
+# Remove disk if already exists, but not if its equal input
+if [[ -e $targetLoc && $disk != $targetLoc ]]
+then
+    echo -e "\n>>> Disk already exists, removing...\n"
+    rm $targetLoc
+fi
+
+# Convert the disk to .vdi.
+# If input == output, no conversion is needed.
+if [[ $disk != $targetLoc ]]
+then
+    $VB convertfromraw $disk $targetLoc
+fi
 
 SERIAL_FILE="$(pwd)/$VMNAME.console.pipe"
 

--- a/etc/vboxrun.sh
+++ b/etc/vboxrun.sh
@@ -36,8 +36,6 @@ targetImg="$homeDir/IncludeOS/seed/My_IncludeOS_Service.vdi"
 diskname="${disk%.*}"
 targetLoc=$diskname.vdi
 
-echo -e "$diskname"
-
 # Remove disk if already exists
 if [[ -e $targetLoc ]]
 then

--- a/etc/vboxrun.sh
+++ b/etc/vboxrun.sh
@@ -36,11 +36,17 @@ targetImg="$homeDir/IncludeOS/seed/My_IncludeOS_Service.vdi"
 diskname="${disk%.*}"
 targetLoc=$diskname.vdi
 
-# Convert the disk to .vdi if needed
-if [[ $disk != *.vdi && ! -e $diskname.vdi ]]
+echo -e "$diskname"
+
+# Remove disk if already exists
+if [[ -e $targetLoc ]]
 then
-    $VB convertfromraw $disk $targetLoc
+    echo -e "\n>>> Disk already exists, removing...\n"
+    rm $diskname.vdi
 fi
+
+# Convert the disk to .vdi
+$VB convertfromraw $disk $targetLoc
 
 SERIAL_FILE="$(pwd)/$VMNAME.console.pipe"
 


### PR DESCRIPTION
vboxrun.sh only converted the .img to .vdi if .vdi didn't exist. To update your VM with the changes from your service you had to first remove the .vdi, even if the .img (service) had changed.

The script will now remove the .vdi if it already exists, and always convert a new .vdi from .img.