### PR TITLE
pci_manager.hpp moved from api/hw to api/kernel

### DIFF
--- a/api/hw/dev.hpp
+++ b/api/hw/dev.hpp
@@ -21,11 +21,11 @@
 #include <common>
 #include <virtio/virtionet.hpp>
 #include <virtio/virtio_blk.hpp>
+#include <kernel/pci_manager.hpp>
 
 #include "nic.hpp"
 #include "pit.hpp"
 #include "disk.hpp"
-#include "pci_manager.hpp"
 
 namespace hw {
 

--- a/api/kernel/pci_manager.hpp
+++ b/api/kernel/pci_manager.hpp
@@ -15,14 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef HW_PCI_MANAGER_HPP
-#define HW_PCI_MANAGER_HPP
+#ifndef KERNEL_PCI_MANAGER_HPP
+#define KERNEL_PCI_MANAGER_HPP
 
 #include <vector>
 #include <cstdio>
 #include <unordered_map>
 
-#include "pci_device.hpp"
+#include <hw/pci_device.hpp>
 
 class PCI_manager {
 private:
@@ -53,4 +53,4 @@ private:
   friend class OS;
 }; //< class PCI_manager
 
-#endif //< HW_PCI_MANAGER_HPP
+#endif //< KERNEL_PCI_MANAGER_HPP

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -26,7 +26,7 @@
 
 // A private class to handle IRQ
 #include <hw/ioport.hpp>
-#include <hw/pci_manager.hpp>
+#include <kernel/pci_manager.hpp>
 #include <kernel/irq_manager.hpp>
 
 bool OS::power_   {true};

--- a/src/kernel/pci_manager.cpp
+++ b/src/kernel/pci_manager.cpp
@@ -19,8 +19,7 @@
 
 #include <common>
 
-#include <hw/pci_device.hpp>
-#include <hw/pci_manager.hpp>
+#include <kernel/pci_manager.hpp>
 
 #define NUM_BUSES 2
 


### PR DESCRIPTION
The pci_manager doesn't represent a hardware component but just
manages pci_devices. Besides, the source file pci_manager.cpp
was already in the src/kernel folder.