### PR TITLE
etc: cpu host should not be default

### DIFF
--- a/etc/qemu_cmd.sh
+++ b/etc/qemu_cmd.sh
@@ -21,7 +21,7 @@ export qemu_ifup="$INCLUDEOS_HOME/etc/qemu-ifup"
 [ ! -v HDA ] && export HDA="-drive file=$IMAGE,format=raw,if=ide"
 [ ! -v HDB ] && export HDB=""
 [ ! -v HDD ] && export HDD="$HDA $HDB"
-[ ! -v CPU ] && export CPU="-cpu host"
+[ ! -v CPU ] && export CPU=""
 [ ! -v KEY ] && export KEY="-k en-us"
 
 export QEMU_OPTS="$HDD $NET $GRAPHICS $SMP $MEM $CPU $KEY"


### PR DESCRIPTION
Looks like I broke it for everyone running qemu nested by setting host as default. Fix that now.