### PR TITLE
udp: Fix buffer release issue

### DIFF
--- a/src/debug/test_service.cpp
+++ b/src/debug/test_service.cpp
@@ -85,9 +85,26 @@ void Service::start()
               addr.str().c_str(), port, strdata.c_str());
     // send the same thing right back!
     sock.sendto(addr, port, data, len,
-    [] {
-      // sent
-      INFO("UDP test", "SUCCESS");
+    [&sock, addr, port]
+    {
+      // print this message once
+      printf("*** Starting spam (you should see this once)\n");
+      
+      typedef std::function<void()> rnd_gen_t;
+      auto next = std::make_shared<rnd_gen_t> ();
+      
+      *next = 
+      [next, &sock, addr, port] ()
+      {
+        // spam this message at max speed
+        std::string text("Spamorino Cappucino\n");
+        
+        sock.sendto(addr, port, text.data(), text.size(),
+        [next] { (*next)(); });
+      };
+      
+      // start spamming
+      (*next)();
     });
   });
   

--- a/src/net/ip4/udp_socket.cpp
+++ b/src/net/ip4/udp_socket.cpp
@@ -18,6 +18,9 @@
 #include <net/ip4/udp_socket.hpp>
 #include <memory>
 
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+
 namespace net
 {
   UDPSocket::UDPSocket(UDP& udp_, port_t port)
@@ -54,12 +57,15 @@ namespace net
       size_t len,
       sendto_handler cb)
   {
-    udp.sendq.emplace_back(
-        (const uint8_t*) buffer, len, cb, this->udp,
-        local_addr(), this->l_port, destIP, port);
-    
-    // UDP packets are meant to be sent immediately, so try flushing
-    udp.flush();
+    if (likely(len))
+    {
+      udp.sendq.emplace_back(
+          (const uint8_t*) buffer, len, cb, this->udp,
+          local_addr(), this->l_port, destIP, port);
+      
+      // UDP packets are meant to be sent immediately, so try flushing
+      udp.flush();
+    }
   }
   void UDPSocket::bcast(
       addr_t srcIP, 
@@ -68,12 +74,15 @@ namespace net
       size_t len,
       sendto_handler cb)
   {
-    udp.sendq.emplace_back(
-        (const uint8_t*) buffer, len, cb, this->udp,
-        srcIP, this->l_port, IP4::INADDR_BCAST, port);
-    
-    // UDP packets are meant to be sent immediately, so try flushing
-    udp.flush();
+    if (likely(len))
+    {
+      udp.sendq.emplace_back(
+          (const uint8_t*) buffer, len, cb, this->udp,
+          srcIP, this->l_port, IP4::INADDR_BCAST, port);
+      
+      // UDP packets are meant to be sent immediately, so try flushing
+      udp.flush();
+    }
   }
   
 }


### PR DESCRIPTION
UDP swallowed buffers too fast due to immediate-flushing behavior. Now fixed