### PR TITLE
Possible fix to stress + tcp test failing

### DIFF
--- a/test/stress/test.py
+++ b/test/stress/test.py
@@ -67,7 +67,7 @@ def memory_increase(lead_time, expected_memuse = memuse_at_start):
     percent = float(increase) / expected_memuse
 
   if increase > acceptable_increase:
-    print color.WARN(name_tag), "Memory increased by ", percent, "%."
+    print color.WARNING(name_tag), "Memory increased by ", percent, "%."
     print "(" , expected_memuse, "->", use, ",", increase,"b increase, but no increase expected.)"
   else:
     print color.OK(name_tag + "Memory constant, no leak detected")
@@ -89,7 +89,7 @@ def UDP_burst(burst_size = BURST_SIZE, burst_interval = BURST_INTERVAL):
     for i in range(0, burst_size):
       sock.sendto(data, (HOST, PORT_FLOOD))
   except Exception as e:
-    print color.WARN("<Test.py> Python socket timed out while sending. ")
+    print color.WARNING("<Test.py> Python socket timed out while sending. ")
     return False
   sock.close()
   time.sleep(burst_interval)
@@ -163,7 +163,7 @@ def fire_bursts(func, sub_test_name, lead_out = 3):
     mem_base = memi
 
     if memincrease > acceptable_increase:
-      print color.WARN(name_tag), "Memory increased by ",memincrease,"b, ",float(memincrease) / BURST_SIZE, "pr. packet \n"
+      print color.WARNING(name_tag), "Memory increased by ",memincrease,"b, ",float(memincrease) / BURST_SIZE, "pr. packet \n"
     else:
       print color.OK(name_tag), "Memory increase ",memincrease,"b \n"
 

--- a/test/vmrunner.py
+++ b/test/vmrunner.py
@@ -25,7 +25,7 @@ class color:
     C_UNDERLINE = '\033[4m'
 
     @staticmethod
-    def WARN(string):
+    def WARNING(string):
       return color.C_WARNING + "[ WARNING ] " + string + color.C_ENDC
 
     @staticmethod
@@ -84,7 +84,7 @@ def print_exception():
 
 # Catch
 def handler(signum, frame):
-    print color.WARN("Process interrupted")
+    print color.WARNING("Process interrupted")
     thread.interrupt_main()
 
 signal.signal(signal.SIGINT, handler)
@@ -278,7 +278,7 @@ class vm:
           try:
             res = func()
           except Exception as err:
-            print color.WARN("Exception raised in event callback: ")
+            print color.WARNING("Exception raised in event callback: ")
             print_exception()
             res = False
             self.stop().wait()


### PR DESCRIPTION
Added a simple wait function to the stress/test.py which makes sure it does not continue until the TIME_WAIT connections are below a set limit. Not sure if this is a solution you want, but it makes sure this test does not interfere with other tests.

Last commit fixes some irregular function calls.