### PR TITLE
VirtioNet now buffers outgoing packets

### DIFF
--- a/api/hw/nic.hpp
+++ b/api/hw/nic.hpp
@@ -38,6 +38,7 @@ namespace hw {
 template <typename DRIVER>
 class Nic {
 public:
+
   using driver_t = DRIVER;
 
   /** Get a readable name. */
@@ -47,25 +48,28 @@ public:
   /** The mac address. */
   inline const net::Ethernet::addr& mac()
   { return driver_.mac(); }
-  
+
   inline void set_linklayer_out(net::upstream del)
   { driver_.set_linklayer_out(del); }
-  
+
   inline net::upstream get_linklayer_out()
   { return driver_.get_linklayer_out(); }
-  
+
   inline void transmit(net::Packet_ptr pckt)
   { driver_.transmit(pckt); }
-  
+
   inline uint16_t MTU() const noexcept
   { return driver_.MTU(); }
-  
+
   inline net::BufferStore& bufstore() noexcept
   { return driver_.bufstore(); }
-  
+
+  inline void on_buffers_available(net::buf_avail_delg del)
+  { driver_.on_buffers_available(del); };
+
 private:
   driver_t driver_;
-  
+
   /**
    *  Constructor
    *
@@ -80,7 +84,7 @@ private:
 
 /** Future drivers may start out like so, */
 class E1000 {
-public: 
+public:
   inline const char* name() const noexcept
   { return "E1000 Driver"; }
   //...whatever the Nic class implicitly needs

--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -34,7 +34,7 @@ namespace hw{ class Serial; }
  *
  *  @note For device access, see Dev
  */
-class OSCAR WILDE ISN'T A VALID CLASS NAME IS IT? {
+class OS {
 public:   
   using rsprint_func = delegate<void(const char*, size_t)>;
   

--- a/api/net/inet_common.hpp
+++ b/api/net/inet_common.hpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,27 +23,30 @@
 #include <delegate>
 
 namespace net {
-// Packet must be forward declared to avoid circular dependency
-// i.e. IP uses Packet, and Packet uses IP headers
-class Packet;
-class Ethernet;
+  // Packet must be forward declared to avoid circular dependency
+  // i.e. IP uses Packet, and Packet uses IP headers
+  class Packet;
+  class Ethernet;
 
-using LinkLayer = Ethernet;
+  using LinkLayer = Ethernet;
 
-using Packet_ptr = std::shared_ptr<Packet>;
+  using Packet_ptr = std::shared_ptr<Packet>;
 
-// Downstream / upstream delegates
-using downstream = delegate<void(Packet_ptr)>;
-using upstream = downstream;
+  // Downstream / upstream delegates
+  using downstream = delegate<void(Packet_ptr)>;
+  using upstream = downstream;
 
-// Compute the internet checksum for the buffer / buffer part provided
-uint16_t checksum(void* data, size_t len) noexcept;
+  // Delegate for signalling available buffers
+  using buf_avail_delg = delegate<void(size_t count)>;
 
-// View a packet differently based on context
-template <typename T, typename Packet>
-inline auto view_packet_as(Packet packet) noexcept {
-	return std::static_pointer_cast<T>(packet);
-}
+  // Compute the internet checksum for the buffer / buffer part provided
+  uint16_t checksum(void* data, size_t len) noexcept;
+
+  // View a packet differently based on context
+  template <typename T, typename Packet>
+  inline auto view_packet_as(Packet packet) noexcept {
+    return std::static_pointer_cast<T>(packet);
+  }
 
 } //< namespace net
 

--- a/api/net/packet.hpp
+++ b/api/net/packet.hpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@
 
 #include <net/buffer_store.hpp>
 #include <net/ip4.hpp>
+#include <cassert>
 
 namespace net {
 
@@ -29,7 +30,7 @@ void default_release(BufferStore::buffer_t, size_t);
 class Packet : public std::enable_shared_from_this<Packet> {
 public:
   static constexpr size_t MTU {1500};
-  
+
   using release_del = BufferStore::release_del;
 
   /**
@@ -40,69 +41,72 @@ public:
    *  @param datalen: Length of data in the buffer
    *
    *  @WARNING: There are two adjacent parameters of the same type, violating CG I.24.
-   */    
+   */
   Packet(BufferStore::buffer_t buf, size_t bufsize, size_t datalen, release_del d = default_release) noexcept;
-  
+
   /** Destruct. */
   virtual ~Packet();
-  
+
   /** Get the buffer */
   BufferStore::buffer_t buffer() const noexcept
   { return buf_; }
-  
+
   /** Get the network packet length - i.e. the number of populated bytes  */
   inline uint32_t size() const noexcept
   { return size_; }
-  
+
   /** Get the size of the buffer. This is >= len(), usually MTU-size */
   inline uint32_t capacity() const noexcept
   { return capacity_; }
-  
+
   int set_size(const size_t) noexcept;
-  
+
   /** Set next-hop ip4. */
   void next_hop(IP4::addr ip) noexcept;
-  
+
   /** Get next-hop ip4. */
   IP4::addr next_hop() const noexcept;
-  
-  /**
-   *  Add a packet to this packet chain.
-   * 
-   *  @Warning: Let's hope this recursion won't smash the stack
-   */
+
+  /* Add a packet to this packet chain.  */
   void chain(Packet_ptr p) noexcept {
-    if (!chain_) chain_ = p;
-    else chain_->chain(p); 
-  }
-
-  /**
-   *  Get the next packet in the chain.
-   *
-   *  @Todo: Make chain iterators (i.e. begin / end) */
-  Packet_ptr unchain() noexcept
-  { return chain_; }
-  
-  /** Get the the total number of packets in the chain */
-  size_t chain_length() const noexcept {
     if (!chain_) {
-      return 1;
+      chain_ = p;
+      last_ = p;
+    } else {
+      last_->chain(p);
+      last_ = p->last_in_chain() ? p->last_in_chain() : p;
+      assert(last_);
     }
-
-    return 1 + chain_->chain_length();
   }
-  
+
+  /* Get the last packet in the chain */
+  Packet_ptr last_in_chain() noexcept
+  { return last_; }
+
+  /* Get the tail, i.e. chain minus the first element */
+  Packet_ptr tail() noexcept
+  { return chain_; }
+
+  /* Get the tail, and detach it from the head (for FIFO) */
+  Packet_ptr detach_tail() noexcept
+  {
+    auto tail = chain_;
+    chain_ = 0;
+    return tail;
+  }
+
+
   /**
    *  For a UDPv6 packet, the payload location is the start of
    *  the UDPv6 header, and so on
    */
   inline void set_payload(BufferStore::buffer_t location) noexcept
   { payload_ = location; }
-  
+
   /** Get the payload of the packet */
   inline BufferStore::buffer_t payload() const noexcept
   { return payload_; }
-  
+
   /**
    *  Upcast back to normal packet
    *
@@ -111,7 +115,7 @@ public:
    */
   static Packet_ptr packet(Packet_ptr pckt) noexcept
   { return *static_cast<Packet_ptr*>(&pckt); }
-  
+
   /** @Todo: Avoid Protected Data. (Jedi Council CG, C.133) **/
 protected:
   BufferStore::buffer_t payload_   {nullptr};
@@ -122,9 +126,10 @@ protected:
 private:
   /** Send the buffer back home, after destruction */
   release_del release_;
-  
+
   /** Let's chain packets */
-  Packet_ptr chain_ {};
+  Packet_ptr chain_ {0};
+  Packet_ptr last_ {0};
 
   /** Default constructor Deleted. See Packet(Packet&). */
   Packet() = delete;
@@ -144,7 +149,7 @@ private:
   /** Delete copy and move assignment operators. See Packet(Packet&). */
   Packet& operator=(Packet) = delete;
   Packet operator=(Packet&&) = delete;
-}; //< class Packet  
+}; //< class Packet
 } //< namespace net
 
 #endif

--- a/api/virtio/virtio.hpp
+++ b/api/virtio/virtio.hpp
@@ -6,27 +6,27 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**  
-     @note This virtio implementation was very much inspired by 
+/**
+     @note This virtio implementation was very much inspired by
      SanOS, (C) Michael Ringgaard. All due respect.
-     
+
      STANDARD:
-     
+
      We're aiming to become standards compilant according to this one:
-     
+
      Virtio 1.0, OASIS Committee Specification Draft 03
      (http://docs.oasis-open.org/virtio/virtio/v1.0/virtio-v1.0.html)
-     
-     In the following abbreviated to Virtio 1.03 or Virtio std.          
+
+     In the following abbreviated to Virtio 1.03 or Virtio std.
 */
 #pragma once
 #ifndef VIRTIO_VIRTIO_HPP
@@ -61,7 +61,7 @@
 #define VIRTIO_CONFIG_S_DRIVER_OK       4
 #define VIRTIO_CONFIG_S_FAILED          0x80
 
-/** A simple scatter-gather list used for Queue::enqueue. 
+/** A simple scatter-gather list used for Queue::enqueue.
     ( From sanos, virtio.h  - probably Linux originally)
  */
 struct scatterlist {
@@ -72,7 +72,7 @@ struct scatterlist {
 //#include <class_irq_handler.hpp>
 class Virtio
 {
-public:    
+public:
   // http://docs.oasis-open.org/virtio/virtio/v1.0/csprd01/virtio-v1.0-csprd01.html#x1-860005
   // Virtio device types
   enum virtiotype_t
@@ -91,7 +91,7 @@ public:
     RP_SERIAL,
     CAIF
   };
-  
+
   /** Virtio Queue class. */
   class Queue
   {
@@ -102,83 +102,83 @@ public:
     typedef uint16_t u16;
     typedef uint8_t  u8;
 
-    
+
     /** Virtio Ring Descriptor. Virtio std. §2.4.5  */
-    struct virtq_desc { 
-      /* Address (guest-physical). */ 
-      le64 addr; 
-      /* Length. */ 
-      le32 len; 
-      
-      /* This marks a buffer as continuing via the next field. */ 
+    struct virtq_desc {
+      /* Address (guest-physical). */
+      le64 addr;
+      /* Length. */
+      le32 len;
+
+      /* This marks a buffer as continuing via the next field. */
       #define VIRTQ_DESC_F_NEXT     1
-      /* This marks a buffer as device write-only (otherwise device read-only). */ 
+      /* This marks a buffer as device write-only (otherwise device read-only). */
       #define VIRTQ_DESC_F_WRITE    2
-      /* This means the buffer contains a list of buffer descriptors. */ 
+      /* This means the buffer contains a list of buffer descriptors. */
       #define VIRTQ_DESC_F_INDIRECT 4
-      /* The flags as indicated above. */ 
-      le16 flags; 
-      /* Next field if flags & NEXT */ 
-      le16 next; 
+      /* The flags as indicated above. */
+      le16 flags;
+      /* Next field if flags & NEXT */
+      le16 next;
     };
-    
-    
+
+
     /** Virtio Available ring. Virtio std. §2.4.6 */
-    struct virtq_avail { 
-#define VIRTQ_AVAIL_F_NO_INTERRUPT      1 
-      le16 flags; 
-      le16 idx; 
-      le16 ring[/* Queue Size */];  
-      /*le16 used_event;  Only if VIRTIO_F_EVENT_IDX */ 
+    struct virtq_avail {
+#define VIRTQ_AVAIL_F_NO_INTERRUPT      1
+      le16 flags;
+      le16 idx;
+      le16 ring[/* Queue Size */];
+      /*le16 used_event;  Only if VIRTIO_F_EVENT_IDX */
     };
-    
-    
+
+
     /** Virtio Used ring elements. Virtio std. §2.4.8 */
-    struct virtq_used_elem { 
-      /* le32 is used here for ids for padding reasons. */ 
-      /* Index of start of used descriptor chain. */ 
-      le32 id; 
-      /* Total length of the descriptor chain which was used (written to) */ 
-      le32 len; 
+    struct virtq_used_elem {
+      /* le32 is used here for ids for padding reasons. */
+      /* Index of start of used descriptor chain. */
+      le32 id;
+      /* Total length of the descriptor chain which was used (written to) */
+      le32 len;
     };
-    
+
     /** Virtio Used ring. Virtio std. §2.4.8 */
-    struct virtq_used { 
-#define VIRTQ_USED_F_NO_NOTIFY  1 
-      le16 flags; 
-      le16 idx; 
-      struct virtq_used_elem ring[ /* Queue Size */]; 
-       /*le16 avail_event; Only if VIRTIO_F_EVENT_IDX */ 
-    }; 
-    
-    
-    /** Virtqueue. Virtio std. §2.4.2 */
-    struct virtq { 
-      // The actual descriptors (16 bytes each) 
-      virtq_desc* desc;// [ /* Queue Size*/  ]; 
-      
-      // A ring of available descriptor heads with free-running index. 
-      virtq_avail* avail; 
-      
-      // Padding to the next PAGE_SIZE boundary. 
-      u8* pad; //[ /* Padding */ ]; 
- 
-      // A ring of used descriptor heads with free-running index. 
-      virtq_used* used; 
+    struct virtq_used {
+#define VIRTQ_USED_F_NO_NOTIFY  1
+      le16 flags;
+      le16 idx;
+      struct virtq_used_elem ring[ /* Queue Size */];
+       /*le16 avail_event; Only if VIRTIO_F_EVENT_IDX */
     };
-    
+
+
+    /** Virtqueue. Virtio std. §2.4.2 */
+    struct virtq {
+      // The actual descriptors (16 bytes each)
+      virtq_desc* desc;// [ /* Queue Size*/  ];
+
+      // A ring of available descriptor heads with free-running index.
+      virtq_avail* avail;
+
+      // Padding to the next PAGE_SIZE boundary.
+      u8* pad; //[ /* Padding */ ];
+
+      // A ring of used descriptor heads with free-running index.
+      virtq_used* used;
+    };
+
     /** Virtque size calculation. Virtio std. §2.4.2 */
     static inline unsigned virtq_size(unsigned int qsz);
-    
+
     // The size as read from the PCI device
     uint16_t _size;
-    
+
     // Actual size in bytes - virtq_size(size)
-    uint32_t _size_bytes;    
-    
+    uint32_t _size_bytes;
+
     // The actual queue struct
     virtq _queue;
-    
+
     uint16_t _iobase = 0; // Device PCI location
     uint16_t _num_free = 0; // Number of free descriptors
     uint16_t _free_head = 0; // First available descriptor
@@ -186,47 +186,47 @@ public:
     uint16_t _last_used_idx = 0; // Last entry inserted by device
     uint16_t _pci_index = 0; // Queue nr.
     //void **_data;
-    
-        
+
+
     /** Handler for data coming in on virtq.used. */
     delegate<int(uint8_t* data, int len)> _data_handler;
-    
+
     /** Initialize the queue buffer */
     void init_queue(int size, void* buf);
 
   public:
     /** Kick hypervisor.
-      
+
         Will notify the host (Qemu/Virtualbox etc.) about pending data  */
     void kick();
 
     /** Constructor. @param size shuld be fetched from PCI device. */
     Queue(uint16_t size, uint16_t q_index, uint16_t iobase);
-    
+
     /** Get the queue descriptor. To be written to the Virtio device. */
     virtq_desc* queue_desc() const { return _queue.desc; }
-    
-    /** Push data tokens onto the queue. 
+
+    /** Push data tokens onto the queue.
         @param sg : A scatterlist of tokens
         @param out : The number of outbound tokens (device-readable - TX)
         @param in : The number of tokens to be inbound (device-writable RX)
     */
     int enqueue(scatterlist sg[], uint32_t out, uint32_t in, void*);
-    
+
     void enqueue(void* out, uint32_t out_len, void* in, uint32_t in_len);
     void* dequeue(uint32_t& len);
-    
+
     /** Dequeue a received packet. From SanOS */
     uint8_t* dequeue(uint32_t* len);
-    
+
     void disable_interrupts();
     void enable_interrupts();
-    
+
     void set_data_handler(delegate<int(uint8_t* data,int len)> dataHandler);
-    
+
     /** Release token. @param head : the token ID to release*/
     void release(uint32_t head);
-    
+
     /** Get number of free tokens in Queue */
     inline uint16_t num_free(){ return _num_free; }
 
@@ -234,9 +234,10 @@ public:
     inline uint16_t new_incoming()
     { return _queue.used->idx - _last_used_idx; }
 
+    /** Get number of used buffers */
     inline uint16_t num_avail()
     { return _queue.avail->idx - _queue.used->idx; }
-    
+
     // access the current index
     virtq_desc& current()
     {
@@ -246,65 +247,65 @@ public:
     {
       return _queue.desc[ _queue.desc[_free_head].next ];
     }
-    
+
     // go to next index
     void go_next()
     {
       _free_head = _queue.desc[_free_head].next;
     }
-    
+
     inline uint16_t size(){ return _size; }
-    
+
   };
-  
+
 
   /** Get the Virtio config registers from the PCI device.
-      
+
       @note it varies how these are structured, hence a void* buf */
   void get_config(void* buf, int len);
-  
+
   /** Get the (saved) device IRQ */
   inline uint8_t irq(){ return _irq; };
 
   /** Reset the virtio device */
   void reset();
-  
+
   /** Negotiate supported features with host */
   void negotiate_features(uint32_t features);
-  
+
   /** Register interrupt handler & enable IRQ */
   //void enable_irq_handler(IRQ_handler::irq_delegate d);
   void enable_irq_handler();
 
   /** Probe PCI device for features */
   uint32_t probe_features();
-  
+
   /** Get locally stored features */
   inline uint32_t features(){ return _features; };
-  
+
   /** Get iobase. Wrapper around PCI_Device::iobase */
   inline uint32_t iobase(){ return _iobase; }
 
   /** Get queue size. @param index - the Virtio queue index */
-  uint32_t queue_size(uint16_t index);      
-  
+  uint32_t queue_size(uint16_t index);
+
   /** Assign a queue descriptor to a PCI queue index */
   bool assign_queue(uint16_t index, uint32_t queue_desc);
-  
+
   /** Tell Virtio device if we're OK or not. Virtio Std. § 3.1.1,step 8*/
   void setup_complete(bool ok);
 
 
-  /** Indicate which Virtio version (PCI revision ID) is supported. 
-      
+  /** Indicate which Virtio version (PCI revision ID) is supported.
+
       Currently only Legacy is supported (partially the 1.0 standard)
    */
   static inline bool version_supported(uint16_t i) { return i <= 0; }
 
-  
-  /** Virtio device constructor. 
-      
-      Should conform to Virtio std. §3.1.1, steps 1-6  
+
+  /** Virtio device constructor.
+
+      Should conform to Virtio std. §3.1.1, steps 1-6
       (Step 7 is "Device specific" which a subclass will handle)
   */
   Virtio(hw::PCI_Device& pci);
@@ -312,25 +313,24 @@ public:
 private:
   //PCI memer as reference (so no indirection overhead)
   hw::PCI_Device& _pcidev;
-  
+
   //We'll get this from PCI_device::iobase(), but that lookup takes longer
-  uint32_t _iobase = 0;  
-  
+  uint32_t _iobase = 0;
+
   uint8_t _irq = 0;
   uint32_t _features = 0;
   uint16_t _virtio_device_id = 0;
-  
+
   // Indicate if virtio device ID is legacy or standard
   bool _LEGACY_ID = 0;
   bool _STD_ID = 0;
-  
+
   void set_irq();
 
   //TEST
   int calls = 0;
-  
+
   void default_irq_handler();
 };
 
 #endif
-

--- a/src/net/ethernet.cpp
+++ b/src/net/ethernet.cpp
@@ -6,17 +6,17 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define DEBUG // Allow debugging
-#define DEBUG2
+//#define DEBUG // Allow debugging
+//#define DEBUG2
 
 #include <os>
 #include <net/ethernet.hpp>
@@ -55,29 +55,29 @@ void Ethernet::transmit(Packet_ptr pckt) {
   // Verify ethernet header
   assert(hdr->dest.major != 0 || hdr->dest.minor !=0);
   assert(hdr->type != 0);
-  
+
   // Add source address
   hdr->src = mac_;
-  
+
   debug2("<Ethernet OUT> Transmitting %i b, from %s -> %s. Type: %i\n",
       pckt->size(), mac_.str().c_str(), hdr->dest.str().c_str(), hdr->type);
-  
+
   physical_out_(pckt);
 }
 
 void Ethernet::bottom(Packet_ptr pckt) {
   assert(pckt->size() > 0);
-  
+
   header* eth = reinterpret_cast<header*>(pckt->buffer());
-  
+
   /** Do we pass on ethernet headers? As for now, yes.
     data += sizeof(header);
     len -= sizeof(header);
-  */    
+  */
   debug2("<Ethernet IN> %s => %s , Eth.type: 0x%x ",
     eth->src.str().c_str(), eth->dest.str().c_str(), eth->type);
-  
-  switch(eth->type) { 
+
+  switch(eth->type) {
   case ETH_IP4:
     debug2("IPv4 packet\n");
     ip4_handler_(pckt);
@@ -87,12 +87,12 @@ void Ethernet::bottom(Packet_ptr pckt) {
     debug2("IPv6 packet\n");
     ip6_handler_(pckt);
     break;
-    
+
   case ETH_ARP:
     debug2("ARP packet\n");
     arp_handler_(pckt);
     break;
-    
+
   case ETH_WOL:
     debug2("Wake-on-LAN packet\n");
     break;
@@ -100,7 +100,7 @@ void Ethernet::bottom(Packet_ptr pckt) {
   case ETH_VLAN:
     debug("VLAN tagged frame (not yet supported)");
     break;
-    
+
   default:
     // This might be 802.3 LLC traffic
     if (net::ntohs(eth->type) > 1500) {

--- a/src/net/packet.cpp
+++ b/src/net/packet.cpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,42 +22,44 @@
 
 namespace net {
 
-Packet::Packet(BufferStore::buffer_t buf, size_t bufsize, size_t datalen, release_del rel) noexcept:
+  Packet::Packet(BufferStore::buffer_t buf, size_t bufsize, size_t datalen, release_del rel) noexcept:
   buf_       {buf},
-  capacity_  {bufsize},
-  size_      {datalen},
-  next_hop4_ {},
-  release_   {rel}
+    capacity_  {bufsize},
+    size_      {datalen},
+    next_hop4_ {},
+    release_   {rel}
 {
   debug("<Packet> CONSTRUCT packet, buf @ %p\n", buf);
 }
 
-Packet::~Packet() {
-  debug("<Packet> DESTRUCT packet, buf @ %p\n", buf_);
-  release_(buf_, capacity_);
-}
-
-IP4::addr Packet::next_hop() const noexcept {
-  return next_hop4_;
-}
-
-void Packet::next_hop(IP4::addr ip) noexcept {
-  next_hop4_ = ip;
-}
-
-int Packet::set_size(const size_t size) noexcept {
-  if(size > capacity_) {
-    return 0;
+  Packet::~Packet() {
+    debug("<Packet> DESTRUCT packet, buf @ %p\n", buf_);
+    release_(buf_, capacity_);
   }
 
-  size_ = size;
+  IP4::addr Packet::next_hop() const noexcept {
+    return next_hop4_;
+  }
 
-  return size_;
-}
+  void Packet::next_hop(IP4::addr ip) noexcept {
+    next_hop4_ = ip;
+  }
 
-void default_release(BufferStore::buffer_t b, size_t) {
-  (void) b;
-  debug("<Packet DEFAULT RELEASE> Ignoring buffer.");
-}
+  int Packet::set_size(const size_t size) noexcept {
+    if(size > capacity_) {
+      return 0;
+    }
+
+    size_ = size;
+
+    return size_;
+  }
+
+  void default_release(BufferStore::buffer_t b, size_t) {
+    (void) b;
+    debug("<Packet DEFAULT RELEASE> Ignoring buffer.");
+  }
+
+
 
 } //< namespace net

--- a/src/virtio/virtionet.cpp
+++ b/src/virtio/virtionet.cpp
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #define PRINT_INFO
-//#define DEBUG // Allow debuging
+#define DEBUG // Allow debuging
 //#define DEBUG2
 
 #include <virtio/virtionet.hpp>
@@ -57,38 +57,38 @@ VirtioNet::VirtioNet(hw::PCI_Device& d)
     | (1 << VIRTIO_NET_F_STATUS);
   //| (1 << VIRTIO_NET_F_MRG_RXBUF); //Merge RX Buffers (Everything i 1 buffer)
   uint32_t wanted_features = needed_features; /*;
-    | (1 << VIRTIO_NET_F_CSUM)
-    | (1 << VIRTIO_F_ANY_LAYOUT)
-    | (1 << VIRTIO_NET_F_CTRL_VQ)
-    | (1 << VIRTIO_NET_F_GUEST_ANNOUNCE)
-    | (1 << VIRTIO_NET_F_CTRL_MAC_ADDR);*/
+                                                | (1 << VIRTIO_NET_F_CSUM)
+                                                | (1 << VIRTIO_F_ANY_LAYOUT)
+                                                | (1 << VIRTIO_NET_F_CTRL_VQ)
+                                                | (1 << VIRTIO_NET_F_GUEST_ANNOUNCE)
+                                                | (1 << VIRTIO_NET_F_CTRL_MAC_ADDR);*/
 
   negotiate_features(wanted_features);
 
 
   CHECK ((features() & needed_features) == needed_features,
-	 "Negotiated needed features");
+         "Negotiated needed features");
 
   CHECK ((features() & wanted_features) == wanted_features,
-	 "Negotiated wanted features");
+         "Negotiated wanted features");
 
   CHECK(features() & (1 << VIRTIO_NET_F_CSUM),
-	"Device handles packets w. partial checksum");
+        "Device handles packets w. partial checksum");
 
   CHECK(features() & (1 << VIRTIO_NET_F_GUEST_CSUM),
-	"Guest handles packets w. partial checksum");
+        "Guest handles packets w. partial checksum");
 
   CHECK(features() & (1 << VIRTIO_NET_F_CTRL_VQ),
-       "There's a control queue");
+        "There's a control queue");
 
   CHECK(features() & (1 << VIRTIO_F_ANY_LAYOUT),
-       "Queue can handle any header/data layout");
+        "Queue can handle any header/data layout");
 
   CHECK(features() & (1 << VIRTIO_F_RING_INDIRECT_DESC),
-	"We can use indirect descriptors");
+        "We can use indirect descriptors");
 
   CHECK(features() & (1 << VIRTIO_F_RING_EVENT_IDX),
-	"There's a Ring Event Index to use");
+        "There's a Ring Event Index to use");
 
   CHECK(features() & (1 << VIRTIO_NET_F_MQ),
         "There are multiple queue pairs");
@@ -97,23 +97,23 @@ VirtioNet::VirtioNet(hw::PCI_Device& d)
     printf("\t\t* max_virtqueue_pairs: 0x%x \n",_conf.max_virtq_pairs);
 
   CHECK(features() & (1 << VIRTIO_NET_F_MRG_RXBUF),
-	"Merge RX buffers");
+        "Merge RX buffers");
 
 
   // Step 1 - Initialize RX/TX queues
   auto success = assign_queue(0, (uint32_t)rx_q.queue_desc());
   CHECK(success, "RX queue assigned (0x%x) to device",
-	(uint32_t)rx_q.queue_desc());
+        (uint32_t)rx_q.queue_desc());
 
   success = assign_queue(1, (uint32_t)tx_q.queue_desc());
   CHECK(success, "TX queue assigned (0x%x) to device",
-	(uint32_t)tx_q.queue_desc());
+        (uint32_t)tx_q.queue_desc());
 
   // Step 2 - Initialize Ctrl-queue if it exists
   if (features() & (1 << VIRTIO_NET_F_CTRL_VQ)) {
     success = assign_queue(2, (uint32_t)tx_q.queue_desc());
     CHECK(success, "CTRL queue assigned (0x%x) to device",
-	  (uint32_t)ctrl_q.queue_desc());
+          (uint32_t)ctrl_q.queue_desc());
   }
 
   // Step 3 - Fill receive queue with buffers
@@ -137,7 +137,7 @@ VirtioNet::VirtioNet(hw::PCI_Device& d)
   get_config();
 
   CHECK(_conf.mac.major > 0, "Valid Mac address: %s",
-	_conf.mac.str().c_str());
+        _conf.mac.str().c_str());
 
 
   // Step 7 - 9 - GSO: @todo Not using GSO features yet.
@@ -198,12 +198,9 @@ void VirtioNet::irq_handler(){
   if (isr & 1){
 
     // This now means service RX & TX interchangeably
-    service_RX();
-
     // We need a zipper-solution; we can't receive n packets before sending
     // anything - that's unfair.
-
-    //service_TX();
+    service_queues();
   }
 
   // Step 2. B)
@@ -219,19 +216,21 @@ void VirtioNet::irq_handler(){
 
 }
 
-void VirtioNet::service_RX(){
+void VirtioNet::service_queues(){
   debug2("<RX Queue> %i new packets, %i available tokens \n",
-        rx_q.new_incoming(),rx_q.num_avail());
+         rx_q.new_incoming(),rx_q.num_avail());
 
 
   /** For RX, we dequeue, add new buffers and let receiver is responsible for
       memory management (they know when they're done with the packet.) */
 
-  int i = 0;
+  int dequeued_rx = 0;
   uint32_t len = 0;
   uint8_t* data;
+  int dequeued_tx = 0;
 
   rx_q.disable_interrupts();
+  tx_q.disable_interrupts();
   // A zipper, alternating between sending and receiving
   while(rx_q.new_incoming() or tx_q.new_incoming()){
 
@@ -241,49 +240,74 @@ void VirtioNet::service_RX(){
 
       auto pckt_ptr = std::make_shared<Packet>
         (data+sizeof(virtio_net_hdr), // Offset buffer (bufstore knows the offset)
-	 MTU()-sizeof(virtio_net_hdr), // Capacity
-	 len - sizeof(virtio_net_hdr), release_buffer); // Size
+         MTU()-sizeof(virtio_net_hdr), // Capacity
+         len - sizeof(virtio_net_hdr), release_buffer); // Size
 
       _link_out(pckt_ptr);
 
       // Requeue a new buffer
       add_receive_buffer();
 
-      i++;
+      dequeued_rx++;
 
     }
     debug2("<VirtioNet> Service loop about to kick RX if %i \n",i);
 
-    if (i)
-      rx_q.kick();
-
     // Do one TX-packet
     if (tx_q.new_incoming()){
       tx_q.dequeue(&len);
+      dequeued_tx++;
     }
 
-    rx_q.enable_interrupts();
   }
+
+  // Let virtio know we have increased receive capacity
+  if (dequeued_rx)
+    rx_q.kick();
+
+  rx_q.enable_interrupts();
+
+  // If we have a transmit queue, eat from it, otherwise let the stack know we
+  // have increased transmit capacity
+  if (dequeued_tx) {
+
+    debug("<VirtioNet> Transmitted something, now transmitting any buffer\n");
+
+    // transmit as much as possible from the buffer
+    if (transmit_queue_){
+      auto buf = transmit_queue_;
+      transmit_queue_ = 0;
+      transmit(buf);
+    }
+
+    // If we now emptied the buffer, offer packets to stack
+    if (! transmit_queue_ && tx_q.num_avail() > 1)
+      buffer_available_event_(tx_q.num_avail() / 2);
+
+  }
+
+  tx_q.enable_interrupts();
 
   debug2("<VirtioNet> Done servicing queues\n");
 }
 
-void VirtioNet::service_TX(){
-  debug2("<TX Queue> %i transmitted, %i waiting packets\n",
-        tx_q.new_incoming(),tx_q.num_avail());
+void VirtioNet::add_to_tx_buffer(net::Packet_ptr pckt){
+  if (transmit_queue_)
+      transmit_queue_->chain(pckt);
+    else
+      transmit_queue_ = pckt;
 
-  uint32_t len = 0;
-  int i = 0;
+#ifdef DEBUG
+  size_t chain_length = 1;
+  Packet_ptr next = transmit_queue_->tail();
+  while (next) {
+    chain_length++;
+    next = next->tail();
+  }
+#endif
 
-  /** For TX, just dequeue all incoming tokens.
+  debug("Buffering, %i packets chained \n", chain_length);
 
-      Sender allocated the buffer and is responsible for memory management.
-      @todo Sender doesn't know when the packet is transmitted; deal with it. */
-  for (;i < tx_q.new_incoming(); i++)
-    tx_q.dequeue(&len);
-
-  debug2("\t Dequeued %i packets \n",i);
-  // Deallocate buffer.
 }
 
 void VirtioNet::transmit(net::Packet_ptr pckt){
@@ -302,6 +326,32 @@ void VirtioNet::transmit(net::Packet_ptr pckt){
       support VirtualBox
   */
 
+  int transmitted = 0;
+  net::Packet_ptr tail {pckt};
+
+  // Transmit all we can directly
+  while (tx_q.num_free() and tail) {
+    debug("%i tokens left in TX queue \n", tx_q.num_free());
+    enqueue(tail);
+    tail = tail->detach_tail();
+    transmitted++;
+    if (! tail)
+      break;
+
+  }
+
+  // Notify virtio about new packets
+  if (transmitted)
+    tx_q.kick();
+
+  // Buffer the rest
+  if (tail)
+    add_to_tx_buffer(tail);
+
+}
+
+void VirtioNet::enqueue(net::Packet_ptr pckt){
+
   // A scatterlist for virtio-header + data
   scatterlist sg[2];
 
@@ -313,7 +363,5 @@ void VirtioNet::transmit(net::Packet_ptr pckt){
 
   // Enqueue scatterlist, 2 pieces readable, 0 writable.
   tx_q.enqueue(sg, 2, 0, 0);
-
-  tx_q.kick();
 
 }

--- a/test/transmit/Makefile
+++ b/test/transmit/Makefile
@@ -1,0 +1,20 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# The name of your service
+SERVICE = test_transmit
+SERVICE_NAME = Network transmission tests
+
+# Your service parts
+FILES = service.cpp
+
+# Your disk image
+DISK=
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+endif
+
+include $(INCLUDEOS_INSTALL)/Makeseed

--- a/test/transmit/README.md
+++ b/test/transmit/README.md
@@ -1,0 +1,5 @@
+# Test packet transmission, buffering and transmit-buffers available event
+
+This test will try to generate and transmit packets as fast as possible, which should now not cause panic, but rather buffering.
+
+*NOTE: This is a Work In Progress*

--- a/test/transmit/run.sh
+++ b/test/transmit/run.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh
+

--- a/test/transmit/service.cpp
+++ b/test/transmit/service.cpp
@@ -1,0 +1,78 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//#define DEBUG // Debug supression
+
+#include <os>
+#include <list>
+#include <net/inet4>
+#include <vector>
+
+using namespace std;
+using namespace net;
+
+std::shared_ptr<net::Inet4<VirtioNet> > inet;
+
+void Service::start()
+{
+  // Assign an IP-address, using Hårek-mapping :-)
+  auto& eth0 = hw::Dev::eth<0,VirtioNet>();
+  auto& mac = eth0.mac();
+
+  inet = std::make_shared<net::Inet4<VirtioNet>>(eth0);
+
+  inet->network_config({{ mac.part[2],mac.part[3],mac.part[4],mac.part[5] }},
+                       {{ 255,255,0,0 }}, // Netmask
+                       {{ 10,0,0,1 }}, // Gateway
+                       {{ 8,8,8,8}});  // DNS
+
+  printf("Service IP address: %s \n", inet->ip_addr().str().c_str());
+
+  // UDP
+  UDP::port_t port = 4242;
+  auto& sock = inet->udp().bind(port);
+
+  sock.onRead([] (UDP::Socket& conn, UDP::addr_t addr, UDP::port_t port,
+                  const char* data, int len) -> int {
+                printf("Getting UDP data from %s: %i: %s\n",
+                       addr.str().c_str(), port, data);
+                // send the same thing right back!
+                conn.sendto(addr, port, data, len);
+                return 0;
+              });
+
+  eth0.on_buffers_available([](size_t s){
+      CHECK(1,"There are now %i available buffers", s);
+    });
+
+
+  hw::PIT::instance().onTimeout(200ms,[=](){
+      const int packets { 600 };
+      INFO("TEST", "Trying to transmit %i packets at maximum throttle", packets);
+      for (int i=0; i < packets; i++){
+        auto pckt = inet->createPacket(inet->MTU());
+        Ethernet::header* hdr = reinterpret_cast<Ethernet::header*>(pckt->buffer());
+        hdr->dest.major = Ethernet::addr::BROADCAST_FRAME.major;
+        hdr->dest.minor = Ethernet::addr::BROADCAST_FRAME.minor;
+        hdr->type = Ethernet::ETH_ARP;
+        inet->link().transmit(pckt);
+      }
+
+      CHECK(1,"Transmission didn't panic");
+
+    });
+}

--- a/test/transmit/service.cpp
+++ b/test/transmit/service.cpp
@@ -48,10 +48,18 @@ void Service::start()
 
   sock.onRead([] (UDP::Socket& conn, UDP::addr_t addr, UDP::port_t port,
                   const char* data, int len) -> int {
-                printf("Getting UDP data from %s: %i: %s\n",
-                       addr.str().c_str(), port, data);
+                CHECK(1, "Got  UDP data from %s: %i: %s",
+                      addr.str().c_str(), port, data);
                 // send the same thing right back!
-                conn.sendto(addr, port, data, len);
+                const int packets { 600 };
+
+                INFO("TEST 2", "Trying to transmit %i packets at maximum throttle", packets);
+                for (int i = 0; i < packets; i++)
+                  conn.sendto(addr, port, data, len);
+
+
+
+
                 return 0;
               });
 
@@ -62,7 +70,7 @@ void Service::start()
 
   hw::PIT::instance().onTimeout(200ms,[=](){
       const int packets { 600 };
-      INFO("TEST", "Trying to transmit %i packets at maximum throttle", packets);
+      INFO("TEST 2", "Trying to transmit %i packets at maximum throttle", packets);
       for (int i=0; i < packets; i++){
         auto pckt = inet->createPacket(inet->MTU());
         Ethernet::header* hdr = reinterpret_cast<Ethernet::header*>(pckt->buffer());
@@ -74,5 +82,8 @@ void Service::start()
 
       CHECK(1,"Transmission didn't panic");
 
+
     });
+
+
 }


### PR DESCRIPTION
* `VirtioNet::transmit` will now check if the incoming packet is chained, and if so transmit the whole chain
  * If the virtio transmit-ring is full, the remaining packet chain will be saved and new packets will be added to that chain
* When the virtio device notifies the driver that packets have been sent:
  * A) We transmit any waiting packets using `transmit` (and if there's not enough space in the ring, we requeue the remaining packets)
  * B) If the transmit buffer is empty (no waiting packets), we call the new `buffer_available_event`

Next up is to make the buffer available event visible in inet