### PR TITLE
Wrapped the IRQ_handler instance (bsp_idt) in static singleton. 

### DIFF
--- a/api/kernel/irq_manager.hpp
+++ b/api/kernel/irq_manager.hpp
@@ -95,10 +95,9 @@ public:
 
   /**
    *  Subscribe to an IRQ
-
+   *
    *  @param irq: The IRQ to subscribe to
    *  @param del: A delegate to attach to the IRQ DPC-system
-
    *  The delegate will be called a.s.a.p. after @param irq gets triggered
    *
    *  @warning The delegate is responsible for signalling a proper EOI
@@ -122,12 +121,19 @@ public:
    */
   static void eoi(uint8_t irq);
 
-  
+  /**
+   * Get the IRQ manager for a specific CPU core
+   */
+  static inline IRQ_manager& cpu(uint16_t){
+    static IRQ_manager bsp;
+    return bsp;
+  }
+
   uint8_t get_next_msix_irq();
 
 
   void register_interrupt(uint8_t vector);
-  
+
   irq_delegate get_intr_handler(uint8_t vector) {
     return irq_delegates_[vector];
   }
@@ -137,13 +143,13 @@ private:
   bool         idt_is_set                {false};
   irq_delegate irq_delegates_[IRQ_LINES];
   int32_t      irq_counters_[IRQ_LINES]  {0};
-  
+
   int timer_interrupts {0};
-  
+
   MemBitmap  irq_subs;
   MemBitmap  irq_pend;
   MemBitmap  irq_todo;
-  
+
   static const char       default_attr {static_cast<char>(0x8e)};
   static const uint16_t   default_sel  {0x8};
 
@@ -159,7 +165,7 @@ private:
                    void (*function_addr)(),
                    uint16_t segment_sel,
                    char attributes);
-  
+
   /** The OS will call the following : */
   friend class OS;
   friend void ::irq_default_handler();
@@ -168,13 +174,10 @@ private:
   static void init();
 
   void bsp_init();
-  
+
   /** Notify all delegates waiting for interrupts */
   void notify();
 
 }; //< IRQ_manager
-
-// IDT manager for bootstrap processor
-extern IRQ_manager bsp_idt;
 
 #endif //< KERNEL_IRQ_MANAGER_HPP

--- a/src/hw/ide.cpp
+++ b/src/hw/ide.cpp
@@ -61,7 +61,7 @@ namespace hw {
 {
   INFO("IDE","VENDOR_ID : 0x%x, PRODUCT_ID : 0x%x", _pcidev.vendor_id(), _pcidev.product_id());
   INFO("IDE","Attaching to  PCI addr 0x%x",_pcidev.pci_addr());
-  
+
   /** PCI device checking */
   if (_pcidev.vendor_id() not_eq IDE_VENDOR_ID) {
     panic("This is not an Intel device");
@@ -144,7 +144,7 @@ namespace hw {
       callback(buffer_t());
       return;
     }
-  
+
     set_irq_mode(true);
     set_drive(0xE0 | _drive | ((blk >> 24) & 0x0F));
     set_nbsectors(count);
@@ -171,12 +171,12 @@ namespace hw {
     auto* buffer = new uint8_t[block_size()];
 
     wait_status_flags(IDE_DRDY, false);
-  
+
     uint16_t* wptr = (uint16_t*) buffer;
     uint16_t* wend = (uint16_t*)&buffer[block_size()];
     while (wptr < wend)
       *(wptr++) = inw(IDE_DATA);
-  
+
     // return a shared_ptr wrapper for the buffer
     return buffer_t(buffer, std::default_delete<uint8_t[]>());
   }
@@ -205,7 +205,7 @@ namespace hw {
         if ((ret & flags) not_eq flags)
           break;
       }
-    
+
       ret = inb(IDE_STATUS);
     }
   }
@@ -260,7 +260,7 @@ namespace hw {
     _ide_irqs.push_back(ide_irq(buffer, _current_callback));
     _nb_irqs--;
 
-    bsp_idt.register_interrupt(IDE_IRQN);
+    IRQ_manager::cpu(0).register_interrupt(IDE_IRQN);
   }
 
   extern "C" void ide_irq_entry();
@@ -274,8 +274,8 @@ namespace hw {
 
   void IDE::enable_irq_handler() {
     auto del(delegate<void()>::from<IDE, &IDE::callback_wrapper>(this));
-    bsp_idt.subscribe(IDE_IRQN, del);
-    bsp_idt.set_handler(IDE_IRQN + 32, ide_irq_entry);
+    IRQ_manager::cpu(0).subscribe(IDE_IRQN, del);
+    IRQ_manager::cpu(0).set_handler(IDE_IRQN + 32, ide_irq_entry);
   }
 
 } //< namespace hw

--- a/src/hw/pit.cpp
+++ b/src/hw/pit.cpp
@@ -74,10 +74,10 @@ namespace hw {
     temp_mode_ = current_mode_;
     temp_freq_divider_ = current_freq_divider_;
 
-    auto prev_irq_handler = bsp_idt.get_handler(32);
+    auto prev_irq_handler = IRQ_manager::cpu(0).get_handler(32);
 
     debug("<PIT EstimateCPUFreq> Sampling\n");
-    bsp_idt.set_handler(32, cpu_sampling_irq_entry);
+    IRQ_manager::cpu(0).set_handler(32, cpu_sampling_irq_entry);
 
     // GO!
     set_mode(RATE_GEN);
@@ -91,7 +91,7 @@ namespace hw {
     set_mode(temp_mode_);
     set_freq_divider(temp_freq_divider_);
 
-    bsp_idt.set_handler(32, prev_irq_handler);
+    IRQ_manager::cpu(0).set_handler(32, prev_irq_handler);
   }
 
   MHz PIT::CPUFrequency(){
@@ -110,7 +110,7 @@ namespace hw {
 
     if (current_freq_divider_ != millisec_interval)
       set_freq_divider(millisec_interval);
-    
+
     auto cycles_pr_millisec = KHz(CPUFrequency());
     //debug("<PIT start_timer> CPU KHz: %f Cycles to wait: %f \n",cycles_pr_millisec.count(), cycles_pr_millisec.count() * in_msecs);
 
@@ -246,9 +246,9 @@ namespace hw {
     PIT::disable_regular_interrupts();
     // register irq handler
     auto handler(IRQ_manager::irq_delegate::from<PIT,&PIT::irq_handler>(&instance()));
-    bsp_idt.subscribe(0, handler);
+    IRQ_manager::cpu(0).subscribe(0, handler);
     // must be done to program IOAPIC to redirect to BSP LAPIC
-    bsp_idt.enable_irq(0);
+    IRQ_manager::cpu(0).enable_irq(0);
   }
 
   void PIT::set_mode(Mode mode){

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -62,20 +62,20 @@ void OS::start() {
 
   // read ACPI tables
   hw::ACPI::init();
-  
+
   // setup APIC, APIC timer, SMP etc.
   hw::APIC::init();
-  
+
   // Set up interrupt handlers
   IRQ_manager::init();
-  
+
   INFO("BSP", "Enabling interrupts");
   hw::APIC::setup_subs();
-  bsp_idt.enable_interrupts();
-  
+  IRQ_manager::cpu(0).enable_interrupts();
+
   // Initialize the Interval Timer
   hw::PIT::init();
-  
+
   // Initialize PCI devices
   PCI_manager::init();
 
@@ -118,7 +118,7 @@ void OS::event_loop() {
   FILLINE('~');
 
   while (power_) {
-    bsp_idt.notify();
+    IRQ_manager::cpu(0).notify();
     debug("<OS> Woke up @ t = %li\n", uptime());
   }
 

--- a/src/virtio/virtionet.cpp
+++ b/src/virtio/virtionet.cpp
@@ -153,17 +153,17 @@ VirtioNet::VirtioNet(hw::PCI_Device& d)
     auto recv_del(delegate<void()>::from<VirtioNet,&VirtioNet::msix_recv_handler>(this));
     auto xmit_del(delegate<void()>::from<VirtioNet,&VirtioNet::msix_xmit_handler>(this));
     // update BSP IDT
-    bsp_idt.subscribe(irq() + 0, xmit_del);
-    bsp_idt.subscribe(irq() + 1, recv_del);
-    bsp_idt.subscribe(irq() + 2, conf_del);
+    IRQ_manager::cpu(0).subscribe(irq() + 0, xmit_del);
+    IRQ_manager::cpu(0).subscribe(irq() + 1, recv_del);
+    IRQ_manager::cpu(0).subscribe(irq() + 2, conf_del);
   }
   else
   {
     // legacy PCI interrupt
     auto del(delegate<void()>::from<VirtioNet,&VirtioNet::irq_handler>(this));
-    bsp_idt.subscribe(irq(),del);
+    IRQ_manager::cpu(0).subscribe(irq(),del);
   }
-  
+
   // Done
   INFO("VirtioNet", "Driver initialization complete");
   CHECK(_conf.status & 1, "Link up\n");
@@ -240,7 +240,7 @@ void VirtioNet::irq_handler(){
     get_config();
     debug("\t             New status: 0x%x \n",_conf.status);
   }
-  
+
   IRQ_manager::eoi(irq());
 }
 


### PR DESCRIPTION
Might solve #545. @fwsGonzo you'll probably have opinions on how I name this one. As you can see I've added a numeric argument in case we'd want to use the getter for several instances. I'm not sure we want to expose a getter for each CPU though - I think it would probably be better to have a static function, or some other global IRQ supervisor that could assign your IRQ to whichever CPU was in charge of that particular line (I know they use IRQ balancing in Linux by default) 

However, we don't need to pollute the global namespace, plus avoiding using global constructor for the `bsp_idt`-instance seems to solve #545 for me on trident3. 