### PR TITLE
tcp: Clean up (possible) copies of shared_ptr in callbacks

### DIFF
--- a/api/net/tcp.hpp
+++ b/api/net/tcp.hpp
@@ -610,6 +610,10 @@ namespace net {
         ReadRequest(size_t n = 0) :
           buffer(buffer_t(new uint8_t[n], std::default_delete<uint8_t[]>()), n),
           callback([](auto, auto){}) {}
+
+        void clean_up() {
+          callback.reset();
+        }
       };
 
       /*
@@ -978,6 +982,8 @@ namespace net {
         Creates a connection with a remote.
       */
       Connection(TCP& host, Port local_port, Socket remote);
+
+      Connection(const Connection&) = default;
 
       /*
         The hosting TCP instance.
@@ -1778,6 +1784,13 @@ namespace net {
       */
       void signal_close();
 
+      /**
+       * @brief Clean up user callbacks
+       * @details Removes all the user defined lambdas to avoid any potential
+       * copies of a Connection_ptr to the this connection.
+       */
+      void clean_up();
+
 
       /// OPTIONS ///
       /*
@@ -1892,8 +1905,8 @@ namespace net {
     inline std::string status() const
     { return to_string(); }
 
-
-
+    inline size_t writeq_size() const
+    { return writeq.size(); }
 
   private:
 

--- a/src/net/tcp.cpp
+++ b/src/net/tcp.cpp
@@ -256,11 +256,11 @@ string TCP::to_string() const {
   // Write all connections in a cute list.
   stringstream ss;
   ss << "LISTENING SOCKETS:\n";
-  for(auto listen_it : listeners_) {
+  for(auto& listen_it : listeners_) {
     ss << listen_it.second.to_string() << "\n";
   }
   ss << "\nCONNECTIONS:\n" <<  "Proto\tRecv\tSend\tIn\tOut\tLocal\t\t\tRemote\t\t\tState\n";
-  for(auto con_it : connections_) {
+  for(auto& con_it : connections_) {
     auto& c = *(con_it.second);
     ss << "tcp4\t"
        << " " << "\t" << " " << "\t"

--- a/src/net/tcp_connection.cpp
+++ b/src/net/tcp_connection.cpp
@@ -330,7 +330,7 @@ bool Connection::is_listening() const {
 Connection::~Connection() {
   // Do all necessary clean up.
   // Free up buffers etc.
-  debug2("<TCP::Connection::~Connection> Bye bye... \n");
+  debug("<TCP::Connection::~Connection> Remote: %u\n", remote_.port());
 }
 
 
@@ -770,7 +770,19 @@ void Connection::start_time_wait_timeout() {
 
 void Connection::signal_close() {
   debug("<TCP::Connection::signal_close> It's time to delete this connection. \n");
+
+  clean_up();
   host_.close_connection(*this);
+}
+
+void Connection::clean_up() {
+  on_accept_.reset();
+  on_connect_.reset();
+  on_disconnect_.reset(),
+  on_error_.reset();
+  on_packet_received_.reset();
+  on_packet_dropped_.reset();
+  read_request.clean_up();
 }
 
 std::string Connection::TCB::to_string() const {


### PR DESCRIPTION
Last step is `TCP` cleaning up a Connection (closing). It removes the `Connection_ptr` from it's map, so the last pointer goes out of scope, destroying the Connection and releasing all it's resources.
Due to Connection_ptr being copied into lambdas, the Connection always had one (or more, depending on how many callbacks copying ptrs) instance of itself, making it invincible (the bad kind).

```
conn->read(1024, [conn] ... // copies here
```
Connection now calls `reset()` on all `delegate` (callbacks) right before closing.