### PR TITLE
A fix for pulling down tags

### DIFF
--- a/etc/get_latest_binary_bundle_asset.py
+++ b/etc/get_latest_binary_bundle_asset.py
@@ -1,12 +1,21 @@
 #!/usr/bin/python
+""" Will return one of fields of the JSON output supplied. Expects to get two
+    command line inputs:
+
+    sys.argv[1]: JSON data from the github releases page
+                 api.github.com/repos/<repo-id>/<project>/releases
+    sys.argv[2]: Name of resource to print. Could be name or download url.
+"""
+
 import sys
 import json
 import fileinput
 
+
 def get_json():
     json_str=""
-    
-    for line in fileinput.input():
+
+    for line in sys.argv[1]:
         json_str += line
 
     return json_str
@@ -14,11 +23,6 @@ def get_json():
 
 json_str = get_json()
 
-#print "JSON?", 
-
 obj = json.loads(json_str);
-asset_id = obj["assets"][0]["id"]
 
-print asset_id
-
-
+print obj[0]["assets"][0][sys.argv[2]]

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -19,7 +19,7 @@ INCLUDEOS_INSTALL=${INCLUDEOS_INSTALL-$INCLUDEOS_INSTALL_LOC/IncludeOS_install}
 # Get the latest tag from IncludeOS repo
 echo -e "\n\n>>> Updating git-tags "
 git fetch --tags https://github.com/hioa-cs/IncludeOS.git master
-tag=`git describe --abbrev=0`
+tag=`git describe master --abbrev=0`
 echo "Latest tag found: $tag"
 
 filename_tag=`echo $tag | tr . -`

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -21,7 +21,7 @@ echo -e "\n\n>>> Getting the ID of the latest release from GitHub"
 JSON=`curl https://api.github.com/repos/hioa-cs/IncludeOS/releases`
 FILENAME=`$INCLUDEOS_SRC/etc/get_latest_binary_bundle_asset.py "$JSON" name` 
 DOWNLOAD_URL=`$INCLUDEOS_SRC/etc/get_latest_binary_bundle_asset.py "$JSON" browser_download_url`
-echo -e "\nFile to download: $DOWNLOAD_URL"
+echo -e "\n\n>>> File to download: $DOWNLOAD_URL"
 
 # If the tarball exists, use that
 if [ -e $FILENAME ]

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -16,34 +16,28 @@ INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
 INCLUDEOS_INSTALL_LOC=${INCLUDEOS_INSTALL_LOC-$HOME}
 INCLUDEOS_INSTALL=${INCLUDEOS_INSTALL-$INCLUDEOS_INSTALL_LOC/IncludeOS_install}
 
-# Get the latest tag from IncludeOS repo
-echo -e "\n\n>>> Updating git-tags "
-git fetch --tags https://github.com/hioa-cs/IncludeOS.git master
-tag=`git describe master --abbrev=0`
-echo "Latest tag found: $tag"
-
-filename_tag=`echo $tag | tr . -`
-filename="IncludeOS_install_"$filename_tag".tar.gz"
-echo "Full filename: $filename"
+# Find the latest release
+echo -e "\n\n>>> Getting the ID of the latest release from GitHub"
+JSON=`curl https://api.github.com/repos/hioa-cs/IncludeOS/releases`
+FILENAME=`$INCLUDEOS_SRC/etc/get_latest_binary_bundle_asset.py "$JSON" name` 
+DOWNLOAD_URL=`$INCLUDEOS_SRC/etc/get_latest_binary_bundle_asset.py "$JSON" browser_download_url`
+echo -e "\nFile to download: $DOWNLOAD_URL"
 
 # If the tarball exists, use that
-if [ -e $filename ]
+if [ -e $FILENAME ]
 then
     echo -e "\n\n>>> IncludeOS tarball exists - extracting to $INCLUDEOS_INSTALL_LOC"
 else
     # Download from GitHub API
-    echo -e "\n\n>>> Getting the ID of the latest release from GitHub"
-    JSON=`curl https://api.github.com/repos/hioa-cs/IncludeOS/releases/tags/$tag`
-    ASSET=`echo $JSON | $INCLUDEOS_SRC/etc/get_latest_binary_bundle_asset.py`
-    ASSET_URL=https://api.github.com/repos/hioa-cs/IncludeOS/releases/assets/$ASSET
-
     echo -e "\n\n>>> Downloading latest IncludeOS release tarball from GitHub"
-    curl -H "Accept: application/octet-stream" -L -o $filename $ASSET_URL
+    curl -H "Accept: application/octet-stream" -L -o $FILENAME $DOWNLOAD_URL
 fi
 
 # Extracting the downloaded tarball
 echo -e "\n\n>>> Fetched tarball - extracting to $INCLUDEOS_INSTALL_LOC/IncludeOS_install"
-gunzip $filename -c | tar -C $INCLUDEOS_INSTALL_LOC -xf -   # Pipe gunzip to tar
+gunzip $FILENAME -c | tar -C $INCLUDEOS_INSTALL_LOC -xf -   # Pipe gunzip to tar
+
+exit 0
 
 # Install submodules
 echo -e "\n\n>>> Installing submodules"

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -37,8 +37,6 @@ fi
 echo -e "\n\n>>> Fetched tarball - extracting to $INCLUDEOS_INSTALL_LOC/IncludeOS_install"
 gunzip $FILENAME -c | tar -C $INCLUDEOS_INSTALL_LOC -xf -   # Pipe gunzip to tar
 
-exit 0
-
 # Install submodules
 echo -e "\n\n>>> Installing submodules"
 pushd $INCLUDEOS_SRC


### PR DESCRIPTION
Does not rely on tags at all any more. Will now rather find the latest release from the json output from [releases](https://api.github.com/repos/hioa-cs/IncludeOS/releases). Small change to the python script which now let's you extract multiple fields from the json output. Fix for #615 