### PR TITLE
Refactored PacketIP4 and TCP::Packet

### DIFF
--- a/examples/demo_service/service.cpp
+++ b/examples/demo_service/service.cpp
@@ -60,6 +60,8 @@ std::string HTML_RESPONSE() {
   return header + html;
 }
 
+const std::string NOT_FOUND = "HTTP/1.1 404 Not Found \n Connection: close\n\n";
+
 void Service::start() {
   // Assign a driver (VirtioNet) to a network interface (eth0)
   // @note: We could determine the appropirate driver dynamically, but then we'd
@@ -88,31 +90,38 @@ void Service::start() {
 
   // Add a TCP connection handler - here a hardcoded HTTP-service
   server.onAccept([](auto conn) -> bool {
-      printf("<Service> @onAccept - Connection attempt from: %s \n",
-             conn->to_string().c_str());
-      return true; // allow all connections
+    printf("<Service> @onAccept - Connection attempt from: %s \n",
+           conn->to_string().c_str());
+    return true; // allow all connections
 
-    }).onConnect([](auto conn) {
-        printf("<Service> @onConnect - Connection successfully established.\n");
-        // read async with a buffer size of 1024 bytes
-        // define what to do when data is read
-        conn->read(1024, [conn](net::TCP::buffer_t buf, size_t n) {
-            // create string from buffer
-            std::string data { (char*)buf.get(), n };
-            printf("<Service> @read:\n%s\n", data.c_str());
-
-            // create response
-            std::string response = HTML_RESPONSE();
-            // write the data from the string with the strings size
-            conn->write(response.data(), response.size(), [](size_t n) {
-                printf("<Service> @write: %u bytes written\n", n);
-              });
-          });
-
-      }).onDisconnect([](auto conn, auto reason) {
-          printf("<Service> @onDisconnect - Reason: %s \n", reason.to_string().c_str());
-          conn->close();
+  }).onConnect([](auto conn) {
+    printf("<Service> @onConnect - Connection successfully established.\n");
+    // read async with a buffer size of 1024 bytes
+    // define what to do when data is read
+    conn->read(1024, [conn](net::TCP::buffer_t buf, size_t n) {
+      // create string from buffer
+      std::string data { (char*)buf.get(), n };
+      printf("<Service> @read:\n%s\n", data.c_str());
+      if(data.find("GET / ") != std::string::npos) {
+        // create response
+        std::string response = HTML_RESPONSE();
+        // write the data from the string with the strings size
+        conn->write(response.data(), response.size(), [](size_t n) {
+          printf("<Service> @write: %u bytes written\n", n);
         });
+      }
+      else {
+        conn->write(NOT_FOUND.data(), NOT_FOUND.size());
+      }
+
+    });
+
+  }).onDisconnect([](auto conn, auto reason) {
+    printf("<Service> @onDisconnect - Reason: %s \n", reason.to_string().c_str());
+    conn->close();
+  }).onPacketReceived([](auto, auto packet) {
+    printf("@Packet: %s\n", packet->to_string().c_str());
+  });
 
   printf("*** TEST SERVICE STARTED *** \n");
 }

--- a/src/net/ip4/ip4.cpp
+++ b/src/net/ip4/ip4.cpp
@@ -73,11 +73,11 @@ namespace net {
     auto ip4_pckt = std::static_pointer_cast<PacketIP4>(pckt);
     ip4_pckt->make_flight_ready();
 
-    IP4::ip_header& hdr = ip4_pckt->ip4_header();
+    IP4::ip_header& hdr = ip4_pckt->ip_header();
     // Create local and target subnets
     addr target = hdr.daddr        & stack_.netmask();
     addr local  = stack_.ip_addr() & stack_.netmask();
-    
+
     // Compare subnets to know where to send packet
     pckt->next_hop(target == local ? hdr.daddr : stack_.router());
 
@@ -92,7 +92,7 @@ namespace net {
           stack_.ip_addr().str().c_str(),
           pckt->next_hop().str().c_str(),
           pckt->size(),
-          ip4_pckt->ip4_segment_size()
+          ip4_pckt->ip_segment_size()
           );
 
     linklayer_out_(pckt);

--- a/src/net/tcp.cpp
+++ b/src/net/tcp.cpp
@@ -117,7 +117,7 @@ bool TCP::port_in_use(const TCP::Port port) const {
 
 uint16_t TCP::checksum(TCP::Packet_ptr packet) {
   // TCP header
-  TCP::Header* tcp_hdr = &(packet->header());
+  TCP::Header* tcp_hdr = &(packet->tcp_header());
   // Pseudo header
   TCP::Pseudo_header pseudo_hdr;
 

--- a/src/net/tcp_connection_states.cpp
+++ b/src/net/tcp_connection_states.cpp
@@ -104,12 +104,12 @@ bool Connection::State::check_seq(Connection& tcp, TCP::Packet_ptr in) {
     acceptable = true;
   }
   // #3 (INVALID)
-  else if( in->seq() + in->data_length()-1 > tcb.RCV.NXT+tcb.RCV.WND ) {
+  else if( in->seq() + in->tcp_data_length()-1 > tcb.RCV.NXT+tcb.RCV.WND ) {
     acceptable = false;
   }
   // #4
   else if( (tcb.RCV.NXT <= in->seq() and in->seq() < tcb.RCV.NXT + tcb.RCV.WND)
-           or ( tcb.RCV.NXT <= in->seq()+in->data_length()-1 and in->seq()+in->data_length()-1 < tcb.RCV.NXT+tcb.RCV.WND ) ) {
+           or ( tcb.RCV.NXT <= in->seq()+in->tcp_data_length()-1 and in->seq()+in->tcp_data_length()-1 < tcb.RCV.NXT+tcb.RCV.WND ) ) {
     acceptable = true;
   }
   /*
@@ -130,7 +130,7 @@ bool Connection::State::check_seq(Connection& tcp, TCP::Packet_ptr in) {
     }
     std::stringstream ss;
     ss << "Unacceptable SEQ: "
-       << "[Packet: SEQ: " << in->seq() << " LEN: " << in->data_length() << "] "
+       << "[Packet: SEQ: " << in->seq() << " LEN: " << in->tcp_data_length() << "] "
        << "[TCB: RCV.NXT: " << tcb.RCV.NXT << " RCV.WND: " << tcb.RCV.WND << "]";
 
     tcp.drop(in, ss.str());
@@ -311,16 +311,16 @@ bool Connection::State::check_ack(Connection& tcp, TCP::Packet_ptr in) {
 /////////////////////////////////////////////////////////////////////
 
 void Connection::State::process_segment(Connection& tcp, TCP::Packet_ptr in) {
-  assert(in->has_data());
+  assert(in->has_tcp_data());
 
   auto& tcb = tcp.tcb();
-  auto length = in->data_length();
+  auto length = in->tcp_data_length();
   // Receive could result in a user callback. This is used to avoid sending empty ACK reply.
   debug("<TCP::Connection::State::process_segment> Received packet with DATA-LENGTH: %i. Add to receive buffer. \n", length);
   tcb.RCV.NXT += length;
   auto snd_nxt = tcb.SND.NXT;
   if(tcp.read_request.buffer.capacity()) {
-    auto received = tcp.receive((uint8_t*)in->data(), in->data_length(), in->isset(PSH));
+    auto received = tcp.receive((uint8_t*)in->tcp_data(), in->tcp_data_length(), in->isset(PSH));
     Ensures(received == length);
   }
 
@@ -404,7 +404,7 @@ void Connection::State::process_fin(Connection& tcp, TCP::Packet_ptr in) {
   auto& tcb = tcp.tcb();
   // Advance RCV.NXT over the FIN?
   tcb.RCV.NXT++;
-  //auto fin = in->data_length();
+  //auto fin = in->tcp_data_length();
   //tcb.RCV.NXT += fin;
   auto snd_nxt = tcb.SND.NXT;
   // empty the read buffer
@@ -771,7 +771,7 @@ State::Result Connection::Closed::handle(Connection& tcp, TCP::Packet_ptr in) {
   }
   auto packet = tcp.outgoing_packet();
   if(!in->isset(ACK)) {
-    packet->set_seq(0).set_ack(in->seq() + in->data_length()).set_flags(RST | ACK);
+    packet->set_seq(0).set_ack(in->seq() + in->tcp_data_length()).set_flags(RST | ACK);
   } else {
     packet->set_seq(in->ack()).set_flag(RST);
   }
@@ -930,7 +930,7 @@ State::Result Connection::SynSent::handle(Connection& tcp, TCP::Packet_ptr in) {
       //tcp.state().handle(tcp, in);
 
       // 7. process segment text
-      if(in->has_data()) {
+      if(in->has_tcp_data()) {
         process_segment(tcp, in);
       }
 
@@ -948,7 +948,7 @@ State::Result Connection::SynSent::handle(Connection& tcp, TCP::Packet_ptr in) {
       packet->set_seq(tcb.ISS).set_ack(tcb.RCV.NXT).set_flags(SYN | ACK);
       tcp.transmit(packet);
       tcp.set_state(Connection::SynReceived::instance());
-      if(in->has_data()) {
+      if(in->has_tcp_data()) {
         process_segment(tcp, in);
       }
       return OK;
@@ -1015,17 +1015,16 @@ State::Result Connection::SynReceived::handle(Connection& tcp, TCP::Packet_ptr i
 
       // Taken from acknowledge (without congestion control)
       tcb.SND.UNA = in->ack();
-      if(tcp.rttm.active)
-        tcp.rttm.stop();
       if(tcp.rtx_timer.active)
         tcp.rtx_stop();
 
+      tcp.signal_connect(); // NOTE: User callback
+
       // 7. proccess the segment text
-      if(in->has_data()) {
+      if(in->has_tcp_data()) {
+        debug2("<TCP::Connection::SynReceived::handle> @warning: Packet has data? %s\n", in->to_string().c_str());
         process_segment(tcp, in);
       }
-
-      tcp.signal_connect(); // NOTE: User callback
 
       // 8. check FIN bit
       if(in->isset(FIN)) {
@@ -1087,7 +1086,7 @@ State::Result Connection::Established::handle(Connection& tcp, TCP::Packet_ptr i
   // 6. check URG - DEPRECATED
 
   // 7. proccess the segment text
-  if(in->has_data()) {
+  if(in->has_tcp_data()) {
     process_segment(tcp, in);
   }
 
@@ -1137,7 +1136,7 @@ State::Result Connection::FinWait1::handle(Connection& tcp, TCP::Packet_ptr in) 
   }
 
   // 7. proccess the segment text
-  if(in->has_data()) {
+  if(in->has_tcp_data()) {
     process_segment(tcp, in);
   }
 
@@ -1188,7 +1187,7 @@ State::Result Connection::FinWait2::handle(Connection& tcp, TCP::Packet_ptr in) 
   }
 
   // 7. proccess the segment text
-  if(in->has_data()) {
+  if(in->has_tcp_data()) {
     process_segment(tcp, in);
   }
 


### PR DESCRIPTION
* Made size/length calculation more dynamic
 * TCP Packet is now using functions inside PacketIP4 to determine offsets.
* Added prefix to a lot of functions.

Hopefully solves #565 (earlier failed scenario is now working).

Also made demo only reply with HTML on `GET / ` requests.