### PR TITLE
net: Distribute free buffers, udp: Remove gather phase

### DIFF
--- a/api/net/inet4.hpp
+++ b/api/net/inet4.hpp
@@ -133,9 +133,10 @@ namespace net {
     virtual void
     on_transmit_queue_available(transmit_avail_delg del) override {
       tqa.push_back(del);
+      printf("* adding transmit listener  (sz=%u)\n", tqa.size() );
     }
 
-    inline virtual size_t transmit_queue_available() override {
+    virtual size_t transmit_queue_available() override {
       return nic_.transmit_queue_available();
     }
 
@@ -144,7 +145,9 @@ namespace net {
     }
 
   private:
-    void transmit_queue_available(size_t);
+    inline void process_sendq(size_t);
+    // delegates registered to get signalled about free packets
+    std::vector<transmit_avail_delg> tqa;
     
     IP4::addr ip4_addr_;
     IP4::addr netmask_;
@@ -164,8 +167,6 @@ namespace net {
 
     std::shared_ptr<net::DHClient> dhcp_{};
     BufferStore& bufstore_;
-    // delegates registered to get signalled about free packets
-    std::vector<transmit_avail_delg> tqa;
   };
 }
 

--- a/api/net/inet4.hpp
+++ b/api/net/inet4.hpp
@@ -55,14 +55,14 @@ namespace net {
     Ethernet& link() override
     { return eth_; }
 
-    inline IP4& ip_obj() override
+    IP4& ip_obj() override
     { return ip4_; }
 
     /** Get the TCP-object belonging to this stack */
-    inline TCP& tcp() override { debug("<TCP> Returning tcp-reference to %p \n",&tcp_); return tcp_; }
+    TCP& tcp() override { return tcp_; }
 
     /** Get the UDP-object belonging to this stack */
-    inline UDP& udp() override { return udp_; }
+    UDP& udp() override { return udp_; }
 
     /** Get the DHCP client (if any) */
     inline std::shared_ptr<DHClient> dhclient() override { return dhcp_;  }
@@ -129,9 +129,10 @@ namespace net {
       this->dns_server = dns;
     }
 
-    inline virtual void
+    // register a callback for receiving signal on free packet-buffers
+    virtual void
     on_transmit_queue_available(transmit_avail_delg del) override {
-      nic_.on_transmit_queue_available(del);
+      tqa.push_back(del);
     }
 
     inline virtual size_t transmit_queue_available() override {
@@ -143,7 +144,8 @@ namespace net {
     }
 
   private:
-
+    void transmit_queue_available(size_t);
+    
     IP4::addr ip4_addr_;
     IP4::addr netmask_;
     IP4::addr router_;
@@ -162,6 +164,8 @@ namespace net {
 
     std::shared_ptr<net::DHClient> dhcp_{};
     BufferStore& bufstore_;
+    // delegates registered to get signalled about free packets
+    std::vector<transmit_avail_delg> tqa;
   };
 }
 

--- a/api/net/inet4.inc
+++ b/api/net/inet4.inc
@@ -25,7 +25,7 @@ namespace net
     /** Upstream wiring  */
     // Packets available
     nic.on_transmit_queue_available(
-      transmit_avail_delg::from<Inet4<T>, transmit_queue_available>(*this));
+      transmit_avail_delg::from<Inet4<T>, &Inet4<T>::transmit_queue_available>(*this));
     
     // Phys -> Eth (Later, this will be passed through router)
     nic.set_linklayer_out(eth_bottom);

--- a/api/net/inet4.inc
+++ b/api/net/inet4.inc
@@ -25,7 +25,7 @@ namespace net
     /** Upstream wiring  */
     // Packets available
     nic.on_transmit_queue_available(
-      transmit_avail_delg::from<Inet4<T>, &Inet4<T>::transmit_queue_available>(*this));
+      transmit_avail_delg::from<Inet4<T>, &Inet4<T>::process_sendq>(*this));
     
     // Phys -> Eth (Later, this will be passed through router)
     nic.set_linklayer_out(eth_bottom);
@@ -86,7 +86,7 @@ namespace net
   }
   
   template <typename T>
-  void Inet4<T>::transmit_queue_available(size_t packets)
+  void Inet4<T>::process_sendq(size_t packets)
   {
     ////////////////////////////////////////////
     // divide up fairly

--- a/api/net/inet4.inc
+++ b/api/net/inet4.inc
@@ -23,6 +23,9 @@ namespace net
     auto tcp_bottom(upstream::from<TCP,&TCP::bottom>(tcp_));
     
     /** Upstream wiring  */
+    // Packets available
+    nic.on_transmit_queue_available(
+      transmit_avail_delg::from<Inet4<T>, transmit_queue_available>(*this));
     
     // Phys -> Eth (Later, this will be passed through router)
     nic.set_linklayer_out(eth_bottom);
@@ -42,7 +45,6 @@ namespace net
     // IP4 -> TCP
     ip4_.set_tcp_handler(tcp_bottom);
     
-   
     /** Downstream delegates */
     auto phys_top(downstream
                   ::from<hw::Nic<VirtioNet>,&hw::Nic<VirtioNet>::transmit>(nic));
@@ -81,6 +83,51 @@ namespace net
     INFO("Inet4","Applying DHCP client");
     dhcp_ = std::make_shared<DHClient>(*this);
     dhcp_->negotiate();
+  }
+  
+  template <typename T>
+  void Inet4<T>::transmit_queue_available(size_t packets)
+  {
+    ////////////////////////////////////////////
+    // divide up fairly
+    size_t div = packets / tqa.size();
+    
+    // give each protocol a chance to take
+    for (size_t i = 0; i < tqa.size(); i++)
+      tqa[i](div);
+    
+    // hand out remaining
+    for (size_t i = 0; i < tqa.size(); i++)
+    {
+      div = buffers_available();
+      if (!div) break;
+      // give as much as possible
+      tqa[i](div);
+    }
+    ////////////////////////////////////////////
+    
+    /*
+    size_t list[tqa.size()];
+    for (size_t i = 0; i < tqa.size(); i++)
+      list[i] = tqa[i](0);
+    
+    size_t give[tqa.size()] = {0};
+    int cp = 0; // current protocol
+    
+    // distribute packets one at a time for each protocol
+    while (packets--)
+    {
+      if (list[cp])
+      {
+        // give one packet
+        give[cp]++;  list[cp]--;
+      }
+      cp = (cp + 1) % tqa.size();
+    }
+    // hand out several packets per protocol
+    for (size_t i = 0; i < tqa.size(); i++)
+      if (give[i]) tqa[i](give[i]);
+    */
   }
   
 }

--- a/api/net/inet_common.hpp
+++ b/api/net/inet_common.hpp
@@ -36,9 +36,8 @@ namespace net {
   using downstream = delegate<void(Packet_ptr)>;
   using upstream = downstream;
 
-  // Delegate for signalling available space in device transmit queue
-  // 'count' is a multiple of packets
-  using transmit_avail_delg = delegate<void(size_t count)>;
+  // Delegate for signalling available buffers in device transmit queue
+  using transmit_avail_delg = delegate<void(size_t)>;
 
   // Compute the internet checksum for the buffer / buffer part provided
   uint16_t checksum(void* data, size_t len) noexcept;

--- a/api/net/ip4/udp.hpp
+++ b/api/net/ip4/udp.hpp
@@ -115,18 +115,15 @@ namespace net {
     UDPSocket& bind();
   
     //! construct this UDP module with @inet
-    UDP(Stack& inet) :
-      stack_(inet)
-    {
-      network_layer_out_ = [] (net::Packet_ptr) {};
-    }
+    UDP(Stack& inet);
     
     Stack& stack()
     {
       return stack_;
     }
     
-    size_t process_sendq(size_t num);
+    // create packets from send queue
+    void process_sendq(size_t num);
     
   private: 
     downstream  network_layer_out_;

--- a/src/debug/test_service.cpp
+++ b/src/debug/test_service.cpp
@@ -87,7 +87,6 @@ void Service::start()
     sock.sendto(addr, port, data, len,
     [] {
       // sent
-      
       INFO("UDP test", "SUCCESS");
     });
   });

--- a/src/net/ip4/udp.cpp
+++ b/src/net/ip4/udp.cpp
@@ -103,7 +103,12 @@ namespace net {
       num--;
       
       if (buffer.done())
+      {
+        // call on_written callback
+        buffer.callback();
+        // remove buffer from queue
         sendq.pop_front();
+      }
     }
   }
   

--- a/src/net/ip4/udp.cpp
+++ b/src/net/ip4/udp.cpp
@@ -23,6 +23,14 @@
 
 namespace net {
 
+  UDP::UDP(Stack& inet)
+    : stack_(inet)
+  {
+    network_layer_out_ = [] (net::Packet_ptr) {};
+    inet.on_transmit_queue_available(
+      transmit_avail_delg::from<UDP, &UDP::process_sendq>(this));
+  }
+  
   void UDP::bottom(net::Packet_ptr pckt)
   {
     debug("<UDP handler> Got data");
@@ -50,9 +58,9 @@ namespace net {
     if (it == ports_.end()) {
       // create new socket
       auto res = ports_.emplace(
-                                std::piecewise_construct,
-                                std::forward_as_tuple(port),
-                                std::forward_as_tuple(stack_, port));
+        std::piecewise_construct,
+        std::forward_as_tuple(port),
+        std::forward_as_tuple(stack_, port));
       it = res.first;
     }
     return it->second;
@@ -65,7 +73,8 @@ namespace net {
 
     debug("UDP finding free ephemeral port\n");  
     while (ports_.find(++current_port_) != ports_.end())
-      if (current_port_  == 0) current_port_ = 1025; // prevent automatic ports under 1024
+      // prevent automatic ports under 1024
+      if (current_port_  == 0) current_port_ = 1024;
   
     debug("UDP binding to %i port\n", current_port_);
     return bind(current_port_);
@@ -84,19 +93,8 @@ namespace net {
     network_layer_out_(pckt);
   }
   
-  size_t UDP::process_sendq(size_t num)
+  void UDP::process_sendq(size_t num)
   {
-    // for gathering phase
-    if (num == 0)
-    {
-      size_t total = 0;
-      for (auto& buf : sendq)
-        total += buf.packets_needed();
-      
-      return total;
-    }
-    
-    // for processing phase
     while (!sendq.empty() && num != 0)
     {
       WriteBuffer& buffer = sendq.front();
@@ -107,8 +105,6 @@ namespace net {
       if (buffer.done())
         sendq.pop_front();
     }
-    
-    return num;
   }
   
   size_t UDP::WriteBuffer::packets_needed() const

--- a/test/UDP/service.cpp
+++ b/test/UDP/service.cpp
@@ -41,6 +41,7 @@ void Service::start()
   const UDP::port_t port = 4242;
   auto& sock = inet.udp().bind(port);
   
+  /*
   sock.on_read(
   [&sock] (UDP::addr_t addr, UDP::port_t port,
            const char* data, size_t len)
@@ -55,7 +56,7 @@ void Service::start()
       
       INFO("UDP test", "SUCCESS");
     });
-  });
+  });*/
   
   INFO("UDP test", "Listening on port %d\n", port);
 }


### PR DESCRIPTION
Adds the free buffers distribution algorithm, which is very simple by design right now. At first we give each registered protocol a fair share of the total pie, then in the second phase we try to hand out as much as possible to each protocol. A better version will keep all phases equally fair.

Also finished the sendq implementation in UDP.