### PR TITLE
tcp: now renewing instead of reseting read buffer

### DIFF
--- a/api/net/tcp.hpp
+++ b/api/net/tcp.hpp
@@ -621,6 +621,7 @@ namespace net {
           and "step back".
         */
         void acknowledge(size_t bytes) {
+          debug2("<Connection::WriteQueue> Acknowledge %u bytes\n",bytes);
           while(bytes and !q.empty())
           {
             auto& buf = q.front().first;
@@ -667,14 +668,15 @@ namespace net {
           auto& buf = q[current-1].first;
           buf.advance(bytes);
 
-          debug2("<Connection::WriteQueue> Advance: off=%u rem=%u ack=%u\n",
-            buf.offset, buf.remaining, buf.acknowledged);
+          debug2("<Connection::WriteQueue> Advance: bytes=%u off=%u rem=%u ack=%u\n",
+            bytes, buf.offset, buf.remaining, buf.acknowledged);
 
           if(!buf.remaining) {
             debug("<Connection::WriteQueue> Advance: Done (%u)\n",
               buf.offset);
-            q[current-1].second(buf.offset);
-            current++;
+            // make sure to advance current before callback is made,
+            // but after index (current) is received.
+            q[current++-1].second(buf.offset);
           }
         }
 
@@ -684,7 +686,7 @@ namespace net {
         */
         void push_back(const WriteRequest& wr) {
           q.push_back(wr);
-          debug2("<Connection::WriteQueue> Inserted WR: off=%u rem=%u ack=%u\n",
+          debug("<Connection::WriteQueue> Inserted WR: off=%u rem=%u ack=%u\n",
             wr.first.offset, wr.first.remaining, wr.first.acknowledged);
           if(current == q.size()-1)
             current++;
@@ -778,7 +780,7 @@ namespace net {
           case CLOSING:
             return "Connection closing";
           case REFUSED:
-            return "Conneciton refused";
+            return "Connection refused";
           case RESET:
             return "Connection reset";
           default:

--- a/api/net/tcp.hpp
+++ b/api/net/tcp.hpp
@@ -519,10 +519,20 @@ namespace net {
           return length > 0;
         }
 
-        inline void clear() {
+        void clear() {
           memset(begin(), 0, offset);
           remaining = capacity();
           offset = 0;
+          push = false;
+        }
+
+        /*
+          Renews the ReadBuffer by assigning a new buffer_t, releasing ownership
+        */
+        inline void renew() {
+          remaining = capacity();
+          offset = 0;
+          buffer = buffer_t(new uint8_t[remaining], std::default_delete<uint8_t[]>());
           push = false;
         }
       }; // < Connection::ReadBuffer
@@ -720,6 +730,7 @@ namespace net {
       */
       struct Disconnect;
 
+      // TODO: Remove reference to Connection, probably not needed..
       using DisconnectCallback          = delegate<void(std::shared_ptr<Connection>, Disconnect)>;
 
       /*

--- a/src/net/tcp_connection.cpp
+++ b/src/net/tcp_connection.cpp
@@ -103,6 +103,8 @@ void Connection::write(WriteBuffer buffer, WriteCallback callback) {
   try {
     // try to write
     auto written = state_->send(*this, buffer);
+    debug("<Connection::write> off=%u rem=%u  written=%u\n",
+      buffer.offset, buffer.remaining, written);
     // put request in line
     writeq.push_back({buffer, callback});
     // if data was written, advance

--- a/src/net/tcp_connection.cpp
+++ b/src/net/tcp_connection.cpp
@@ -78,8 +78,8 @@ size_t Connection::receive(const uint8_t* data, size_t n, bool PUSH) {
       assert(buf.full());
       // signal the user
       read_request.callback(buf.buffer, buf.size());
-      // reset the buffer
-      buf.clear();
+      // renew the buffer, releasing the old one
+      buf.renew();
     }
     n -= read;
     received += read;
@@ -91,8 +91,8 @@ size_t Connection::receive(const uint8_t* data, size_t n, bool PUSH) {
   if(PUSH) {
     buf.push = PUSH;
     read_request.callback(buf.buffer, buf.size());
-    // reset the buffer
-    buf.clear();
+    // renew the buffer, releasing the old one
+    buf.renew();
   }
 
   return received;

--- a/src/util/async.cpp
+++ b/src/util/async.cpp
@@ -26,7 +26,7 @@ void Async::upload_file(
     [length, next] (size_t n) {
 
       // if all data written, go to next chunk
-      printf("sock write: %u / %u\n", n, length);
+      debug("sock write: %u / %u\n", n, length);
       next(n == length);
 
     }, true);
@@ -63,6 +63,7 @@ void Async::disk_transfer(
         fs::buffer_t buffer,
         uint64_t     length)
     {
+      debug("<Async> len=%llu\n",length);
       if (err) {
         printf("%s\n", err.to_string().c_str());
         callback(err, false);


### PR DESCRIPTION
Changed to rather "renew" (allocating a new) buffer instead of reseting the current one. Cost between `clear` (memset) and `renew` (make_shared) maybe is the same? It also makes Connection release the ownership of the buffer when giving it to the user via user callback.