### PR TITLE
tcp: new write queue implementation + fix to vmrunner.py

### DIFF
--- a/api/net/tcp.hpp
+++ b/api/net/tcp.hpp
@@ -836,6 +836,12 @@ namespace net {
       inline const TCP& host() const { return host_; }
 
       /*
+        The local Port bound to this connection.
+      */
+      inline TCP::Port local_port() const
+      { return local_port_; }
+
+      /*
         The local Socket bound to this connection.
       */
       inline TCP::Socket local() const { return {host_.inet_.ip_addr(), local_port_}; }
@@ -1484,6 +1490,7 @@ namespace net {
 
       inline void reduce_ssthresh() {
         auto fs = flight_size();
+        printf("<Connection::reduce_ssthresh> FlightSize: %u\n", fs);
         
         if(limited_tx_)
           fs -= 2*(uint32_t)SMSS();
@@ -1738,8 +1745,7 @@ namespace net {
     std::deque<Connection_ptr> writeq;
 
     using PortMap = std::bitset<UINT16_MAX>;
-    //std::unique_ptr<PortMap> used_ports;
-    PortMap used_ports;
+    std::unique_ptr<PortMap> used_ports;
 
     /*
       Settings
@@ -1761,7 +1767,7 @@ namespace net {
     /*
       Returns a free port for outgoing connections.
     */
-    TCP::Port free_port();
+    TCP::Port next_free_port();
 
     /*
       Check if the port is in use either among "listeners" or "connections"

--- a/src/net/tcp.cpp
+++ b/src/net/tcp.cpp
@@ -48,7 +48,7 @@ TCP::TCP(IPStack& inet) :
 */
 TCP::Connection& TCP::bind(Port port) {
   // Already a listening socket.
-  if(port_in_use(port)) {
+  if(listeners_.find(port) != listeners_.end()) {
     throw TCPException{"Port is already taken."};
   }
   auto& connection = (listeners_.emplace(port, Connection{*this, port})).first->second;

--- a/src/net/tcp_connection.cpp
+++ b/src/net/tcp_connection.cpp
@@ -708,7 +708,7 @@ TCP::Seq Connection::generate_iss() {
 void Connection::set_state(State& state) {
   prev_state_ = state_;
   state_ = &state;
-  printf("<TCP::Connection::set_state> %s => %s \n",
+  debug("<TCP::Connection::set_state> %s => %s \n",
         prev_state_->to_string().c_str(), state_->to_string().c_str());
 }
 

--- a/src/net/tcp_connection_states.cpp
+++ b/src/net/tcp_connection_states.cpp
@@ -589,7 +589,7 @@ size_t Connection::SynReceived::send(Connection&, WriteBuffer&) {
 
 size_t Connection::Established::send(Connection& tcp, WriteBuffer& buffer) {
   // if nothing in queue, try to write directly
-  if(tcp.writeq.empty())
+  if(!tcp.writeq.remaining_requests())
     return tcp.send(buffer);
 
   return 0;
@@ -597,7 +597,7 @@ size_t Connection::Established::send(Connection& tcp, WriteBuffer& buffer) {
 
 size_t Connection::CloseWait::send(Connection& tcp, WriteBuffer& buffer) {
   // if nothing in queue, try to write directly
-  if(tcp.writeq.empty())
+  if(!tcp.writeq.remaining_requests())
     return tcp.send(buffer);
 
   return 0;

--- a/src/net/tcp_connection_states.cpp
+++ b/src/net/tcp_connection_states.cpp
@@ -436,8 +436,6 @@ void Connection::State::send_reset(Connection& tcp) {
   tcp.writeq_reset();
   auto packet = tcp.outgoing_packet();
   packet->set_seq(tcp.tcb().SND.NXT).set_ack(0).set_flag(RST);
-  // flush retransmission queue
-  tcp.rtx_flush();
   tcp.transmit(packet);
 }
 /////////////////////////////////////////////////////////////////////
@@ -898,7 +896,7 @@ State::Result Connection::SynSent::handle(Connection& tcp, TCP::Packet_ptr in) {
     tcb.IRS       = in->seq();
     tcb.SND.UNA   = in->ack();
 
-    tcp.rtx_ack(in->ack());
+    //tcp.rtx_ack(in->ack());
 
     // (our SYN has been ACKed)
     if(tcb.SND.UNA > tcb.ISS) {
@@ -1010,7 +1008,7 @@ State::Result Connection::SynReceived::handle(Connection& tcp, TCP::Packet_ptr i
       tcb.SND.UNA = in->ack();
       if(tcp.rttm.active)
         tcp.rttm.stop();
-      tcp.rtx_ack(in->ack());
+      //tcp.rtx_ack(in->ack());
 
       // 7. proccess the segment text
       if(in->has_data()) {
@@ -1145,7 +1143,8 @@ State::Result Connection::FinWait1::handle(Connection& tcp, TCP::Packet_ptr in) 
     if(in->ack() == tcp.tcb().SND.NXT) {
       // TODO: I guess or FIN is ACK'ed..?
       tcp.set_state(TimeWait::instance());
-      tcp.rtx_stop();
+      if(tcp.rtx_timer.active)
+        tcp.rtx_stop();
       tcp.start_time_wait_timeout();
     } else {
       tcp.set_state(Closing::instance());
@@ -1191,7 +1190,8 @@ State::Result Connection::FinWait2::handle(Connection& tcp, TCP::Packet_ptr in) 
       Start the time-wait timer, turn off the other timers.
     */
     tcp.set_state(Connection::TimeWait::instance());
-    tcp.rtx_stop();
+    if(tcp.rtx_timer.active)
+      tcp.rtx_stop();
     tcp.start_time_wait_timeout();
   }
   return OK;

--- a/test/tcp/service.cpp
+++ b/test/tcp/service.cpp
@@ -61,10 +61,10 @@ void FINISH_TEST() {
   INFO("TEST", "Started 3 x MSL timeout.");
   hw::PIT::instance().onTimeout(3 * MSL_TEST, [] {
       INFO("TEST", "Verify release of resources");
-      CHECK(inet->tcp().activeConnections() == 0, "tcp.activeConnections() == 0");
-      CHECK(inet->buffers_available() == buffers_available,
-            "inet->buffers_available() == buffers_available");
-      INFO("Buffers available", "%u", inet->buffers_available());
+      CHECK(inet->tcp().activeConnections() == 0, 
+        "tcp.activeConnections() == 0");
+      CHECK(inet->buffers_available() == buffers_available, 
+        "inet->buffers_available() == buffers_available");
       printf("# TEST SUCCESS #\n");
     });
 }
@@ -153,7 +153,7 @@ void print_stuff()
 
 void Service::start()
 {
-  hw::PIT::on_timeout(5.0, print_stuff);
+  //hw::PIT::on_timeout(5.0, print_stuff);
   
   IP4::addr A1 (255, 255, 255, 255);
   IP4::addr B1 (  0, 255, 255, 255);

--- a/test/vmrunner.py
+++ b/test/vmrunner.py
@@ -92,12 +92,14 @@ class qemu(hypervisor):
 
   def kvm_present(self):
     command = "egrep -m 1 '^flags.*(vmx|svm)' /proc/cpuinfo"
-    if not subprocess.check_output(command, shell = True):
-      print "<qemu> KVM OFF"
-      return False
-    else:
+    try:
+      subprocess.check_output(command, shell = True)
       print "<qemu> KVM ON"
       return True
+
+    except Exception as err:
+      print "<qemu> KVM OFF"
+      return False
 
   def boot(self):
     self._out_sign = "<" + type(self).__name__ + ">"
@@ -181,6 +183,9 @@ class vm:
 
   def on_timeout(self, callback):
     self._on_timeout = callback
+
+  def readline(self):
+    return self._hyper.readline()
 
   def boot(self, timeout = None):
 


### PR DESCRIPTION
* TCP `WriteQueue`: No longer queues Packets for retransmission, but creates new ones on demand by not releasing WriteBuffers until fully acknowledged.
* `vmrunner.py` now works without kvm.