### PR TITLE
Added boot screen, removed BIOS-interrupts

### DIFF
--- a/api/kernel/vga.hpp
+++ b/api/kernel/vga.hpp
@@ -58,8 +58,11 @@ public:
   void write(char) noexcept;
   void putEntryAt(const char, const uint8_t, const size_t, const size_t) noexcept;
   void putEntryAt(const char, const size_t, const size_t) noexcept;
+  void setCursorAt(const size_t, const size_t) noexcept;
   void increment(int) noexcept;
   void newline() noexcept;
+  inline void set_color(vga_color c)
+  { color = c; };
   
 private:
   static const uint16_t DEFAULT_ENTRY;

--- a/src/boot/bootloader.asm
+++ b/src/boot/bootloader.asm
@@ -16,26 +16,27 @@
 ;; limitations under the License.
 
 USE16
-	;; Memory layout, 16-bit
-	%define _boot_segment 0x7c0 
-  
-  ;; Memory layout, 32-bit
-  %define _mode32_code_segment 0x08
-  %define _mode32_data_segment 0x10
-  
-  %define _kernel_loc   0x200000
-  %define _kernel_stack 0x200000
-	
-	;; We don't really need a stack, except for calls
-	%define _stack_segment 0x7000
-	%define _stack_pointer 0xfffe ;Within the ss, for 16 bit
+;; Memory layout, 16-bit
+%define _boot_segment 0x07c0 
+%define _vga_segment  0xb800
 
-	;; Char helpers
-	%define _CR 0x0D
-	%define _LF 0x0A
+;; Memory layout, 32-bit
+%define _mode32_code_segment 0x08
+%define _mode32_data_segment 0x10
+  
+%define _kernel_loc   0x200000
+%define _kernel_stack 0x200000
+  
+;; We don't really need a stack, except for calls
+%define _stack_segment 0x7000
+%define _stack_pointer 0xfffe ;Within the ss, for 16 bit
 
-	;; ELF offset of _start in text section
-	%define _elf_start 0x34
+;; Char helpers
+%define _CR 0x0D
+%define _LF 0x0A
+
+; ELF offset of _start in text section
+%define _elf_start 0x34
 	
 ;;; START
 ;;; We'll start at the beginning, but jump over some data
@@ -45,40 +46,42 @@ _start:
 ;;; The size of the service on disk, to be loaded at boot. (Convenient to 
 ;;; have it at the beginning, so it remains at a fixed location. )
 srv_size:
-	dd 0			
+	dd 0
 
 srv_offs:
 	dd 0
 ;;; Actual start
 boot:
-
 	;; Need to set data segment, to access strings
 	mov ax, _boot_segment	
 	mov ds, ax		
+	
+	; fast a20 enable	
+	in al, 0x92
+	or al, 2
+	out 0x92, al
 
-	mov esi,str_boot
+	;;  Clear the screen
+	call fill_screen
+
+	;;  Print the IncludeOS logo
+	mov esi, str_includeos
 	call printstr
-  
-  ; fast a20 enable
-  in al, 0x92
-  or al, 2
-  out 0x92, al
+	mov ax, 0x0800
+	mov [color], ax
+	mov esi, str_literally
+	call printstr
+	
   
   ; check that it was enabled
 	test al,0
-	jz .a20_ok
-	
+	jz .a20_ok	
 	;; NOT OK
 	mov esi,str_a20_fail
 	call printstr	
 	cli
 	hlt
 .a20_ok:
-	mov esi,str_a20_ok
-	call printstr
-
-	
-	
 	call protected_mode	
 	
 protected_mode:
@@ -90,49 +93,50 @@ protected_mode:
 	mov eax,cr0
 	or al,1
 	mov cr0,eax
-	
-	;xchg bx,bx
-	;; 	jmp 0x8:$+3
 	jmp _mode32_code_segment:mode32+(_boot_segment<<4)
 
-USE16
-
-	;; %include "asm/load_os_16bit.asm"
-			
-;;; 16-bit code
-USE16
-	
-printstr:
-	mov ah,0eh
-.repeat:	
-	lodsb
-	cmp al,0
-	je .done
-	int 10h
-	jmp .repeat
+fill_screen:
+	mov bx, _vga_segment
+	mov es, bx
+	mov bx, 0
+	mov al, 0
+	mov ah, [color]	
+.fill:	
+	mov [es:bx], ax
+	add bx,2
+	cmp bx, (25*80*2)
+	jge .done
+	jmp .fill
 .done:
 	ret
 	
-;;; Print the char in %al to serial port, via BIOS int.
-;;; OBS: Only works in real mode.
-;;; OBS: In Bochs, looks like serial port must be initialized first
-print_al_serial:
-	xor edx,edx
-	mov ah,1
-	int 14h
+printstr:
+	mov bx, _vga_segment
+	mov es, bx
+	mov bx, [cursor]
+	mov ah, [color]
+.repeat:
+	lodsb
+	cmp al,0
+	je .done
+	mov [es:bx], al
+	mov [es:bx + 1], ah
+	add bx, 2
+	jmp .repeat
+.done:
+	mov [cursor], bx
 	ret
 	
-print_al_scr:
-	mov ah,0x0e
-	int 0x10	
-
-str_boot:
-	db `IncludeOS!\n\r`,0
-str_a20_ok:
-	db `A20 OK!\n\r`,0
-str_a20_fail:
-	db `A20 NOT OK\n\r`,0
-
+str_includeos:
+	db `#include <os> `,0
+str_literally:	
+	db `\/\/ Literally `,0
+str_a20_fail:	
+	db `A20 Err\n\r`,0
+cursor:				
+	dw (80 * 11 * 2) + 48
+color:
+	dw 0x0d
 	
 USE32
 ALIGN 32
@@ -206,16 +210,16 @@ mode32:
 	cmp edx, 0
 	jge .more  ;; jump when gequal
 	
-  ;; Bochs breakpoint
+	;; Bochs breakpoint
 	;;xchg bx,bx
   
 	;; GERONIMO!
 	;; Jump to service
 	mov ecx, [srv_offs+(_boot_segment<<4)]
-  jmp ecx
+	jmp ecx
 	
 	%include "boot/disk_read_lba.asm"
 	
-;; BOOT SIGNATURE
+	;; BOOT SIGNATURE
 	times 510-($-$$) db 0	;
 	dw 0xAA55

--- a/src/boot/bootloader.asm
+++ b/src/boot/bootloader.asm
@@ -67,7 +67,7 @@ boot:
 	;;  Print the IncludeOS logo
 	mov esi, str_includeos
 	call printstr
-	mov ax, 0x0800
+	mov ax, 0x07
 	mov [color], ax
 	mov esi, str_literally
 	call printstr

--- a/src/kernel/vga.cpp
+++ b/src/kernel/vga.cpp
@@ -47,6 +47,11 @@ void ConsoleVGA::putEntryAt(const char c, const size_t x, const size_t y) noexce
   put(make_vgaentry(c, this->color), x, y);
 }
 
+void ConsoleVGA::setCursorAt(const size_t x, const size_t y) noexcept {
+  this->column = x;
+  this->row = y; 
+}
+
 inline void ConsoleVGA::put(uint16_t entry, size_t x, size_t y) noexcept {
   const size_t index = y * VGA_WIDTH + x;
   this->buffer[index] = entry;


### PR DESCRIPTION
Instead of using BIOS-interrupts the bootloader just writes to VGA memory. A boot screen is added, which is nice for letting people know something happened, in i.e. virtualbox.