### PR TITLE
First draft of IDE device driver implementation

### DIFF
--- a/api/hw/disk.hpp
+++ b/api/hw/disk.hpp
@@ -22,9 +22,6 @@
 
 namespace hw {
 
-/** Hopefully somebody will port a driver for this one */
-class IDE;
-
 template <typename DRIVER>
 class Disk {
 public:

--- a/api/hw/ide.hpp
+++ b/api/hw/ide.hpp
@@ -1,0 +1,73 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HW_IDE_HPP
+#define HW_IDE_HPP
+
+#include <delegate>
+#include <hw/pci_device.hpp>
+
+namespace hw {
+
+  /** IDE device driver.  */
+  class IDE
+  {
+    public:
+      typedef uint64_t block_t;
+      typedef delegate<void(block_t, char*)> on_read_func;
+      typedef delegate<void(block_t, block_t)> on_write_func;
+
+      /** Human readable name.  */
+      constexpr const char* name() const
+      {
+        return "IDE Controller";
+      }
+
+      /** Returns the optimal block size for this device.  */
+      constexpr block_t block_size() const
+      {
+        return 512;
+      }
+
+      void read(block_t blk, on_read_func del);
+      void write(block_t blk, const char* data);
+
+      /**
+       * Constructor.
+       * @param pcidev An initialized PCI device.
+       */
+      IDE(hw::PCI_Device& pcidev);
+
+    private:
+      void set_drive(uint8_t drive);
+      void set_nbsectors(uint8_t cnt);
+      void set_blocknum(block_t blk);
+      void set_command(uint16_t command);
+
+      void wait_status_busy(void);
+      void wait_status_flags(int flags, bool set);
+
+    private:
+      hw::PCI_Device& _pcidev; // PCI device
+      uint8_t _drive; // Drive id (IDE_MASTER or IDE_SLAVE)
+      uint32_t _iobase; // PCI device io base address.
+      block_t _nb_blk; // Max nb blocks of the device
+  };
+
+} //< namespace hw
+
+#endif //< HW_IDE_HPP

--- a/api/hw/ioport.hpp
+++ b/api/hw/ioport.hpp
@@ -42,6 +42,26 @@ namespace hw {
     __asm__ volatile ("outb %%al,%%dx"::"a" (data), "d"(port));
   }
 
+  /** Receive a word from port.
+      @param port : The port number to receive from
+  */
+  static inline uint16_t inw(int port)
+  {
+    int ret;
+    __asm__ volatile ("xorl %eax,%eax");
+    __asm__ volatile ("inw %%dx,%%ax":"=a" (ret):"d"(port));
+
+    return ret;
+  }
+
+  /** Send a word to port.
+      @param port : The port to send to
+      @param data : One word of data to send to @param port
+  */
+  static inline void outw(int port, uint16_t data) {
+    __asm__ volatile ("outw %%ax,%%dx"::"a" (data), "d"(port));
+  }
+
 } //< namespace hw
 
 #endif // HW_IOPORT_HPP

--- a/src/Makefile
+++ b/src/Makefile
@@ -64,7 +64,7 @@ OS_OBJECTS = kernel/kernel_start.o kernel/syscalls.o kernel/vga.o \
 		kernel/irq_manager.o kernel/pci_manager.o \
 		crt/c_abi.o crt/string.o crt/quick_exit.o crt/cxx_abi.o  crt/mman.o \
 		util/memstream.o \
-		hw/pit.o hw/pic.o hw/pci_device.o hw/cpu_freq_sampling.o \
+		hw/ide.o hw/pit.o hw/pic.o hw/pci_device.o hw/cpu_freq_sampling.o \
 		virtio/virtio.o virtio/virtionet.o virtio/virtio_blk.o \
 		virtio/virtio_con.o virtio/virtio_queue.o \
 		net/ethernet.o net/inet_common.o net/arp.o net/ip4.o \

--- a/src/hw/ide.cpp
+++ b/src/hw/ide.cpp
@@ -1,0 +1,172 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Intel IDE Controller datasheet at :
+ * ftp://download.intel.com/design/intarch/datashts/29055002.pdf
+ */
+
+#include <hw/ide.hpp>
+#include <kernel/irq_manager.hpp>
+#include <kernel/syscalls.hpp>
+
+#define IDE_DATA        0x1F0
+#define IDE_SECCNT      0x1F2
+#define IDE_BLKLO       0x1F3
+#define IDE_BLKMID      0x1F4
+#define IDE_BLKHI       0x1F5
+#define IDE_DRV         0x1F6
+#define IDE_CMD         0x1F7
+#define IDE_STATUS      IDE_CMD
+
+#define IDE_CMD_READ     0x20
+#define IDE_CMD_WRITE    0x30
+#define IDE_CMD_IDENTIFY 0xEC
+
+#define IDE_MASTER  0x00
+#define IDE_SLAVE   0x10
+
+#define IDE_DRQ      (1 << 3)
+#define IDE_DRDY     (1 << 6)
+#define IDE_BUSY     (1 << 7)
+
+#define IDE_VENDOR_ID   PCI_Device::VENDOR_INTEL
+#define IDE_PRODUCT_ID  0x7010
+
+#define IDE_TIMEOUT 2048
+
+namespace hw {
+
+  void IDE::read(block_t blk, on_read_func del)
+  {
+    if (blk >= _nb_blk) {
+      del(blk, NULL);
+      return;
+    }
+
+    set_drive(0xE0 | (_drive << 4) | ((blk >> 24) & 0x0F));
+    set_nbsectors(1);
+    set_blocknum(blk);
+    set_command(IDE_CMD_READ);
+
+    uint16_t* buf = new uint16_t[block_size()];
+
+    wait_status_flags(IDE_DRDY, false);
+    for (block_t i = 0; i < block_size() / sizeof (uint16_t); i++)
+      buf[i] = inw(IDE_DATA);
+
+    del(blk, (char*)buf);
+  }
+
+  IDE::IDE(hw::PCI_Device& pcidev)
+    : _pcidev(pcidev)
+    , _drive(IDE_MASTER)
+    , _iobase(0)
+    , _nb_blk(0)
+  {
+    INFO("IDE","VENDOR_ID : 0x%x, PRODUCT_ID : 0x%x", _pcidev.vendor_id(), _pcidev.product_id());
+    INFO("IDE","Attaching to  PCI addr 0x%x",_pcidev.pci_addr());
+
+    // PCI device checking
+    if (_pcidev.vendor_id() != IDE_VENDOR_ID)
+      panic("This is not an Intel device");
+    CHECK(true, "Vendor ID is INTEL");
+
+    if (_pcidev.product_id() != IDE_PRODUCT_ID)
+      panic("This is not an IDE Controller");
+    CHECK(true, "Product ID is IDE Controller");
+
+    // Probe PCI resources and fetch I/O-base for device
+    _pcidev.probe_resources();
+    _iobase = _pcidev.iobase();
+    CHECK(_iobase, "Unit has valid I/O base (0x%x)", _iobase);
+
+    // IDE device initialization
+    set_drive(_drive);
+    set_nbsectors(0);
+    set_blocknum(0);
+    set_command(IDE_CMD_IDENTIFY);
+
+    if (!inb(IDE_STATUS))
+      panic("Device not found");
+    CHECK(true, "IDE device found");
+    wait_status_flags(IDE_DRDY, false);
+
+    uint16_t buffer[256];
+    for (int i = 0; i < 256; i++)
+      buffer[i] = inw(IDE_DATA);
+
+    _nb_blk = (buffer[61] << 16) | buffer[60];
+
+    INFO("IDE", "Initialization complete");
+  }
+
+  void IDE::wait_status_busy(void)
+  {
+    uint8_t ret;
+    while (((ret = inb(IDE_STATUS)) & IDE_BUSY) == IDE_BUSY);
+  }
+
+  void IDE::wait_status_flags(int flags, bool set)
+  {
+    wait_status_busy();
+
+    int i;
+    uint8_t ret = inb(IDE_STATUS);
+    for (i = IDE_TIMEOUT; i; i--) {
+      if (set) {
+        if ((ret & flags) != flags)
+          break;
+      } else {
+        if ((ret & flags) != flags)
+          break;
+      }
+      ret = inb(IDE_STATUS);
+    }
+  }
+
+  void IDE::set_drive(uint8_t drive)
+  {
+    wait_status_flags(IDE_DRQ, true);
+    outb(IDE_DRV, drive);
+  }
+
+  void IDE::set_nbsectors(uint8_t cnt)
+  {
+    wait_status_flags(IDE_DRQ, true);
+    outb(IDE_SECCNT, cnt);
+  }
+
+  void IDE::set_blocknum(block_t blk)
+  {
+    wait_status_flags(IDE_DRQ, true);
+    outb(IDE_BLKLO, blk & 0xFF);
+
+    wait_status_flags(IDE_DRQ, true);
+    outb(IDE_BLKMID, (blk & 0xFF00) >> 8);
+
+    wait_status_flags(IDE_DRQ, true);
+    outb(IDE_BLKHI, (blk & 0xFF0000) >> 16);
+  }
+
+  void IDE::set_command(uint16_t command)
+  {
+    wait_status_flags(IDE_DRDY, false);
+    outb(IDE_CMD, command);
+  }
+
+} //< namespace hw

--- a/test/disks/Makefile
+++ b/test/disks/Makefile
@@ -1,0 +1,134 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# The name of your service
+SERVICE = Test_disks
+
+# Your service parts
+FILES = service.cpp
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+	INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+endif
+
+# Shorter name
+INSTALL = $(INCLUDEOS_INSTALL)
+
+# Compiler/Linker
+###################################################
+
+OPTIONS = -Ofast -msse3 -Wall -Wextra -mstackrealign
+
+# External Libraries
+###################################################
+LIBC_OBJ = $(INSTALL)/newlib/libc.a
+LIBG_OBJ = $(INSTALL)/newlib/libg.a
+LIBM_OBJ = $(INSTALL)/newlib/libm.a
+
+LIBGCC = $(INSTALL)/libgcc/libgcc.a
+LIBCXX = $(INSTALL)/libcxx/libc++.a $(INSTALL)/libcxx/libc++abi.a
+
+
+INC_NEWLIB=$(INSTALL)/newlib/include
+INC_LIBCXX=$(INSTALL)/libcxx/include
+
+DEBUG_OPTS = -ggdb3 -v
+
+CPP = clang++-3.6 -target i686-elf
+LD  = ld
+
+INCLUDES = -I$(INC_LIBCXX) -I$(INSTALL)/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/api
+
+CAPABS_COMMON = -msse3 -mstackrealign # Needed for 16-byte stack alignment (SSE)
+
+all: CAPABS  =  $(CAPABS_COMMON) -O2
+debug: CAPABS = $(CAPABS_COMMON) -O0
+stripped: CAPABS = $(CAPABS_COMMON) -Oz
+
+WARNS   = -Wall -Wextra #-pedantic
+CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 -fno-stack-protector $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 #-flto -fno-exceptions
+
+LDOPTS = -nostdlib -melf_i386 -N  --script=$(INSTALL)/linker.ld -flto
+
+
+# Objects
+###################################################
+
+CRTBEGIN_OBJ = $(INSTALL)/crt/crtbegin.o
+CRTEND_OBJ = $(INSTALL)/crt/crtend.o
+CRTI_OBJ = $(INSTALL)/crt/crti.o
+CRTN_OBJ = $(INSTALL)/crt/crtn.o
+
+# Full link list
+OBJS  = $(FILES:.cpp=.o) .service_name.o
+LIBS =  $(INSTALL)/os.a $(LIBCXX) $(INSTALL)/os.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
+
+OS_PRE = $(CRTBEGIN_OBJ) $(CRTI_OBJ)
+OS_POST = $(CRTEND_OBJ) $(CRTN_OBJ)
+
+DEPS = $(OBJS:.o=.d)
+
+# Complete bulid
+###################################################
+# A complete build includes:
+# - a "service", to be linked with OS-objects (OS included)
+
+all: service
+
+stripped: LDOPTS  += -S #strip all
+stripped: CPPOPTS += -Oz
+stripped: service
+
+
+# The same, but with debugging symbols (OBS: Dramatically increases binary size)
+debug: CCOPTS  += $(DEBUG_OPTS)
+debug: CPPOPTS += $(DEBUG_OPTS)
+debug: LDOPTS  += -M --verbose
+
+debug: OBJS += $(LIBG_OBJ)
+
+debug: service #Don't wanna call 'all', since it strips debug info
+
+# Service
+###################################################
+service.o: service.cpp
+	@echo "\n>> Compiling the service"
+	$(CPP) $(CPPOPTS) -o $@ $<
+
+.service_name.o: $(INSTALL)/service_name.cpp
+	$(CPP) $(CPPOPTS) -DSERVICE_NAME="\"$(SERVICE)\"" -o $@ $<
+
+# Link the service with the os
+service: $(OBJS) $(LIBS)
+	@echo "\n>> Linking service with OS"
+	$(LD) $(LDOPTS) $(OS_PRE) $(OBJS) $(LIBS) $(OS_POST) -o $(SERVICE)
+	@echo "\n>> Building image " $(SERVICE).img
+	$(INSTALL)/vmbuild $(INSTALL)/bootloader $(SERVICE)
+
+# Object files
+###################################################
+
+# Runtime
+crt%.o: $(INSTALL)/crt/crt%.s
+	@echo "\n>> Assembling C runtime:" $@
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# General C++-files to object files
+%.o: %.cpp
+	@echo "\n>> Compiling OS object without header"
+	$(CPP) $(CPPOPTS) -o $@ $<
+
+# AS-assembled object files
+%.o: %.s
+	@echo "\n>> Assembling GNU 'as' files"
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# Cleanup
+###################################################
+clean:
+	$(RM) $(OBJS) $(DEPS) $(SERVICE)
+	$(RM) $(SERVICE).img
+
+-include $(DEPS)

--- a/test/disks/debug/service.gdb
+++ b/test/disks/debug/service.gdb
@@ -1,0 +1,5 @@
+file service
+break _start
+break OS::start
+set non-stop off
+target remote localhost:1234

--- a/test/disks/run.sh
+++ b/test/disks/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh

--- a/test/disks/service.cpp
+++ b/test/disks/service.cpp
@@ -1,0 +1,47 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <os>
+#include <hw/ide.hpp>
+
+static void del(hw::IDE::block_t blk, char* data)
+{
+  (void)blk;
+
+  if (!data) {
+    printf("Error while reading\n");
+    printf("Test failed\n");
+    return;
+  }
+
+  if ((uint8_t)data[510] == 0x55 and (uint8_t)data[511] == 0xAA)
+    printf("Test passed\n");
+  else
+    printf("Test failed\n");
+}
+
+void Service::start()
+{
+  printf("TESTING Disks\n");
+
+  hw::Disk<hw::IDE>& disk0 = hw::Dev::disk<0, hw::IDE>();
+
+  printf("Name : %s\n", disk0.name());
+  printf("Block size : %llu\n", disk0.block_size());
+
+  disk0.read(0, del);
+}


### PR DESCRIPTION
Hi, I just have a few questions about it :

1) For the moment, the `IDE` class only handles the `master` device. Do you
    think that it could be interesting to handle the `slave` device too?
    If so, how could we give the information to the `IDE` class?

2) I don't have implemented the `write` function yet, how should I do that?
    I saw that in the `VirtioBlk` class it's the same thing, what about it? And shouldn't
    we have an Interface `IBlkDriver` which would be implemented by `IDE`, `VirtioBlk`
    and the other block devices?

3) Could you explain me a little how should the FileSystem work in IncludeOS?
   What if I want to bind the IDE with a FS? Shouldn't we make the `hw::Disk`
   class implement the `IDiskDevice` interface?

Cheers.