### PR TITLE
tcp/pit: fixed ambiguous member call on write

### DIFF
--- a/api/hw/pit.hpp
+++ b/api/hw/pit.hpp
@@ -83,6 +83,9 @@ namespace hw {
         @param handler: A delegate or function to be called on timeout.   */
     Timer_iterator onTimeout(std::chrono::milliseconds ms, timeout_handler handler);
 
+    Timer_iterator on_timeout(double sec, timeout_handler handler)
+    { return onTimeout(std::chrono::milliseconds((unsigned)(sec * 1000)), handler); }
+
     /** Create a repeating timer.
         @param ms: Expiration time. Compatible with all std::chrono durations.
         @param handler: A delegate or function to be called every ms interval.

--- a/test/timers/service.cpp
+++ b/test/timers/service.cpp
@@ -63,7 +63,7 @@ void Service::start()
     });
 
   // 1 sec.
-  timer.onTimeout(1s, [] {
+  timer.on_timeout(1, [] {
       CHECKSERT(one_shots == 1, "After 1 sec, 1 other one-shot-timers has fired");
       one_shots++;
     });


### PR DESCRIPTION
.. and PIT now supports seconds as `double`.