### PR TITLE
examples: cleaned up demo_service and added a new tcp example

### DIFF
--- a/api/net/tcp.hpp
+++ b/api/net/tcp.hpp
@@ -390,7 +390,7 @@ public:
 
 		inline void push(const T& packet) {
 			buffer_.push(packet);
-			data_length_ += packet->data_length();
+			data_length_ += (size_t)packet->data_length();
 		}
 
 		inline bool add(T packet) {
@@ -400,7 +400,7 @@ public:
 		}
 
 		inline void pop() {
-			data_length_ -= buffer_.front()->data_length();
+			data_length_ -= (size_t)buffer_.front()->data_length();
 			buffer_.pop();
 		}
 

--- a/examples/demo_service/service.cpp
+++ b/examples/demo_service/service.cpp
@@ -18,21 +18,12 @@
 #include <os>
 #include <net/inet4>
 #include <math.h>
-#include <iostream>
 #include <sstream>
-#include <net/dhcp/dh4client.hpp>
 
 using namespace std::chrono;
 
 // An IP-stack object
 std::unique_ptr<net::Inet4<VirtioNet> > inet;
-
-std::vector<std::string> BUFFER;
-std::shared_ptr<net::TCP::Connection> RSH_PEER {nullptr};
-void write_rsh(const char* data, size_t n) {
-  //OS::rswrite('X');
-  RSH_PEER->write(data, n);
-}
 
 void Service::start() {
   // Assign a driver (VirtioNet) to a network interface (eth0)
@@ -56,24 +47,6 @@ void Service::start() {
   printf("Size of IP-stack: %i b \n",sizeof(inet));
   printf("Service IP address: %s \n", inet->ip_addr().str().c_str());
 
-  // buffer up all output until connection is established
-  /*OS::set_rsprint([](const char* data, size_t n){
-    BUFFER.push_back({data, n});
-  });*/
-    
-  auto& rsh = inet->tcp().bind(22);
-
-  
-
-  rsh.onConnect([](auto conn) {
-    // change print to write directly to connection.
-    printf("Established remote shell connection, changing rsprint... \n");
-    RSH_PEER = conn;
-    OS::set_rsprint(&write_rsh);
-  });
-
-
-
   // Set up a TCP server on port 80
   auto& server = inet->tcp().bind(80);
   
@@ -93,7 +66,7 @@ void Service::start() {
 
   }).onReceive([](auto conn, bool push) {
       std::string data = conn->read(1024);
-      printf("<Service> @onData - PUSH: %d, Data read: \n %s \n", push, data.c_str());
+      printf("<Service> @onData - PUSH: %d, Data read: \n%s\n", push, data.c_str());
       printf("<Service> Status: %s \n", conn->to_string().c_str());
       int color = rand();
       std::stringstream stream;
@@ -110,7 +83,7 @@ void Service::start() {
        << "<h1 style= \"color: " << "#" << std::hex << (color >> 8) << "\">"  
        <<  "<span style=\""+ubuntu_medium+"\">Include</span><span style=\""+ubuntu_light+"\">OS</span> </h1>"
        <<  "<h2>Now speaks TCP!</h2>"
-  // .... generate more dynamic content 
+        // .... generate more dynamic content 
        << "<p>  ...and can improvise http. With limitations of course, but it's been easier than expected so far </p>"
        << "<footer><hr /> &copy; 2015, Oslo and Akershus University College of Applied Sciences </footer>"
        << "</body></html>\n";
@@ -118,13 +91,13 @@ void Service::start() {
       /* HTTP-header */
       std::string html = stream.str();
       std::string header="HTTP/1.1 200 OK \n "        \
-  "Date: Mon, 01 Jan 1970 00:00:01 GMT \n"      \
-  "Server: IncludeOS prototype 4.0 \n"        \
-  "Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT \n"   \
-  "Content-Type: text/html; charset=UTF-8 \n"     \
-  "Content-Length: "+std::to_string(html.size())+"\n"   \
-  "Accept-Ranges: bytes\n"          \
-  "Connection: close\n\n";
+        "Date: Mon, 01 Jan 1970 00:00:01 GMT \n"      \
+        "Server: IncludeOS prototype 4.0 \n"        \
+        "Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT \n"   \
+        "Content-Type: text/html; charset=UTF-8 \n"     \
+        "Content-Length: "+std::to_string(html.size())+"\n"   \
+        "Accept-Ranges: bytes\n"          \
+        "Connection: close\n\n";
       
       std::string output{header + html};
       conn->write(output.data(), output.size());
@@ -132,21 +105,7 @@ void Service::start() {
   }).onDisconnect([](auto conn, std::string msg) {
       printf("<Service> @onDisconnect - Reason: %s \n", msg.c_str());
       printf("<Service> TCP STATUS:\n%s \n", conn->host().status().c_str());
-
   });
 
-  // Set up a Active conneciton
-  /*net::TCP::Connection& active_con = inet->tcp().connect({{23,235,43,133}});
-
-  active_con.onConnect([](net::TCP::Connection& conn) {
-      std::string request{"GET / HTTP/1.1 \n"};
-      conn.write(request.data(), request.size());
-  }).onData([](net::TCP::Connection& conn, bool PUSH) {
-
-  }).onDisconnect([](net::TCP::Connection& conn, std::string msg) {
-
-  });*/
-
   printf("*** TEST SERVICE STARTED *** \n");
-
 }

--- a/examples/tcp/Makefile
+++ b/examples/tcp/Makefile
@@ -1,0 +1,136 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# The name of your service
+SERVICE = tcp_demo
+
+# Your service parts
+FILES = service.cpp
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+	INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+endif
+
+# Shorter name
+INSTALL = $(INCLUDEOS_INSTALL)
+
+# Compiler/Linker
+###################################################
+
+OPTIONS = -Ofast -msse3 -Wall -Wextra -mstackrealign 
+
+# External Libraries
+###################################################
+LIBC_OBJ = $(INSTALL)/newlib/libc.a
+LIBG_OBJ = $(INSTALL)/newlib/libg.a
+LIBM_OBJ = $(INSTALL)/newlib/libm.a 
+
+LIBGCC = $(INSTALL)/libgcc/libgcc.a
+LIBCXX = $(INSTALL)/libcxx/libc++.a $(INSTALL)/libcxx/libc++abi.a
+
+
+INC_NEWLIB=$(INSTALL)/newlib/include
+INC_LIBCXX=$(INSTALL)/libcxx/include
+
+DEBUG_OPTS = -ggdb3 -v
+
+CPP = clang++-3.6 -target i686-elf
+ifndef LD_INC
+	LD_INC = ld
+endif
+
+INCLUDES = -I$(INC_LIBCXX) -I$(INSTALL)/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/api 
+
+CAPABS_COMMON = -msse3 -mstackrealign # Needed for 16-byte stack alignment (SSE)
+
+all: CAPABS  =  $(CAPABS_COMMON) -O2  
+debug: CAPABS = $(CAPABS_COMMON) -O0
+stripped: CAPABS = $(CAPABS_COMMON) -Oz
+
+WARNS   = -Wall -Wextra #-pedantic
+CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 -fno-stack-protector $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 #-flto -fno-exceptions
+
+LDOPTS = -nostdlib -melf_i386 -N  --script=$(INSTALL)/linker.ld -flto
+
+
+# Objects
+###################################################
+
+CRTBEGIN_OBJ = $(INSTALL)/crt/crtbegin.o
+CRTEND_OBJ = $(INSTALL)/crt/crtend.o
+CRTI_OBJ = $(INSTALL)/crt/crti.o
+CRTN_OBJ = $(INSTALL)/crt/crtn.o
+
+# Full link list
+OBJS  = $(FILES:.cpp=.o) .service_name.o
+LIBS =  $(INSTALL)/os.a $(LIBCXX) $(INSTALL)/os.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
+
+OS_PRE = $(CRTBEGIN_OBJ) $(CRTI_OBJ)
+OS_POST = $(CRTEND_OBJ) $(CRTN_OBJ)
+
+DEPS = $(OBJS:.o=.d)
+
+# Complete bulid
+###################################################
+# A complete build includes:
+# - a "service", to be linked with OS-objects (OS included)
+
+all: service
+
+stripped: LDOPTS  += -S #strip all
+stripped: CPPOPTS += -Oz
+stripped: service
+
+
+# The same, but with debugging symbols (OBS: Dramatically increases binary size)
+debug: CCOPTS  += $(DEBUG_OPTS)
+debug: CPPOPTS += $(DEBUG_OPTS)
+debug: LDOPTS  += -M --verbose
+
+debug: OBJS += $(LIBG_OBJ)
+
+debug: service #Don't wanna call 'all', since it strips debug info
+
+# Service
+###################################################
+service.o: service.cpp
+	@echo "\n>> Compiling the service"
+	$(CPP) $(CPPOPTS) -o $@ $<
+
+.service_name.o: $(INSTALL)/service_name.cpp
+	$(CPP) $(CPPOPTS) -DSERVICE_NAME="\"$(SERVICE)\"" -o $@ $<
+
+# Link the service with the os
+service: $(OBJS) $(LIBS) 
+	@echo "\n>> Linking service with OS"
+	$(LD_INC) $(LDOPTS) $(OS_PRE) $(OBJS) $(LIBS) $(OS_POST) -o $(SERVICE)
+	@echo "\n>> Building image " $(SERVICE).img
+	$(INSTALL)/vmbuild $(INSTALL)/bootloader $(SERVICE)
+
+# Object files
+###################################################
+
+# Runtime
+crt%.o: $(INSTALL)/crt/crt%.s
+	@echo "\n>> Assembling C runtime:" $@
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# General C++-files to object files
+%.o: %.cpp
+	@echo "\n>> Compiling OS object without header"
+	$(CPP) $(CPPOPTS) -o $@ $< 
+
+# AS-assembled object files
+%.o: %.s
+	@echo "\n>> Assembling GNU 'as' files"
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# Cleanup
+###################################################
+clean: 
+	$(RM) $(OBJS) $(DEPS) $(SERVICE) 
+	$(RM) $(SERVICE).img
+
+-include $(DEPS)

--- a/examples/tcp/debug/service.gdb
+++ b/examples/tcp/debug/service.gdb
@@ -1,0 +1,5 @@
+file service
+break _start
+break OS::start
+set non-stop off
+target remote localhost:1234

--- a/examples/tcp/run.sh
+++ b/examples/tcp/run.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh
+

--- a/examples/tcp/server.py
+++ b/examples/tcp/server.py
@@ -1,0 +1,36 @@
+import socket
+import sys
+
+# Create a TCP/IP socket
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+# Bind the socket to the port
+server_address = ('127.0.0.1', 1337)
+print >>sys.stderr, 'starting up on %s port %s' % server_address
+sock.bind(server_address)
+
+# Listen for incoming connections
+sock.listen(5)
+
+while True:
+    # Wait for a connection
+    print >>sys.stderr, 'waiting for a connection'
+    connection, client_address = sock.accept()
+
+    try:
+        print >>sys.stderr, 'connection from', client_address
+
+        # Receive the data in small chunks and retransmit it
+        while True:
+            data = connection.recv(1024)
+            if data:
+                print >>sys.stderr, 'received: %s' % data
+                connection.sendall(data)
+                #connection.close()
+            else:
+                print >>sys.stderr, 'no more data from', client_address
+                break
+            
+    finally:
+        # Clean up the connection
+        connection.close()

--- a/examples/tcp/server.py
+++ b/examples/tcp/server.py
@@ -20,15 +20,13 @@ while True:
     try:
         print >>sys.stderr, 'connection from', client_address
 
-        # Receive the data in small chunks and retransmit it
         while True:
             data = connection.recv(1024)
             if data:
                 print >>sys.stderr, 'received: %s' % data
                 connection.sendall(data)
-                #connection.close()
             else:
-                print >>sys.stderr, 'no more data from', client_address
+                print >>sys.stderr, 'closing', client_address
                 break
             
     finally:

--- a/examples/tcp/service.cpp
+++ b/examples/tcp/service.cpp
@@ -1,0 +1,75 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <os>
+#include <net/inet4>
+#include <math.h>
+#include <net/dhcp/dh4client.hpp>
+
+using namespace std::chrono;
+
+// An IP-stack object
+std::unique_ptr<net::Inet4<VirtioNet> > inet;
+net::TCP::Socket python_server{ {{10,0,2,2}} , 1337};
+
+void Service::start() {
+  // Assign a driver (VirtioNet) to a network interface (eth0)
+  hw::Nic<VirtioNet>& eth0 = hw::Dev::eth<0,VirtioNet>();
+  
+  // Bring up a network stack, attached to the nic
+  inet = std::make_unique<net::Inet4<VirtioNet> >(eth0);
+  
+  // Static IP configuration, until we (possibly) get DHCP
+  inet->network_config( {{ 10,0,0,42 }},      // IP
+			{{ 255,255,255,0 }},  // Netmask
+			{{ 10,0,0,1 }},       // Gateway
+			{{ 8,8,8,8 }} );      // DNS
+    
+  
+  // Set up a TCP server on port 80
+  auto& server = inet->tcp().bind(80);
+  
+  printf("Server listening: %s \n", server.to_string().c_str());
+  
+  server
+  // Client has connected
+  .onConnect([](std::shared_ptr<net::TCP::Connection> client) {
+  	printf("Connected [Client]: %s\n", client->remote().to_string().c_str());
+		// Connect to our python server
+		inet->tcp().connect(python_server)
+		// When connection established
+		->onConnect([client](std::shared_ptr<net::TCP::Connection> python) {
+			printf("Connected [Python]: %s\n", python->to_string().c_str());
+			
+			client->onReceive([python](std::shared_ptr<net::TCP::Connection> client, bool) {
+				// Read the request from our client
+    		std::string request = client->read(1024);
+    		printf("Received [Client]: %s\n", request.c_str());
+    		python->write(request);
+
+			});
+
+			python->onReceive([client](std::shared_ptr<net::TCP::Connection> python, bool) {
+				// Read the response from our python server
+				std::string response = python->read(1024);
+				client->write(response);
+
+			});
+		}); // << onConnect (python)
+	}); // << onConnect (client)
+
+}

--- a/src/net/tcp.cpp
+++ b/src/net/tcp.cpp
@@ -170,7 +170,7 @@ void TCP::bottom(net::Packet_ptr packet_ptr) {
 		if(listen_conn_it != listeners.end()) {
 			auto& listen_conn = listen_conn_it->second;
 			debug("<TCP::bottom> Listener found: %s ...\n", listen_conn.to_string().c_str());
-			auto connection = (connections.emplace(tuple, std::make_shared<Connection>(Connection{listen_conn})).first->second);
+			auto connection = (connections.emplace(tuple, std::make_shared<Connection>(listen_conn)).first->second);
 			// Set remote
 			connection->set_remote(packet->source());
 			debug("<TCP::bottom> ... Creating connection: %s \n", connection->to_string().c_str());
@@ -200,7 +200,7 @@ string TCP::status() const {
 	}
 	ss << "\nCONNECTIONS:\n" <<  "Proto\tRecv\tSend\tIn\tOut\tLocal\t\t\tRemote\t\t\tState\n";
 	for(auto con_it : connections) {
-		auto c = *(con_it.second);
+		auto& c = *(con_it.second);
 		ss << "tcp4\t" 
 			<< c.receive_buffer().data_size() << "\t" << c.send_buffer().data_size() << "\t"
 			<< c.bytes_received() << "\t" << c.bytes_transmitted() << "\t"

--- a/src/net/tcp.cpp
+++ b/src/net/tcp.cpp
@@ -202,7 +202,7 @@ string TCP::status() const {
 	for(auto con_it : connections) {
 		auto& c = *(con_it.second);
 		ss << "tcp4\t" 
-			<< c.receive_buffer().data_size() << "\t" << c.send_buffer().data_size() << "\t"
+			<< " " << "\t" << " " << "\t"
 			<< c.bytes_received() << "\t" << c.bytes_transmitted() << "\t"
 			<< c.local().to_string() << "\t\t" << c.remote().to_string() << "\t\t" 
 			<< c.state().to_string() << "\n";

--- a/src/net/tcp_connection.cpp
+++ b/src/net/tcp_connection.cpp
@@ -174,7 +174,6 @@ void Connection::close() {
 		if(is_state(Closed::instance()))
 			signal_close();
 	} catch(TCPException err) {
-		debug("<TCP::Connection::close> Active close on connection. \n");
 		signal_error(err);
 	}
 }
@@ -271,8 +270,8 @@ void Connection::transmit(TCP::Packet_ptr packet) {
 	debug("<TCP::Connection::transmit> Transmitting: %s \n", packet->to_string().c_str());
 	host_.transmit(packet);
 	// Don't think we would like to retransmit reset packets..?
-	if(!packet->isset(RST))
-		add_retransmission(packet);
+	//if(!packet->isset(RST))
+	//	add_retransmission(packet);
 }
 
 TCP::Packet_ptr Connection::outgoing_packet() {

--- a/src/net/tcp_connection_states.cpp
+++ b/src/net/tcp_connection_states.cpp
@@ -275,7 +275,7 @@ void Connection::State::process_segment(Connection& tcp, TCP::Packet_ptr in) {
 	if(in->isset(PSH)) {
 		debug("<TCP::Connection::State::process_segment> Packet carries PUSH. Notify user.\n");
 		tcp.signal_receive(true);
-	} else if(tcp.receive_buffer().size() == tcp.host().buffer_limit()) {
+	} else if(tcp.receive_buffer().full()) {
 		// Buffer is now full
 		debug("<TCP::Connection::State::process_segment> Receive buffer is full. Notify user. \n");
 		tcp.signal_receive(false);
@@ -334,10 +334,7 @@ void Connection::State::process_fin(Connection& tcp, TCP::Packet_ptr in) {
   TCB, enter CLOSED state, and return.
 */
 void Connection::State::send_reset(Connection& tcp) {
-	// TODO: send_buffer().clear()
-	while(!tcp.send_buffer().empty()) {
-		tcp.send_buffer_.pop();
-	}
+	tcp.send_buffer_.clear();
 	tcp.outgoing_packet()->set_seq(tcp.tcb().SND.NXT).set_ack(0).set_flag(RST);
 	tcp.transmit();
 }


### PR DESCRIPTION
**TCP example:**
Made a small example with help of a python "server" which demonstrates reading and writing to a incoming and outgoing connection.

I'm using `netcat` to connect to my IncludeOS VM (port 80). Every message sent to IncludeOS will be sent to python server (port 1337 host), returned back to IncludeOS, and again returned back to the client.
