### PR TITLE
return proper error if fork isn't supported

### DIFF
--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -55,7 +55,7 @@ int execve(const char* UNUSED(name),
 
 int fork(){
   debug("SYSCALL FORK NOT SUPPORTED");
-  errno=ENOMEM;
+  errno=ENOSYS;
   return -1;
 };
 


### PR DESCRIPTION
fork manpage states that ENOSYS is returned if fork() isn't supported on this platform.