### PR TITLE
ethernet.hpp: Fix Ethernet MAC address string representation to print leading zeros 

### DIFF
--- a/api/net/ethernet.hpp
+++ b/api/net/ethernet.hpp
@@ -74,7 +74,7 @@ namespace net {
       // hex string representation
       std::string str() const {
         char eth_addr[18];
-        snprintf(eth_addr, sizeof(eth_addr), "%1x:%1x:%1x:%1x:%1x:%1x",
+        snprintf(eth_addr, sizeof(eth_addr), "%02x:%02x:%02x:%02x:%02x:%02x",
                 part[0], part[1], part[2],
                 part[3], part[4], part[5]);
         return eth_addr;

--- a/api/net/ethernet.hpp
+++ b/api/net/ethernet.hpp
@@ -65,6 +65,13 @@ namespace net {
         uint32_t major;
       } __attribute__((packed));
 
+      addr() noexcept : part{} {}
+
+      addr(const uint8_t a, const uint8_t b, const uint8_t c,
+           const uint8_t d, const uint8_t e, const uint8_t f) noexcept
+        : part{a,b,c,d,e,f}
+      {}
+
       addr& operator=(const addr cpy) noexcept {
         minor = cpy.minor;
         major = cpy.major;

--- a/src/net/ethernet.cpp
+++ b/src/net/ethernet.cpp
@@ -29,16 +29,16 @@
 namespace net {
 
   // uint16_t(0x0000), uint32_t(0x01000000)
-  const Ethernet::addr Ethernet::addr::MULTICAST_FRAME {{0,0,0x01,0,0,0}};
+  const Ethernet::addr Ethernet::addr::MULTICAST_FRAME {0,0,0x01,0,0,0};
 
   // uint16_t(0xFFFF), uint32_t(0xFFFFFFFF)
-  const Ethernet::addr Ethernet::addr::BROADCAST_FRAME {{0xff,0xff,0xff,0xff,0xff,0xff}};
+  const Ethernet::addr Ethernet::addr::BROADCAST_FRAME {0xff,0xff,0xff,0xff,0xff,0xff};
 
   // uint16_t(0x3333), uint32_t(0x01000000)
-  const Ethernet::addr Ethernet::addr::IPv6mcast_01 {{0x33,0x33,0x01,0,0,0}};
+  const Ethernet::addr Ethernet::addr::IPv6mcast_01 {0x33,0x33,0x01,0,0,0};
 
   // uint16_t(0x3333), uint32_t(0x02000000)
-  const Ethernet::addr Ethernet::addr::IPv6mcast_02 {{0x33,0x33,0x02,0,0,0}};
+  const Ethernet::addr Ethernet::addr::IPv6mcast_02 {0x33,0x33,0x02,0,0,0};
 
   static void ignore(Packet_ptr UNUSED(pckt)) noexcept {
     debug("<Ethernet handler> Ignoring data (no real handler)\n");

--- a/test/ethernet/Makefile
+++ b/test/ethernet/Makefile
@@ -1,0 +1,22 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# The name of your service
+SERVICE=Ethernet_module_test
+SERVICE_NAME=Ethernet Module Test
+
+# Your service parts
+FILES=service.cpp
+
+LOCAL_INCLUDES=-I$(shell pwd)/../lest/include/lest
+
+# Your disk image
+DISK=
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+endif
+
+include $(INCLUDEOS_INSTALL)/Makeseed

--- a/test/ethernet/README.md
+++ b/test/ethernet/README.md
@@ -1,0 +1,3 @@
+# Ethernet Module Test
+
+NOTE: This test uses the `lest` unit test framework

--- a/test/ethernet/ethernet_module_test.hpp
+++ b/test/ethernet/ethernet_module_test.hpp
@@ -20,6 +20,16 @@
 
 #define MYINFO(X,...) INFO("Ethernet Test",X,##__VA_ARGS__)
 
+/**
+ * @brief This is defined to quite the compiler from complaining
+ * about the missing symbol {clock_gettime}
+ */
+int clock_gettime(clockid_t clk_id, struct timespec *tp){
+  (void*)clk_id;
+  (void*)tp;
+  return 0;
+};
+
 #include <lest.hpp>
 #include <net/inet4>
 

--- a/test/ethernet/ethernet_module_test.hpp
+++ b/test/ethernet/ethernet_module_test.hpp
@@ -40,7 +40,7 @@ const lest::test ethernet_module_test[]
     {
       GIVEN("A net::Ethernet::addr object")
       {
-        const net::Ethernet::addr host_mac_address {0,240,34,255,45,11};
+        const net::Ethernet::addr host_mac_address {{0,240,34,255,45,11}};
 
         WHEN("Converted to a std::string object")
         {

--- a/test/ethernet/ethernet_module_test.hpp
+++ b/test/ethernet/ethernet_module_test.hpp
@@ -18,6 +18,8 @@
 #ifndef ETHERNET_MODULE_TEST_HPP
 #define ETHERNET_MODULE_TEST_HPP
 
+#define MYINFO(X,...) INFO("Ethernet Test",X,##__VA_ARGS__)
+
 #include <lest.hpp>
 #include <net/inet4>
 

--- a/test/ethernet/ethernet_module_test.hpp
+++ b/test/ethernet/ethernet_module_test.hpp
@@ -24,7 +24,7 @@
 #define MYINFO(X,...) INFO("Ethernet Test",X,##__VA_ARGS__)
 
 /**
- * @brief This is defined to quite the compiler from complaining
+ * @brief This is defined to quiet the compiler from complaining
  * about the missing symbol {clock_gettime}
  */
 int clock_gettime(clockid_t clk_id, struct timespec *tp){

--- a/test/ethernet/ethernet_module_test.hpp
+++ b/test/ethernet/ethernet_module_test.hpp
@@ -18,6 +18,9 @@
 #ifndef ETHERNET_MODULE_TEST_HPP
 #define ETHERNET_MODULE_TEST_HPP
 
+#include <lest.hpp>
+#include <net/inet4>
+
 #define MYINFO(X,...) INFO("Ethernet Test",X,##__VA_ARGS__)
 
 /**
@@ -30,9 +33,6 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp){
   return 0;
 };
 
-#include <lest.hpp>
-#include <net/inet4>
-
 const lest::test ethernet_module_test[]
 {
   {
@@ -40,7 +40,7 @@ const lest::test ethernet_module_test[]
     {
       GIVEN("A net::Ethernet::addr object")
       {
-        const net::Ethernet::addr host_mac_address {{0,240,34,255,45,11}};
+        const net::Ethernet::addr host_mac_address {0,240,34,255,45,11};
 
         WHEN("Converted to a std::string object")
         {

--- a/test/ethernet/ethernet_module_test.hpp
+++ b/test/ethernet/ethernet_module_test.hpp
@@ -1,0 +1,47 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ETHERNET_MODULE_TEST_HPP
+#define ETHERNET_MODULE_TEST_HPP
+
+#include <lest.hpp>
+#include <net/inet4>
+
+const lest::test ethernet_module_test[]
+{
+  {
+    SCENARIO("Ethernet MAC address string representation")
+    {
+      GIVEN("A net::Ethernet::addr object")
+      {
+        const net::Ethernet::addr host_mac_address {0,240,34,255,45,11};
+
+        WHEN("Converted to a std::string object")
+        {
+          auto mac_address_string = host_mac_address.str();
+
+          THEN("The MAC address string representation must print leading zeros")
+          {
+            EXPECT(mac_address_string == "00:f0:22:ff:2d:0b");
+          }
+        }
+      }
+    }
+  }
+}; //< const lest::test ethernet_module_test[]
+
+#endif //< ETHERNET_MODULE_TEST_HPP

--- a/test/ethernet/run.sh
+++ b/test/ethernet/run.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh Ethernet_module_test.img

--- a/test/ethernet/service.cpp
+++ b/test/ethernet/service.cpp
@@ -1,0 +1,33 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <os>
+
+#include "ethernet_module_test.hpp"
+
+void Service::start()
+{
+  const auto number_of_failed_tests = lest::run(ethernet_module_test, {"-p"});
+
+  if (number_of_failed_tests) {
+    printf("%d %s failed\n", number_of_failed_tests, (number_of_failed_tests == 1 ? "test has" : "tests have"));
+    MYINFO("FAILURE");
+  } else {
+    printf("%s\n", "All tests passed");
+    MYINFO("SUCCESS");
+  }  
+}

--- a/test/ethernet/test.py
+++ b/test/ethernet/test.py
@@ -1,0 +1,7 @@
+#! /usr/bin/python
+
+import sys
+sys.path.insert(0,"..")
+
+import vmrunner
+vmrunner.vms[0].make().boot()

--- a/test/ethernet/test.sh
+++ b/test/ethernet/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+source ../test_base
+
+make
+start Ethernet_module_test.img

--- a/test/ethernet/vbox.sh
+++ b/test/ethernet/vbox.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../etc/vboxrun.sh Ethernet_module_test.img

--- a/test/ethernet/vm.json
+++ b/test/ethernet/vm.json
@@ -1,0 +1,1 @@
+{"image" : "Ethernet_module_test.img"}

--- a/test/ipv4/ipv4_module_test.hpp
+++ b/test/ipv4/ipv4_module_test.hpp
@@ -24,7 +24,7 @@
 #define MYINFO(X,...) INFO("IPv4 Test",X,##__VA_ARGS__)
 
 /**
- * @brief This is defined to quite the compiler from complaining
+ * @brief This is defined to quiet the compiler from complaining
  * about the missing symbol {clock_gettime}
  */
 int clock_gettime(clockid_t clk_id, struct timespec *tp){

--- a/test/ipv4/ipv4_module_test.hpp
+++ b/test/ipv4/ipv4_module_test.hpp
@@ -21,6 +21,18 @@
 #include <lest.hpp>
 #include <net/inet4>
 
+#define MYINFO(X,...) INFO("IPv4 Test",X,##__VA_ARGS__)
+
+/**
+ * @brief This is defined to quite the compiler from complaining
+ * about the missing symbol {clock_gettime}
+ */
+int clock_gettime(clockid_t clk_id, struct timespec *tp){
+  (void*)clk_id;
+  (void*)tp;
+  return 0;
+};
+
 const lest::test ipv4_module_test[]
 {
   {
@@ -51,7 +63,7 @@ const lest::test ipv4_module_test[]
 
           THEN("The net::IP4::addr object must reflect the address 0.0.0.0")
           {
-            EXPECT(host_address.str() == {"0.0.0.0"});
+            EXPECT(host_address.str() == "0.0.0.0");
           }
         }
       }


### PR DESCRIPTION
# Change
* Fix Ethernet MAC address string representation to print leading zeros
* Added test folder for net::Ethernet module