### PR TITLE
fs: Remove template, term: Add filesystem commands

### DIFF
--- a/api/fs/disk.hpp
+++ b/api/fs/disk.hpp
@@ -20,6 +20,7 @@
 #define FS_DISK_HPP
 
 #include "common.hpp"
+#include "filesystem.hpp"
 #include <hw/disk_device.hpp>
 
 #include <deque>
@@ -28,9 +29,6 @@
 
 namespace fs {
 
-class FileSystem; //< FileSystem interface
-
-template <typename FS>
 class Disk {
 public:
   struct Partition; //< Representation of a disk partition
@@ -108,18 +106,9 @@ public:
   
 private:
   hw::IDiskDevice& device;
-  std::unique_ptr<FS> filesys;
+  std::unique_ptr<FileSystem> filesys;
 }; //< class Disk
 
-template <typename FS>
-inline Disk<FS>::Disk(hw::IDiskDevice& dev) :
-  device {dev}
-{
-  filesys.reset(new FS(device));
-}
-
 } //< namespace fs
-
-#include "disk.inl"
 
 #endif //< FS_DISK_HPP

--- a/api/kernel/terminal.hpp
+++ b/api/kernel/terminal.hpp
@@ -20,8 +20,14 @@
 
 #include <functional>
 #include <map>
+#include <string>
 #include <vector>
 #include <net/inet4>
+
+namespace fs
+{
+  class Disk;
+}
 
 struct Command
 {
@@ -38,6 +44,7 @@ class Terminal
 {
 public:
   using Connection_ptr = std::shared_ptr<net::TCP::Connection>;
+  using Disk_ptr = std::shared_ptr<fs::Disk>;
   enum
   {
     NUL  = 0,
@@ -79,6 +86,9 @@ public:
   }
   
   std::function<void()> on_exit { [] {} };
+  
+  ///
+  void add_disk_commands(Disk_ptr disk);
   
 private:
   void command(uint8_t cmd);

--- a/api/memdisk
+++ b/api/memdisk
@@ -26,17 +26,15 @@
 
 namespace fs
 {
-  // describe a disk with a FAT filesystem
-  using FatDisk = Disk<FAT>;
   // its not really a shared memdisk right now,
   // but we are only using this in conjunction with
   // new_shared_memdisk() which very likely contains FAT
-  using MountedDisk = std::shared_ptr<FatDisk>;
+  using Disk_ptr = std::shared_ptr<Disk>;
   
-  inline MountedDisk new_shared_memdisk()
+  inline Disk_ptr new_shared_memdisk()
   {
     static MemDisk device;
-    return std::make_shared<FatDisk> (device);
+    return std::make_shared<Disk> (device);
   }
 }
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,8 @@ CXXABI_OBJ = $(CXXABI:.cpp=.o)
 
 OS_OBJECTS = kernel/kernel_start.o kernel/syscalls.o kernel/vga.o \
 		kernel/interrupts.o kernel/os.o kernel/cpuid.o \
-		kernel/irq_manager.o kernel/pci_manager.o kernel/terminal.o \
+		kernel/irq_manager.o kernel/pci_manager.o \
+		kernel/terminal.o kernel/terminal_disk.o \
 		crt/c_abi.o crt/string.o crt/quick_exit.o crt/cxx_abi.o  crt/mman.o \
 		util/memstream.o \
 		hw/ide.o hw/pit.o hw/pic.o hw/pci_device.o hw/cpu_freq_sampling.o hw/serial.o\
@@ -72,7 +73,7 @@ OS_OBJECTS = kernel/kernel_start.o kernel/syscalls.o kernel/vga.o \
 		net/dns/dns.o net/dns/client.o net/dhcp/dh4client.o \
 		net/ip6/ip6.o net/ip6/icmp6.o net/ip6/udp6.o net/ip6/ndp.o \
 		net/packet.o net/buffer_store.o \
-		fs/filesystem.o fs/mbr.o fs/vbr.o fs/path.o \
+		fs/disk.o fs/filesystem.o fs/mbr.o fs/vbr.o fs/path.o \
 		fs/ext4.o fs/fat.o fs/fat_sync.o fs/memdisk.o
 
 CRTI_OBJ = crt/crti.o

--- a/src/debug/test_disk.cpp
+++ b/src/debug/test_disk.cpp
@@ -2,13 +2,9 @@
 #include <cassert>
 const char* service_name__ = "...";
 
-//#include <memdisk>
-//auto disk = fs::new_shared_memdisk();
-
 #include <ide>
-#include <fs/fat.hpp>
-using FatDisk = fs::Disk<fs::FAT>;
-std::shared_ptr<FatDisk> disk;
+#include <fs/disk.hpp>
+std::shared_ptr<fs::Disk> disk;
 
 void list_partitions(decltype(disk));
 
@@ -16,7 +12,7 @@ void Service::start()
 {
   // instantiate memdisk with FAT filesystem
   auto& device = hw::Dev::disk<0, hw::IDE>(hw::IDE::SLAVE);
-  disk = std::make_shared<FatDisk> (device);
+  disk = std::make_shared<fs::Disk> (device);
   assert(disk);
   
   // if the disk is empty, we can't mount a filesystem anyways

--- a/src/fs/disk.cpp
+++ b/src/fs/disk.cpp
@@ -1,0 +1,151 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fs/disk.hpp>
+#include <fs/mbr.hpp>
+#include <fs/fat.hpp>
+
+namespace fs {
+
+Disk::Disk(hw::IDiskDevice& dev)
+  : device {dev}
+{
+  // for now we can only assume FAT, anyways
+  filesys.reset(new FAT(device));
+}
+
+void Disk::partitions(on_parts_func func) {
+  
+  /** Read Master Boot Record (sector 0) */
+  device.read(0,
+  [this, func] (hw::IDiskDevice::buffer_t data)
+  {
+    std::vector<Partition> parts;
+    
+    if (!data) {
+      func(true, parts);
+      return;
+    }
+    
+    // First sector is the Master Boot Record
+    auto* mbr =(MBR::mbr*) data.get();
+    
+    for (int i {0}; i < 4; ++i) {
+      // all the partitions are offsets to potential Volume Boot Records
+      parts.emplace_back(
+          mbr->part[i].flags,     //< flags
+          mbr->part[i].type,      //< id
+          mbr->part[i].lba_begin, //< LBA
+          mbr->part[i].sectors);
+    }
+    
+    func(no_error, parts);
+  });
+}
+
+void Disk::mount(on_mount_func func)
+{
+  device.read(0,
+  [this, func] (hw::IDiskDevice::buffer_t data)
+  {
+    if (!data) {
+      // TODO: error-case for unable to read MBR
+      mount(INVALID, func);
+      return;
+    }
+    
+    // auto-detect FAT on MBR:
+    auto* mbr = (MBR::mbr*) data.get();
+    MBR::BPB* bpb = mbr->bpb();
+    
+    if (bpb->bytes_per_sector >= 512 
+     && bpb->fa_tables != 0 
+     && bpb->signature != 0) // check MBR signature too
+    {
+      // we have FAT on MBR (and we are assuming mount FAT)
+      mount(MBR, func);
+      return;
+    }
+    
+    // go through partition list
+    for (int i = 0; i < 4; i++)
+    {
+      if (mbr->part[i].type != 0       // 0 is unused partition
+       && mbr->part[i].lba_begin != 0  // 0 is MBR anyways
+       && mbr->part[i].sectors != 0)   // 0 means no size, so...
+      {
+        mount((partition_t) (VBR1 + i), func);
+        return;
+      }
+    }
+    
+    // no partition was found (TODO: extended partitions)
+    mount(INVALID, func);
+    return;
+  });
+}
+
+void Disk::mount(partition_t part, on_mount_func func) {
+  
+  if (part == INVALID)
+  {
+    // Something bad happened maybe in auto-detect
+    // Either way, no partition was found
+    func(true);
+    return;
+  }
+  else if (part == MBR)
+  {
+    // For the MBR case, all we need to do is mount on sector 0
+    fs().mount(0, device.size(), func);
+  }
+  else
+  {
+    /**
+     *  Otherwise, we will have to read the LBA offset
+     *  of the partition to be mounted
+     */
+    device.read(0,
+    [this, part, func] (hw::IDiskDevice::buffer_t data)
+    {
+      if (!data) {
+        // TODO: error-case for unable to read MBR
+        func(true);
+        return;
+      }
+      
+      auto* mbr = (MBR::mbr*) data.get(); //< Treat data as MBR
+      auto pint = static_cast<int>(part - 1); //< Treat VBR1 as index 0 etc.
+
+      /** Get LBA from selected partition */
+      auto lba_base = mbr->part[pint].lba_begin;
+      auto lba_size = mbr->part[pint].sectors;
+      
+      /**
+       *  Call the filesystems mount function
+       *  with lba_begin as base address
+       */
+      fs().mount(lba_base, lba_size, func);
+    });
+  }
+}
+
+std::string Disk::Partition::name() const {
+  return MBR::id_to_name(id);
+}
+
+} //< namespace fs

--- a/src/kernel/terminal.cpp
+++ b/src/kernel/terminal.cpp
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #include <kernel/terminal.hpp>
+#include <net/inet4>
 
 #include <vector>
 #include <serial>

--- a/test/fat/fat16.cpp
+++ b/test/fat/fat16.cpp
@@ -65,7 +65,7 @@ void Service::start()
     CHECK(!err, "Filesystem mounted on VBR1");
     assert(!err);
     
-    // verify that we can read Makefile
+    // verify that we can read file
     auto& fs = disk->fs();
     auto ent = fs.stat("/banana.txt");
     CHECK(ent.is_valid(), "Stat file in root dir");

--- a/test/fat/fat32.cpp
+++ b/test/fat/fat32.cpp
@@ -21,14 +21,13 @@
 
 #include <fs/fat.hpp>
 #include <ide>
-using FatDisk = fs::Disk<fs::FAT>;
-std::shared_ptr<FatDisk> disk;
+std::shared_ptr<fs::Disk> disk;
 
 void Service::start()
 {
   INFO("FAT32", "Running tests for FAT32");
   auto& device = hw::Dev::disk<0, hw::IDE>(hw::IDE::SLAVE);
-  disk = std::make_shared<FatDisk> (device);
+  disk = std::make_shared<fs::Disk> (device);
   assert(disk);
   
   // verify that the size is indeed N sectors


### PR DESCRIPTION
To use any disk with terminal I had to remove template from disk. Everything should work as expected, although we have temporarily lost the ability to select filesystem. On the bright side, we now have filesystem commands in the terminal given a prepared disk, and we no longer need to know about FAT32 when creating disks.