### PR TITLE
Minor changes to MemDisk...

### DIFF
--- a/api/fs/memdisk.hpp
+++ b/api/fs/memdisk.hpp
@@ -29,7 +29,7 @@ namespace fs {
   public:
     static constexpr size_t SECTOR_SIZE = 512;
 
-    MemDisk() noexcept;
+    explicit MemDisk() noexcept;
 
     virtual const char* name() const noexcept override
     { return "MemDisk"; }
@@ -49,8 +49,8 @@ namespace fs {
     virtual buffer_t read_sync(block_t blk) override;
 
   private:
-    const char*  image_start_;
-    const char*  image_end_;
+    const char* const image_start_;
+    const char* const image_end_;
   }; //< class MemDisk
 
 } //< namespace fs

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ INSTALL = $(INCLUDEOS_INSTALL)
 # stackrealign is needed to guarantee 16-byte stack alignment for SSE
 # the compiler seems to be really dumb in this regard, creating a misaligned stack left and right
 CAPABS_COMMON = -mstackrealign -msse3
-CAPABS = $(CAPABS_COMMON) -O2 -DNO_DEBUG=1
+CAPABS = $(CAPABS_COMMON) -O2 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION
 WARNS   = -Wall -Wextra #-pedantic
 DEBUG_OPTS = -ggdb3
 

--- a/src/fs/memdisk.cpp
+++ b/src/fs/memdisk.cpp
@@ -15,10 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstring>
-#include <cassert>
 #include <cstdio>
+#include <cstring>
 
+#include <api/common>
 #include <fs/memdisk.hpp>
 
 #define likely(x)       __builtin_expect(!!(x), 1)
@@ -40,13 +40,13 @@ namespace fs {
     auto sector_loc = image_start_ + (blk * block_size());
     // Disallow reading memory past disk image
     if (unlikely(sector_loc >= image_end_)) {
-      reader(buffer_t()); return;
+      reader(buffer_t{}); return;
     }
 
     auto buffer = new uint8_t[block_size()];
-    assert( memcpy(buffer, sector_loc, block_size()) == buffer );
+    Ensures( memcpy(buffer, sector_loc, block_size()) == buffer );
 
-    reader( buffer_t(buffer, std::default_delete<uint8_t[]>()) );
+    reader( buffer_t{buffer, std::default_delete<uint8_t[]>()} );
   }
 
   void MemDisk::read(block_t blk, block_t count, on_read_func reader) {
@@ -54,25 +54,25 @@ namespace fs {
     auto end_loc   = start_loc + (count * block_size());
     // Disallow reading memory past disk image
     if (unlikely(end_loc >= image_end_)) {
-      reader(buffer_t()); return;
+      reader(buffer_t{}); return;
     }
 
     auto buffer = new uint8_t[count * block_size()];
-    assert( memcpy(buffer, start_loc, count * block_size()) == buffer );
+    Ensures( memcpy(buffer, start_loc, count * block_size()) == buffer );
 
-    reader( buffer_t(buffer, std::default_delete<uint8_t[]>()) );
+    reader( buffer_t{buffer, std::default_delete<uint8_t[]>()} );
   }
 
   MemDisk::buffer_t MemDisk::read_sync(block_t blk) {
     auto sector_loc = image_start_ + (blk * block_size());
     // Disallow reading memory past disk image
     if (unlikely(sector_loc >= image_end_))
-      return buffer_t();
+      return buffer_t{};
 
     auto buffer = new uint8_t[block_size()];
-    assert( memcpy(buffer, sector_loc, block_size()) == buffer );
+    Ensures( memcpy(buffer, sector_loc, block_size()) == buffer );
 
-    return buffer_t(buffer, std::default_delete<uint8_t[]>());
+    return buffer_t{buffer, std::default_delete<uint8_t[]>()};
   }
 
   MemDisk::block_t MemDisk::size() const noexcept {


### PR DESCRIPTION
## Changes
* Make constructor explicit
* Make addresses (disk boundaries) `const` to avoid accidental changes in methods
* Replaced all `assert`'s for `Ensures`
* Changed `buffer_t` instantiation syntax from `()` to `{}` to differentiate from a function call