### PR TITLE
Added make step to vmrunner

### DIFF
--- a/test/GSL/test.py
+++ b/test/GSL/test.py
@@ -4,4 +4,4 @@ import sys
 sys.path.insert(0,"..")
 
 import vmrunner
-vmrunner.vms[0].boot()
+vmrunner.vms[0].make().boot()

--- a/test/STL/test.py
+++ b/test/STL/test.py
@@ -4,4 +4,4 @@ import sys
 sys.path.insert(0,"..")
 
 import vmrunner
-vmrunner.vms[0].boot()
+vmrunner.vms[0].make().boot()

--- a/test/UDP/test.py
+++ b/test/UDP/test.py
@@ -35,4 +35,4 @@ vm = vmrunner.vms[0]
 vm.on_output("IncludeOS UDP test", UDP_test)
 
 # Boot the VM, taking a timeout as parameter
-vm.boot(20)
+vm.make().boot(20)

--- a/test/bufstore/test.py
+++ b/test/bufstore/test.py
@@ -4,4 +4,4 @@ import sys
 sys.path.insert(0,"..")
 
 import vmrunner
-vmrunner.vms[0].boot(30)
+vmrunner.vms[0].make().boot(30)

--- a/test/crt/test.py
+++ b/test/crt/test.py
@@ -4,4 +4,4 @@ import sys
 sys.path.insert(0,"..")
 
 import vmrunner
-vmrunner.vms[0].boot(40)
+vmrunner.vms[0].make().boot(40)

--- a/test/exceptions/test.py
+++ b/test/exceptions/test.py
@@ -4,4 +4,4 @@ import sys
 sys.path.insert(0,"..")
 
 import vmrunner
-vmrunner.vms[0].boot(30)
+vmrunner.vms[0].make().boot()

--- a/test/fat16/test.py
+++ b/test/fat16/test.py
@@ -20,4 +20,4 @@ vm = vmrunner.vms[0]
 vm.on_exit(cleanup)
 
 # Boot the VM
-vm.boot()
+vm.make().boot()

--- a/test/fat32/test.py
+++ b/test/fat32/test.py
@@ -20,4 +20,4 @@ vm = vmrunner.vms[0]
 vm.on_exit(cleanup)
 
 # Boot the VM
-vm.boot()
+vm.make().boot()

--- a/test/stress/test.py
+++ b/test/stress/test.py
@@ -252,4 +252,4 @@ if len(sys.argv) > 3:
 print color.HEADER(test_name + " initializing")
 print color.INFO(name_tag),"Doing", BURST_COUNT,"bursts of", BURST_SIZE, "packets each"
 
-vm.boot(timeout)
+vm.make().boot(timeout)

--- a/test/tcp/debug.py
+++ b/test/tcp/debug.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+import socket
+import sys
+
+# Usage: python test.py $GUEST_IP $HOST_IP
+GUEST = '10.0.0.42' if (len(sys.argv) < 2) else sys.argv[1]
+HOST = '10.0.0.1' if (len(sys.argv) < 3) else sys.argv[2]
+
+def connect(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_address = (GUEST, port)
+    print >>sys.stderr, 'connecting to %s port %s' % server_address
+    sock.connect(server_address)
+
+    try:
+        while True:
+            data = sock.recv(1024)
+            #print >>sys.stderr, '%s' % data
+            if data:
+                sock.sendall(data);
+            else:
+                break
+    finally:
+        print >>sys.stderr, 'closing socket'
+        sock.close()
+    return
+
+connect(8081)
+connect(8082)
+connect(8083)
+connect(8084)
+
+def listen(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_address = (HOST, port)
+    print >>sys.stderr, 'starting up on %s port %s' % server_address
+    sock.bind(server_address)
+    sock.listen(1)
+
+    while True:
+        connection, client_address = sock.accept()
+        try:
+            print >>sys.stderr, 'connection from', client_address
+            while True:
+                data = connection.recv(1024)
+                if data:
+                    print >>sys.stderr, 'received data, sending data back to the client'
+                    connection.sendall(data)
+                    print >>sys.stderr, 'close connection to client'
+                    connection.close()
+                else:
+                    print >>sys.stderr, 'no more data from', client_address
+                    break
+
+        finally:
+            connection.close()
+            break
+        sock.close()
+    return
+
+listen(8085)

--- a/test/tcp/test.py
+++ b/test/tcp/test.py
@@ -72,4 +72,4 @@ vm = vmrunner.vms[0]
 vm.on_output("IncludeOS TCP test", TCP_test)
 
 # Boot the VM, taking a timeout as parameter
-vm.boot(80)
+vm.make().boot(80)

--- a/test/timers/test.py
+++ b/test/timers/test.py
@@ -4,4 +4,4 @@ import sys
 sys.path.insert(0,"..")
 
 import vmrunner
-vmrunner.vms[0].boot(60)
+vmrunner.vms[0].make().boot(60)

--- a/test/transmit/test.py
+++ b/test/transmit/test.py
@@ -23,7 +23,7 @@ def UDP_test():
       received += len(sock.recv(1024))
 
   print "<Test.py> Received: {}".format(received)
-  
+
   data = "SUCCESS"
   sock.sendto(data, (HOST, PORT))
   print "<Test.py> Sent:     {}".format(data)
@@ -36,4 +36,4 @@ vm = vmrunner.vms[0]
 vm.on_output("Ready", UDP_test)
 
 # Boot the VM, taking a timeout as parameter
-vm.boot(20)
+vm.make().boot(20)

--- a/test/virtio_block/test.py
+++ b/test/virtio_block/test.py
@@ -19,4 +19,4 @@ def failure():
 import vmrunner
 vmrunner.vms[0].on_success(success)
 vmrunner.vms[0].on_panic(failure)
-vmrunner.vms[0].boot()
+vmrunner.vms[0].make().boot()

--- a/test/vmrunner.py
+++ b/test/vmrunner.py
@@ -259,6 +259,14 @@ class vm:
   def readline(self):
     return self._hyper.readline()
 
+  def make(self, params = []):
+    print color.INFO(nametag), "Building test service with 'make' (params=" + str(params) + ")"
+    make = ["make"]
+    make.extend(params)
+    res = subprocess.check_output(make)
+    print color.SUBPROC(res)
+    return self
+
   def boot(self, timeout = None):
 
     # Check for sudo access, needed for qemu commands
@@ -344,10 +352,6 @@ print color.HEADER("IncludeOS vmrunner initializing tests")
 print color.INFO(nametag), "Validating test service"
 validate_test.load_schema("../vm.schema.json")
 validate_test.has_required_stuff(".")
-
-print color.INFO(nametag), "Building test service with 'make'"
-res = subprocess.check_output(["make"])
-print color.SUBPROC(res)
 
 default_spec = {"image" : "test.img"}
 


### PR DESCRIPTION
Introduced `vm.make()`. Was earlier called indirect, is now required to be called before `boot()`.
Can be chained as so: `vm.make().boot()`.

Reason is to support custom make: `vm.make(["FILES=horse.cpp", "DISK=nsa.log"]).boot()`