### PR TITLE
Four new tests implemented

### DIFF
--- a/test/bufstore/run.sh
+++ b/test/bufstore/run.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh
-

--- a/test/bufstore/run.sh
+++ b/test/bufstore/run.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh

--- a/test/bufstore/test.py
+++ b/test/bufstore/test.py
@@ -1,0 +1,7 @@
+#! /usr/bin/python
+
+import sys
+sys.path.insert(0,"..")
+
+import vmrunner
+vmrunner.vms[0].boot(30)

--- a/test/bufstore/test.sh
+++ b/test/bufstore/test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-source ../test_base
-
-make
-start test_bufstore.img "Test bufstore"

--- a/test/bufstore/vm.json
+++ b/test/bufstore/vm.json
@@ -1,0 +1,1 @@
+{"image" : "test_bufstore.img" }

--- a/test/crt/test.py
+++ b/test/crt/test.py
@@ -1,0 +1,7 @@
+#! /usr/bin/python
+
+import sys
+sys.path.insert(0,"..")
+
+import vmrunner
+vmrunner.vms[0].boot(40)

--- a/test/crt/vm.json
+++ b/test/crt/vm.json
@@ -1,0 +1,1 @@
+{"image" : "test_crt.img" }

--- a/test/quick_exit/README.md
+++ b/test/quick_exit/README.md
@@ -1,0 +1,5 @@
+# Testing Quick exit 
+
+This test is supposed to result in a PANIC, after calling the quick-exit handler, and then quick_exit.
+
+

--- a/test/quick_exit/test.py
+++ b/test/quick_exit/test.py
@@ -1,0 +1,7 @@
+#! /usr/bin/python
+
+import sys
+sys.path.insert(0,"..")
+
+import vmrunner
+vmrunner.vms[0].boot(30)

--- a/test/quick_exit/vm.json
+++ b/test/quick_exit/vm.json
@@ -1,0 +1,1 @@
+{"image" : "test_quick_exit.img" }

--- a/test/tcp/test.py
+++ b/test/tcp/test.py
@@ -72,4 +72,4 @@ vm = vmrunner.vms[0]
 vm.on_output("IncludeOS TCP test", TCP_test)
 
 # Boot the VM, taking a timeout as parameter
-vm.boot(40)
+vm.boot(80)

--- a/test/term/term.cpp
+++ b/test/term/term.cpp
@@ -33,10 +33,10 @@ void Service::start()
   hw::Nic<VirtioNet>& eth0 = hw::Dev::eth<0,VirtioNet>();
   inet = std::make_unique<net::Inet4<VirtioNet> >(eth0);
   inet->network_config(
-                       {{ 10,0,0,42 }},      // IP
-                       {{ 255,255,255,0 }},  // Netmask
-                       {{ 10,0,0,1 }},       // Gateway
-                       {{ 8,8,8,8 }} );      // DNS
+                       { 10,0,0,42 },      // IP
+                       { 255,255,255,0 },  // Netmask
+                       { 10,0,0,1 },       // Gateway
+                       { 8,8,8,8 } );      // DNS
 
   INFO("TERM", "Running tests for Terminal");
   auto disk = fs::new_shared_memdisk();

--- a/test/timers/README.md
+++ b/test/timers/README.md
@@ -1,0 +1,2 @@
+# Test of different timers
+

--- a/test/timers/test.py
+++ b/test/timers/test.py
@@ -1,0 +1,7 @@
+#! /usr/bin/python
+
+import sys
+sys.path.insert(0,"..")
+
+import vmrunner
+vmrunner.vms[0].boot(60)

--- a/test/timers/vm.json
+++ b/test/timers/vm.json
@@ -1,0 +1,1 @@
+{"image" : "test_timers.img" }


### PR DESCRIPTION
Timers, quick_exit, crt and bufstore are now implemented with python.

I also removed the run.sh and test.sh from the bufstore directory. Not sure if you want to keep these or not though. 