### PR TITLE
New install scripts

### DIFF
--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -12,9 +12,9 @@
 # Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
 # $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e.
 
-[ ! -v INCLUDEOS_SRC ] && export INCLUDEOS_SRC=$(readlink -f "$(dirname "$0")/")
-[ ! -v INCLUDEOS_INSTALL_LOC ] && export INCLUDEOS_INSTALL_LOC=$HOME
-export INCLUDEOS_HOME=$INCLUDEOS_INSTALL_LOC/IncludeOS_install
+INCLUDEOS_SRC=${INCLUDEOS_SRC-$(readlink -f "$(dirname "$0")/")}
+INCLUDEOS_INSTALL_LOC=${INCLUDEOS_INSTALL_LOC-$HOME}
+INCLUDEOS_INSTALL=${INCLUDEOS_INSTALL-$INCLUDEOS_INSTALL_LOC/IncludeOS_install}
 
 # Get the latest tag from IncludeOS repo
 echo -e "\n\n>>> Updating git-tags "
@@ -63,7 +63,7 @@ popd
 echo -e "\n\n>>> Compiling the vmbuilder, which makes a bootable vm out of your service"
 pushd $INCLUDEOS_SRC/vmbuild
 make
-cp vmbuild $INCLUDEOS_HOME/
+cp vmbuild $INCLUDEOS_INSTALL/
 popd
 
 # Copy scripts for running qemu, creating a memdisk

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -12,7 +12,7 @@
 # Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
 # $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e.
 
-INCLUDEOS_SRC=${INCLUDEOS_SRC-$(readlink -f "$(dirname "$0")/")}
+INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
 INCLUDEOS_INSTALL_LOC=${INCLUDEOS_INSTALL_LOC-$HOME}
 INCLUDEOS_INSTALL=${INCLUDEOS_INSTALL-$INCLUDEOS_INSTALL_LOC/IncludeOS_install}
 

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -17,7 +17,7 @@
 export INCLUDEOS_HOME=$INCLUDEOS_INSTALL_LOC/IncludeOS_install
 
 # Get the latest tag from IncludeOS repo
-echo "\n\n>>> Updating git-tags "
+echo -e "\n\n>>> Updating git-tags "
 git fetch --tags https://github.com/hioa-cs/IncludeOS.git master
 tag=`git describe --abbrev=0`
 echo "Latest tag found: $tag"

--- a/etc/install_osx.sh
+++ b/etc/install_osx.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Install the IncludeOS libraries (i.e. IncludeOS_home) from binary bundle
+# Install the IncludeOS libraries (i.e. IncludeOS_install) from binary bundle
 # ...as opposed to building them all from scratch, which takes a long time
 #
 #
@@ -9,7 +9,7 @@
 # Location of the IncludeOS repo:
 # $ export INCLUDEOS_SRC=your/github/cloned/IncludeOS
 #
-# Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
+# Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_install)
 # $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e.
 
 INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
@@ -68,7 +68,7 @@ BINUTILS_AR=$BINUTILS_DIR/bin/$LINKER_PREFIX"ar"
 BINUTILS_OBJCOPY=$BINUTILS_DIR/bin/$LINKER_PREFIX"objcopy"
 
 # Make directory inside IncludeOS_install to store ld, ar and objcopy
-INCLUDEOS_BIN=$INCLUDEOS_HOME/bin
+INCLUDEOS_BIN=$INCLUDEOS_INSTALL/bin
 mkdir -p $INCLUDEOS_BIN
 
 # For copying ld, ar and objcopy

--- a/etc/install_osx.sh
+++ b/etc/install_osx.sh
@@ -12,10 +12,10 @@
 # Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
 # $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e.
 
-[[ -z $INCLUDEOS_SRC ]] && export INCLUDEOS_SRC=`pwd`
-[[ -z $INCLUDEOS_INSTALL_LOC ]] && export INCLUDEOS_INSTALL_LOC=$HOME
-export INCLUDEOS_HOME=$INCLUDEOS_INSTALL_LOC/IncludeOS_install
-export INCLUDEOS_BUILD=$INCLUDEOS_INSTALL_LOC/IncludeOS_build
+INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
+INCLUDEOS_BUILD=${INCLUDEOS_BUILD-$HOME/IncludeOS_build}
+INCLUDEOS_INSTALL_LOC=${INCLUDEOS_INSTALL_LOC-$HOME}
+INCLUDEOS_INSTALL=${INCLUDEOS_INSTALL-$INCLUDEOS_INSTALL_LOC/IncludeOS_install}
 
 
 echo -e "\n###################################"

--- a/etc/install_osx.sh
+++ b/etc/install_osx.sh
@@ -174,60 +174,6 @@ then
     echo -e "\n>>> Done installing dependencies."
 fi
 
-
-### INSTALL BINARY RELEASE ###
-
-echo -e "\n\n# Installing binary release"
-echo ">>> Updating git-tags "
-# Get the latest tag from IncludeOS repo
-pushd $INCLUDEOS_SRC
-git fetch --tags
-tag=`git describe --abbrev=0`
-
-echo -e "\n>>> Fetching git submodules "
-git submodule init
-git submodule update
-
-popd
-
-filename_tag=`echo $tag | tr . -`
-filename="IncludeOS_install_"$filename_tag".tar.gz"
-
-# Note: Maybe this can be extracted from install_osx.sh?
-# If the tarball exists, use that
-if [ -e $filename ]
-then
-    echo -e "\n\n>>> IncludeOS tarball exists - extracting to $INCLUDEOS_INSTALL_LOC"
-else
-    echo -e "\n\n>>> Downloading IncludeOS release tarball from GitHub"
-    # Download from GitHub API
-    if [ "$1" = "-oauthToken" ]
-    then
-        oauthToken=$2
-        echo -e "\n\n>>> Getting the ID of the latest release from GitHub"
-        JSON=`curl -u $git_user:$oauthToken https://api.github.com/repos/hioa-cs/IncludeOS/releases/tags/$tag`
-    else
-        echo -e "\n\n>>> Getting the ID of the latest release from GitHub"
-        JSON=`curl https://api.github.com/repos/hioa-cs/IncludeOS/releases/tags/$tag`
-    fi
-    ASSET=`echo $JSON | $INCLUDEOS_SRC/etc/get_latest_binary_bundle_asset.py`
-    ASSET_URL=https://api.github.com/repos/hioa-cs/IncludeOS/releases/assets/$ASSET
-
-    echo -e "\n\n>>> Getting the latest release bundle from GitHub"
-    if [ "$1" = "-oauthToken" ]
-    then
-        curl -H "Accept: application/octet-stream" -L -o $filename -u $git_user:$oauthToken $ASSET_URL
-    else
-        curl -H "Accept: application/octet-stream" -L -o $filename $ASSET_URL
-    fi
-
-    echo -e "\n\n>>> Fetched tarball - extracting to $INCLUDEOS_INSTALL_LOC"
-fi
-
-# Install
-gzip -c $filename | tar xopf - -C $INCLUDEOS_INSTALL_LOC
-
-
 ### Define linker and archiver
 
 # Binutils ld & ar
@@ -235,19 +181,9 @@ export LD_INC=$LD_INC
 export AR_INC=$AR_INC
 export OBJCOPY_INC=$OBJCOPY_INC
 
-echo -e "\n\n>>> Building IncludeOS"
-pushd $INCLUDEOS_SRC/src
-make -j
-make install
-popd
-
-echo -e "\n\n>>> Compiling the vmbuilder, which makes a bootable vm out of your service"
-pushd $INCLUDEOS_SRC/vmbuild
-make
-cp vmbuild $INCLUDEOS_HOME/
-popd
-
-$INCLUDEOS_SRC/etc/copy_scripts.sh
+### INSTALL BINARY RELEASE ###
+echo -e "\n\n>>> Calling install_from_bundle.sh script"
+$INCLUDEOS_SRC/etc/install_from_bundle.sh
 
 echo -e "\n### OS X installation done. ###"
 

--- a/etc/install_ubuntu.sh
+++ b/etc/install_ubuntu.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 
-# Install the IncludeOS libraries (i.e. IncludeOS_home) from binary bundle
-# ...as opposed to building them all from scratch, which takes a long time
+# Will install IncludeOS on ubuntu using the install_from_bundle script.sh
+# Dependencies and a network bridge used by qemu is also installed. 
 #
 #
 # OPTIONS:
 #
 # Location of the IncludeOS repo:
 # $ export INCLUDEOS_SRC=your/github/cloned/IncludeOS
-#
-# Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
-# $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e.
 
 INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
 

--- a/etc/install_ubuntu.sh
+++ b/etc/install_ubuntu.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Install the IncludeOS libraries (i.e. IncludeOS_home) from binary bundle
+# ...as opposed to building them all from scratch, which takes a long time
+#
+#
+# OPTIONS:
+#
+# Location of the IncludeOS repo:
+# $ export INCLUDEOS_SRC=your/github/cloned/IncludeOS
+#
+# Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
+# $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e.
+
+[ ! -v INCLUDEOS_SRC ] && export INCLUDEOS_SRC=$(readlink -f "$(dirname "$0")/")
+[ ! -v INCLUDEOS_INSTALL_LOC ] && export INCLUDEOS_INSTALL_LOC=$HOME
+export INCLUDEOS_HOME=$INCLUDEOS_INSTALL_LOC/IncludeOS_install
+
+# Install dependencies
+. $INCLUDEOS_SRC/etc/prepare_ubuntu_deps.sh
+
+DEPENDENCIES="curl make clang-$clang_version nasm bridge-utils qemu"
+echo ">>> Installing dependencies (requires sudo):"
+echo "    Packages: $DEPENDENCIES"
+sudo apt-get update
+sudo apt-get install -y $DEPENDENCIES
+
+echo -e "\n\n>>> Calling install_from_bundle.sh script"
+$INCLUDEOS_SRC/etc/install_from_bundle.sh
+
+
+echo -e "\n\n>>> Creating a virtual network, i.e. a bridge. (Requires sudo)"
+sudo $INCLUDEOS_SRC/etc/create_bridge.sh
+
+echo -e "\n\n>>> Done! Test your installation with ./test.sh"

--- a/etc/install_ubuntu.sh
+++ b/etc/install_ubuntu.sh
@@ -12,9 +12,7 @@
 # Parent directory of where you want the IncludeOS libraries (i.e. IncludeOS_home)
 # $ export INCLUDEOS_INSTALL_LOC=parent/folder/for/IncludeOS/libraries i.e.
 
-[ ! -v INCLUDEOS_SRC ] && export INCLUDEOS_SRC=$(readlink -f "$(dirname "$0")/")
-[ ! -v INCLUDEOS_INSTALL_LOC ] && export INCLUDEOS_INSTALL_LOC=$HOME
-export INCLUDEOS_HOME=$INCLUDEOS_INSTALL_LOC/IncludeOS_install
+INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
 
 # Install dependencies
 . $INCLUDEOS_SRC/etc/prepare_ubuntu_deps.sh

--- a/install.sh
+++ b/install.sh
@@ -32,5 +32,5 @@ then
     . ./etc/install_all_source.sh
 else
     echo ">>> Installing from bundle"
-    . ./etc/install_from_bundle.sh
+    . ./etc/install_ubuntu.sh
 fi


### PR DESCRIPTION
One common ./install.sh script for both mac os x and ubuntu. Moved all common functionality to the ./etc/install_from_bundle.sh and moved all ubuntu specifics to ./etc/install_ubuntu.sh.

If accepted the wiki for installation on osx will need to be updated to reflect this change. (calling ./etc/install_osx.sh still works though)