### PR TITLE
tcp: small changes to api, adapted test & examples + changes to os x script

### DIFF
--- a/etc/install_osx.sh
+++ b/etc/install_osx.sh
@@ -25,7 +25,8 @@ echo -e "###################################"
 echo -e "\n# Prequisites:\n 
     - homebrew (OSX package manager - https://brew.sh) 
     - \`/usr/local\` directory with write access
-    - \`/usr/local/bin\` added to your PATH"
+    - \`/usr/local/bin\` added to your PATH
+    - (Recommended) XCode CTL (Command Line Tools)"
 
 ### DEPENDENCIES ###
 
@@ -130,6 +131,12 @@ function install_nasm {
     echo -e "\n>>> Done installing: nasm"
 }
 
+## WARN ABOUT XCODE CTL ##
+if ! [[ $(xcode-select -p) ]]
+then 
+    echo -e "\nWARNING: Command Line Tools don't seem to be installed, installation MAY not complete. 
+    Install with: xcode-select --install"
+fi
 
 ### INSTALL ###
 echo

--- a/examples/demo_service/Makefile
+++ b/examples/demo_service/Makefile
@@ -4,133 +4,21 @@
 
 # The name of your service
 SERVICE = IncludeOS_Demo_Service
+SERVICE_NAME = IncludeOS Demo Service
 
 # Your service parts
 FILES = service.cpp
 
+# Your disk image
+DISK=
+
+# Your own include-path
+LOCAL_INCLUDES=
+
 # IncludeOS location
 ifndef INCLUDEOS_INSTALL
-	INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
 endif
 
-# Shorter name
-INSTALL = $(INCLUDEOS_INSTALL)
-
-# Compiler/Linker
-###################################################
-
-OPTIONS = -Ofast -msse3 -Wall -Wextra -mstackrealign 
-
-# External Libraries
-###################################################
-LIBC_OBJ = $(INSTALL)/newlib/libc.a
-LIBG_OBJ = $(INSTALL)/newlib/libg.a
-LIBM_OBJ = $(INSTALL)/newlib/libm.a 
-
-LIBGCC = $(INSTALL)/libgcc/libgcc.a
-LIBCXX = $(INSTALL)/libcxx/libc++.a $(INSTALL)/libcxx/libc++abi.a
-
-
-INC_NEWLIB=$(INSTALL)/newlib/include
-INC_LIBCXX=$(INSTALL)/libcxx/include
-
-DEBUG_OPTS = -ggdb3 -v
-
-CPP = clang++-3.6 -target i686-elf
-ifndef LD_INC
-	LD_INC = ld
-endif
-
-INCLUDES = -I$(INC_LIBCXX) -I$(INSTALL)/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/api 
-
-CAPABS_COMMON = -msse3 -mstackrealign # Needed for 16-byte stack alignment (SSE)
-
-all: CAPABS  =  $(CAPABS_COMMON) -O2  
-debug: CAPABS = $(CAPABS_COMMON) -O0
-stripped: CAPABS = $(CAPABS_COMMON) -Oz
-
-WARNS   = -Wall -Wextra #-pedantic
-CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 -fno-stack-protector $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 #-flto -fno-exceptions
-
-LDOPTS = -nostdlib -melf_i386 -N  --script=$(INSTALL)/linker.ld -flto
-
-
-# Objects
-###################################################
-
-CRTBEGIN_OBJ = $(INSTALL)/crt/crtbegin.o
-CRTEND_OBJ = $(INSTALL)/crt/crtend.o
-CRTI_OBJ = $(INSTALL)/crt/crti.o
-CRTN_OBJ = $(INSTALL)/crt/crtn.o
-
-# Full link list
-OBJS  = $(FILES:.cpp=.o) .service_name.o
-LIBS =  $(INSTALL)/os.a $(LIBCXX) $(INSTALL)/os.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
-
-OS_PRE = $(CRTBEGIN_OBJ) $(CRTI_OBJ)
-OS_POST = $(CRTEND_OBJ) $(CRTN_OBJ)
-
-DEPS = $(OBJS:.o=.d)
-
-# Complete bulid
-###################################################
-# A complete build includes:
-# - a "service", to be linked with OS-objects (OS included)
-
-all: service
-
-stripped: LDOPTS  += -S #strip all
-stripped: CPPOPTS += -Oz
-stripped: service
-
-
-# The same, but with debugging symbols (OBS: Dramatically increases binary size)
-debug: CCOPTS  += $(DEBUG_OPTS)
-debug: CPPOPTS += $(DEBUG_OPTS)
-debug: LDOPTS  += -M --verbose
-
-debug: OBJS += $(LIBG_OBJ)
-
-debug: service #Don't wanna call 'all', since it strips debug info
-
-# Service
-###################################################
-service.o: service.cpp
-	@echo "\n>> Compiling the service"
-	$(CPP) $(CPPOPTS) -o $@ $<
-
-.service_name.o: $(INSTALL)/service_name.cpp
-	$(CPP) $(CPPOPTS) -DSERVICE_NAME="\"$(SERVICE)\"" -o $@ $<
-
-# Link the service with the os
-service: $(OBJS) $(LIBS) 
-	@echo "\n>> Linking service with OS"
-	$(LD_INC) $(LDOPTS) $(OS_PRE) $(OBJS) $(LIBS) $(OS_POST) -o $(SERVICE)
-	@echo "\n>> Building image " $(SERVICE).img
-	$(INSTALL)/vmbuild $(INSTALL)/bootloader $(SERVICE)
-
-# Object files
-###################################################
-
-# Runtime
-crt%.o: $(INSTALL)/crt/crt%.s
-	@echo "\n>> Assembling C runtime:" $@
-	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
-
-# General C++-files to object files
-%.o: %.cpp
-	@echo "\n>> Compiling OS object without header"
-	$(CPP) $(CPPOPTS) -o $@ $< 
-
-# AS-assembled object files
-%.o: %.s
-	@echo "\n>> Assembling GNU 'as' files"
-	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
-
-# Cleanup
-###################################################
-clean: 
-	$(RM) $(OBJS) $(DEPS) $(SERVICE) 
-	$(RM) $(SERVICE).img
-
--include $(DEPS)
+# Include the installed seed makefile
+include $(INCLUDEOS_INSTALL)/Makeseed

--- a/examples/demo_service/service.cpp
+++ b/examples/demo_service/service.cpp
@@ -95,8 +95,8 @@ void Service::start() {
       std::string output{header + html};
       conn->write(output.data(), output.size());
 
-  }).onDisconnect([](auto conn, std::string msg) {
-      printf("<Service> @onDisconnect - Reason: %s \n", msg.c_str());
+  }).onDisconnect([](auto conn, auto reason) {
+      printf("<Service> @onDisconnect - Reason: %s \n", reason.to_string().c_str());
       printf("<Service> TCP STATUS:\n%s \n", conn->host().status().c_str());
   });
 

--- a/examples/tcp/Makefile
+++ b/examples/tcp/Makefile
@@ -4,133 +4,21 @@
 
 # The name of your service
 SERVICE = tcp_demo
+SERVICE_NAME = IncludeOS TCP Demo
 
 # Your service parts
 FILES = service.cpp
 
+# Your disk image
+DISK=
+
+# Your own include-path
+LOCAL_INCLUDES=
+
 # IncludeOS location
 ifndef INCLUDEOS_INSTALL
-	INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
 endif
 
-# Shorter name
-INSTALL = $(INCLUDEOS_INSTALL)
-
-# Compiler/Linker
-###################################################
-
-OPTIONS = -Ofast -msse3 -Wall -Wextra -mstackrealign 
-
-# External Libraries
-###################################################
-LIBC_OBJ = $(INSTALL)/newlib/libc.a
-LIBG_OBJ = $(INSTALL)/newlib/libg.a
-LIBM_OBJ = $(INSTALL)/newlib/libm.a 
-
-LIBGCC = $(INSTALL)/libgcc/libgcc.a
-LIBCXX = $(INSTALL)/libcxx/libc++.a $(INSTALL)/libcxx/libc++abi.a
-
-
-INC_NEWLIB=$(INSTALL)/newlib/include
-INC_LIBCXX=$(INSTALL)/libcxx/include
-
-DEBUG_OPTS = -ggdb3 -v
-
-CPP = clang++-3.6 -target i686-elf
-ifndef LD_INC
-	LD_INC = ld
-endif
-
-INCLUDES = -I$(INC_LIBCXX) -I$(INSTALL)/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/api 
-
-CAPABS_COMMON = -msse3 -mstackrealign # Needed for 16-byte stack alignment (SSE)
-
-all: CAPABS  =  $(CAPABS_COMMON) -O2  
-debug: CAPABS = $(CAPABS_COMMON) -O0
-stripped: CAPABS = $(CAPABS_COMMON) -Oz
-
-WARNS   = -Wall -Wextra #-pedantic
-CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 -fno-stack-protector $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 #-flto -fno-exceptions
-
-LDOPTS = -nostdlib -melf_i386 -N  --script=$(INSTALL)/linker.ld -flto
-
-
-# Objects
-###################################################
-
-CRTBEGIN_OBJ = $(INSTALL)/crt/crtbegin.o
-CRTEND_OBJ = $(INSTALL)/crt/crtend.o
-CRTI_OBJ = $(INSTALL)/crt/crti.o
-CRTN_OBJ = $(INSTALL)/crt/crtn.o
-
-# Full link list
-OBJS  = $(FILES:.cpp=.o) .service_name.o
-LIBS =  $(INSTALL)/os.a $(LIBCXX) $(INSTALL)/os.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
-
-OS_PRE = $(CRTBEGIN_OBJ) $(CRTI_OBJ)
-OS_POST = $(CRTEND_OBJ) $(CRTN_OBJ)
-
-DEPS = $(OBJS:.o=.d)
-
-# Complete bulid
-###################################################
-# A complete build includes:
-# - a "service", to be linked with OS-objects (OS included)
-
-all: service
-
-stripped: LDOPTS  += -S #strip all
-stripped: CPPOPTS += -Oz
-stripped: service
-
-
-# The same, but with debugging symbols (OBS: Dramatically increases binary size)
-debug: CCOPTS  += $(DEBUG_OPTS)
-debug: CPPOPTS += $(DEBUG_OPTS)
-debug: LDOPTS  += -M --verbose
-
-debug: OBJS += $(LIBG_OBJ)
-
-debug: service #Don't wanna call 'all', since it strips debug info
-
-# Service
-###################################################
-service.o: service.cpp
-	@echo "\n>> Compiling the service"
-	$(CPP) $(CPPOPTS) -o $@ $<
-
-.service_name.o: $(INSTALL)/service_name.cpp
-	$(CPP) $(CPPOPTS) -DSERVICE_NAME="\"$(SERVICE)\"" -o $@ $<
-
-# Link the service with the os
-service: $(OBJS) $(LIBS) 
-	@echo "\n>> Linking service with OS"
-	$(LD_INC) $(LDOPTS) $(OS_PRE) $(OBJS) $(LIBS) $(OS_POST) -o $(SERVICE)
-	@echo "\n>> Building image " $(SERVICE).img
-	$(INSTALL)/vmbuild $(INSTALL)/bootloader $(SERVICE)
-
-# Object files
-###################################################
-
-# Runtime
-crt%.o: $(INSTALL)/crt/crt%.s
-	@echo "\n>> Assembling C runtime:" $@
-	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
-
-# General C++-files to object files
-%.o: %.cpp
-	@echo "\n>> Compiling OS object without header"
-	$(CPP) $(CPPOPTS) -o $@ $< 
-
-# AS-assembled object files
-%.o: %.s
-	@echo "\n>> Assembling GNU 'as' files"
-	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
-
-# Cleanup
-###################################################
-clean: 
-	$(RM) $(OBJS) $(DEPS) $(SERVICE) 
-	$(RM) $(SERVICE).img
-
--include $(DEPS)
+# Include the installed seed makefile
+include $(INCLUDEOS_INSTALL)/Makeseed

--- a/examples/tcp/service.cpp
+++ b/examples/tcp/service.cpp
@@ -32,6 +32,7 @@
 #include <net/inet4>
 
 using Connection_ptr = std::shared_ptr<net::TCP::Connection>;
+using Disconnect = net::TCP::Connection::Disconnect;
 
 // An IP-stack object
 std::unique_ptr<net::Inet4<VirtioNet> > inet;
@@ -97,14 +98,14 @@ void Service::start() {
 			});
 
 			// When client is disconnecting
-			client->onDisconnect([python](Connection_ptr, std::string msg) {
-				printf("Disconnected [Client]: %s\n", msg.c_str());
+			client->onDisconnect([python](Connection_ptr, Disconnect reason) {
+				printf("Disconnected [Client]: %s\n", reason.to_string().c_str());
 				python->close();
 			});
 
 			// When python is disconnecting
-			python->onDisconnect([client](Connection_ptr, std::string msg) {
-				printf("Disconnected [Python]: %s\n", msg.c_str());
+			python->onDisconnect([client](Connection_ptr, Disconnect reason) {
+				printf("Disconnected [Python]: %s\n", reason.to_string().c_str());
 				client->close();
 			});
 		}); // << onConnect (outgoing (python))

--- a/src/debug/test_tcp.cpp
+++ b/src/debug/test_tcp.cpp
@@ -44,44 +44,15 @@ void Service::start() {
     printf("Server is running: %s \n", server.to_string().c_str());
   });
 
-  server.onAccept([](auto conn)->bool {
-    printf("<Server> onAccept \n");
-    return true;
-
-  }).onConnect([](auto conn) {
-    printf("<Server> onConnect \n");
-
-  }).onReceive([](auto conn, bool) {
-    printf("<Server> onReceive \n");
-
-  }).onDisconnect([](auto conn, std::string msg) {
-    printf("<Server> onDisconnect \n");
-
-  }).onError([](auto conn, auto err) {
-    printf("<Server> Error: %s \n", err.what());
-
-  }).onPacketReceived([](auto conn, auto packet) {
-    printf("<Server> Received. \n");
+  server.onPacketReceived([](auto conn, auto packet) {
+    printf("<Server> Received: %s\n", packet->to_string().c_str());
 
   }).onPacketDropped([](auto packet, std::string reason) {
-    printf("<Server> Dropped. \n");
+    printf("<Server> Dropped: %s - Reason: %s \n", packet->to_string().c_str(), reason.c_str());
 
-  });
-
-  inet->dhclient()->on_config([server](auto&) {
-    printf("<Client> Trying to connect to server. \n");
-    auto conn = inet->tcp().connect({50,63,202,26});
-    printf("<Client> Connection: %s \n", conn->to_string().c_str());
-    conn->onConnect([](auto conn) {
-      printf("<Client> onConnect \n");
-      conn->write("GET / HTTP/1.0");
-
-    }).onReceive([](auto conn, bool) {
-      printf("<Client> onReceive:\n%s \n", conn->read(3000).c_str());
-
-    }).onPacketReceived([](auto conn, auto packet) {
-      printf("<Server> Received: %s \n", packet->to_string().c_str());
-
-    });
+  }).onReceive([](auto conn, bool) {
+    conn->write("<html>Hey</html>");
+  }).onConnect([](auto conn) {
+    printf("<Server> Connected.\n");
   });
 }

--- a/src/net/tcp_connection_states.cpp
+++ b/src/net/tcp_connection_states.cpp
@@ -162,7 +162,7 @@ void Connection::State::unallowed_syn_reset_connection(Connection& tcp, TCP::Pac
 	// Not sure if this is the correct way to send a "reset response"
 	tcp.outgoing_packet()->set_seq(in->ack()).set_flag(RST);
 	tcp.transmit();
-	tcp.signal_disconnect("Connection reset.");
+	tcp.signal_disconnect(Disconnect::RESET);
 }
 
 
@@ -311,7 +311,7 @@ void Connection::State::process_fin(Connection& tcp, TCP::Packet_ptr in) {
     debug("<TCP::Connection::State::process_fin> Processing FIN bit in STATE: %s \n", tcp.state().to_string().c_str());
     assert(in->isset(FIN));
     auto& tcb = tcp.tcb();
-	tcp.signal_disconnect("Connection closing.");
+	tcp.signal_disconnect(Disconnect::CLOSING);
 	// Advance RCV.NXT over the FIN?
 	tcb.RCV.NXT++;
 	//auto fin = in->data_length();
@@ -717,7 +717,7 @@ State::Result Connection::SynReceived::handle(Connection& tcp, TCP::Packet_ptr i
       	// Since we create a new connection when it starts listening, we don't wanna do this, but just delete it.
 
       	if(tcp.prev_state().to_string() == Connection::SynSent::instance().to_string()) {
-      		tcp.signal_disconnect("Connection refused.");
+      		tcp.signal_disconnect(Disconnect::REFUSED);
       	}
 
       	return CLOSED;
@@ -832,7 +832,7 @@ State::Result Connection::Established::handle(Connection& tcp, TCP::Packet_ptr i
 
     // 2. check RST
     if( in->isset(RST) ) {
-    	tcp.signal_disconnect("Connection reset.");
+    	tcp.signal_disconnect(Disconnect::RESET);
     	return CLOSED; // close
     }
 
@@ -892,7 +892,7 @@ State::Result Connection::FinWait1::handle(Connection& tcp, TCP::Packet_ptr in) 
 
     // 2. check RST
     if( in->isset(RST) ) {
-    	tcp.signal_disconnect("Connection reset.");
+    	tcp.signal_disconnect(Disconnect::RESET);
     	return CLOSED; // close
     }
 
@@ -971,7 +971,7 @@ State::Result Connection::FinWait2::handle(Connection& tcp, TCP::Packet_ptr in) 
 
     // 2. check RST
     if( in->isset(RST) ) {
-    	tcp.signal_disconnect("Connection reset.");
+    	tcp.signal_disconnect(Disconnect::RESET);
     	return CLOSED; // close
     }
 
@@ -1045,7 +1045,7 @@ State::Result Connection::CloseWait::handle(Connection& tcp, TCP::Packet_ptr in)
 
     // 2. check RST
     if( in->isset(RST) ) {
-    	tcp.signal_disconnect("Connection reset.");
+    	tcp.signal_disconnect(Disconnect::RESET);
     	return CLOSED; // close
     }
 

--- a/test/tcp/service.cpp
+++ b/test/tcp/service.cpp
@@ -103,7 +103,7 @@ void OUTGOING_TEST(TCP::Socket outgoing) {
 		.onReceive([](Connection_ptr conn, bool) {
 			CHECK(conn->read() == small, "conn->read() == small");
 		})
-		.onDisconnect([](Connection_ptr, std::string) {
+		.onDisconnect([](Connection_ptr, TCP::Connection::Disconnect) {
 			CHECK(true, "Connection closed by server");
 			
 			OUTGOING_TEST_INTERNET(TEST_ADDR_TIME);
@@ -236,7 +236,7 @@ void Service::start()
 		CHECK(!conn->is_writable(), "!conn->is_writable()");
 		CHECK(conn->is_state({"FIN-WAIT-1"}), "conn.is_state(FIN-WAIT-1)");
 	})
-	.onDisconnect([](Connection_ptr conn, std::string) {
+	.onDisconnect([](Connection_ptr conn, TCP::Connection::Disconnect) {
 		CHECK(conn->is_state({"FIN-WAIT-2"}), "conn.is_state(FIN-WAIT-2)");
 		hw::PIT::instance().onTimeout(1s,[conn]{
 			CHECK(conn->is_state({"TIME-WAIT"}), "conn.is_state(TIME-WAIT)");

--- a/test/tcp/vbox.sh
+++ b/test/tcp/vbox.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../etc/vboxrun.sh IncludeOS_TCP_Test.img TCP_test

--- a/test/timers/Makefile
+++ b/test/timers/Makefile
@@ -3,132 +3,17 @@
 #################################################
 
 # The name of your service
-SERVICE = Test_timers
+SERVICE = "Test_timers"
+SERVICE_NAME = "Timers\ Test\ Service"
 
 # Your service parts
 FILES = service.cpp
+# Your disk image
+DISK=
 
 # IncludeOS location
 ifndef INCLUDEOS_INSTALL
-	INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
 endif
 
-# Shorter name
-INSTALL = $(INCLUDEOS_INSTALL)
-
-# Compiler/Linker
-###################################################
-
-OPTIONS = -Ofast -msse3 -Wall -Wextra -mstackrealign 
-
-# External Libraries
-###################################################
-LIBC_OBJ = $(INSTALL)/newlib/libc.a
-LIBG_OBJ = $(INSTALL)/newlib/libg.a
-LIBM_OBJ = $(INSTALL)/newlib/libm.a 
-
-LIBGCC = $(INSTALL)/libgcc/libgcc.a
-LIBCXX = $(INSTALL)/libcxx/libc++.a $(INSTALL)/libcxx/libc++abi.a
-
-
-INC_NEWLIB=$(INSTALL)/newlib/include
-INC_LIBCXX=$(INSTALL)/libcxx/include
-
-DEBUG_OPTS = -ggdb3 -v
-
-CPP = clang++-3.6 -target i686-elf
-LD  = ld 
-
-INCLUDES = -I$(INC_LIBCXX) -I$(INSTALL)/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/api 
-
-CAPABS_COMMON = -msse3 -mstackrealign # Needed for 16-byte stack alignment (SSE)
-
-all: CAPABS  =  $(CAPABS_COMMON) -O2  
-debug: CAPABS = $(CAPABS_COMMON) -O0
-stripped: CAPABS = $(CAPABS_COMMON) -Oz
-
-WARNS   = -Wall -Wextra #-pedantic
-CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 -fno-stack-protector $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 #-flto -fno-exceptions
-
-LDOPTS = -nostdlib -melf_i386 -N  --script=$(INSTALL)/linker.ld -flto
-
-
-# Objects
-###################################################
-
-CRTBEGIN_OBJ = $(INSTALL)/crt/crtbegin.o
-CRTEND_OBJ = $(INSTALL)/crt/crtend.o
-CRTI_OBJ = $(INSTALL)/crt/crti.o
-CRTN_OBJ = $(INSTALL)/crt/crtn.o
-
-# Full link list
-OBJS  = $(FILES:.cpp=.o) .service_name.o
-LIBS =  $(INSTALL)/os.a $(LIBCXX) $(INSTALL)/os.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
-
-OS_PRE = $(CRTBEGIN_OBJ) $(CRTI_OBJ)
-OS_POST = $(CRTEND_OBJ) $(CRTN_OBJ)
-
-DEPS = $(OBJS:.o=.d)
-
-# Complete bulid
-###################################################
-# A complete build includes:
-# - a "service", to be linked with OS-objects (OS included)
-
-all: service
-
-stripped: LDOPTS  += -S #strip all
-stripped: CPPOPTS += -Oz
-stripped: service
-
-
-# The same, but with debugging symbols (OBS: Dramatically increases binary size)
-debug: CCOPTS  += $(DEBUG_OPTS)
-debug: CPPOPTS += $(DEBUG_OPTS)
-debug: LDOPTS  += -M --verbose
-
-debug: OBJS += $(LIBG_OBJ)
-
-debug: service #Don't wanna call 'all', since it strips debug info
-
-# Service
-###################################################
-service.o: service.cpp
-	@echo "\n>> Compiling the service"
-	$(CPP) $(CPPOPTS) -o $@ $<
-
-.service_name.o: $(INSTALL)/service_name.cpp
-	$(CPP) $(CPPOPTS) -DSERVICE_NAME="\"$(SERVICE)\"" -o $@ $<
-
-# Link the service with the os
-service: $(OBJS) $(LIBS) 
-	@echo "\n>> Linking service with OS"
-	$(LD) $(LDOPTS) $(OS_PRE) $(OBJS) $(LIBS) $(OS_POST) -o $(SERVICE)
-	@echo "\n>> Building image " $(SERVICE).img
-	$(INSTALL)/vmbuild $(INSTALL)/bootloader $(SERVICE)
-
-# Object files
-###################################################
-
-# Runtime
-crt%.o: $(INSTALL)/crt/crt%.s
-	@echo "\n>> Assembling C runtime:" $@
-	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
-
-# General C++-files to object files
-%.o: %.cpp
-	@echo "\n>> Compiling OS object without header"
-	$(CPP) $(CPPOPTS) -o $@ $< 
-
-# AS-assembled object files
-%.o: %.s
-	@echo "\n>> Assembling GNU 'as' files"
-	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
-
-# Cleanup
-###################################################
-clean: 
-	$(RM) $(OBJS) $(DEPS) $(SERVICE) 
-	$(RM) $(SERVICE).img
-
--include $(DEPS)
+include $(INCLUDEOS_INSTALL)/Makeseed


### PR DESCRIPTION
**TCP:**
Changed `onDisconnect` to return a `struct Disconnect` instead of a string.
Adapted this change to services (test, demo).

**Examples:**
Less output spam. Also now using the new Makefile.

**OSX build script:**
#435

I'm not sure forcing the user to install Xcode command line tools is the right choice. Added a warning that installation MAY not complete.

Opinions?