### PR TITLE
Timer system, APIC timer

### DIFF
--- a/api/async
+++ b/api/async
@@ -1,8 +1,8 @@
+// -*-C++-*-
 #pragma once
 #ifndef API_ASYNC_HEADER
 #define API_ASYNC_HEADER
 
-// hmm...
 #include "utility/async.hpp"
 
 #endif

--- a/api/hw/apic.hpp
+++ b/api/hw/apic.hpp
@@ -32,6 +32,11 @@ namespace hw {
     static void add_task(smp_task_func, smp_done_func);
     static void work_signal();
     
+    typedef std::function<void()>   timer_func;
+    
+    static void sched_timer(int when, timer_func);
+    static void stop_timer();
+    
     static void init();
     static void setup_subs();
     

--- a/api/hw/apic.hpp
+++ b/api/hw/apic.hpp
@@ -55,7 +55,6 @@ namespace hw {
     static void reboot();
     
   private:
-    static void init_timer(uint8_t);
     static void init_smp();
   };
   

--- a/api/hw/apic.hpp
+++ b/api/hw/apic.hpp
@@ -34,9 +34,6 @@ namespace hw {
     
     typedef std::function<void()>   timer_func;
     
-    static void sched_timer(int when, timer_func);
-    static void stop_timer();
-    
     static void init();
     static void setup_subs();
     

--- a/api/hw/apic_timer.hpp
+++ b/api/hw/apic_timer.hpp
@@ -1,0 +1,43 @@
+
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef HW_APIC_TIMER_HPP
+#define HW_APIC_TIMER_HPP
+
+#include <delegate>
+
+namespace hw {
+  
+  struct APIC_Timer
+  {
+    typedef delegate<void()> handler_t;
+    
+    static void init();
+    
+    static void oneshot(uint32_t microsec);
+    static void stop();
+    static void set_handler(handler_t& handler);
+    
+    static bool     ready();
+    static uint32_t long_duration();
+  };
+
+}
+
+#endif

--- a/api/hw/apic_timer.hpp
+++ b/api/hw/apic_timer.hpp
@@ -28,11 +28,11 @@ namespace hw {
   {
     typedef delegate<void()> handler_t;
     
-    static void init();
+    static void init(const handler_t&);
     
     static void oneshot(uint32_t microsec);
     static void stop();
-    static void set_handler(handler_t& handler);
+    static void set_handler(const handler_t&);
     
     static bool     ready();
     static uint32_t long_duration();

--- a/api/kernel/rdrand.hpp
+++ b/api/kernel/rdrand.hpp
@@ -1,3 +1,4 @@
+// -*-C++-*-
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
 // Copyright 2015 Oslo and Akershus University College of Applied Sciences
@@ -15,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
 #ifndef KERNEL_RDRAND_HPP
 #define KERNEL_RDRAND_HPP
 
@@ -23,4 +25,4 @@
 extern bool rdrand16(uint16_t* result);
 extern bool rdrand32(uint32_t* result);
 
-#endif //< KERNEL_RDRAND_HPP
+#endif

--- a/api/kernel/timer.hpp
+++ b/api/kernel/timer.hpp
@@ -34,6 +34,7 @@
 
 
 #include <cstdint>
+#include <chrono>
 #include <functional>
 #include <delegate>
 
@@ -41,19 +42,26 @@ class Timers
 {
 public:
   typedef uint32_t id_t;
-  typedef uint32_t timestamp_t;
+  typedef std::chrono::microseconds duration_t;
   typedef delegate<void()> handler_t;
   
-  /// create a timer that begins @when and repeats every @period
+  /// create a one-shot timer that triggers @when from now
   /// returns a timer id
-  static id_t create(timestamp_t when, timestamp_t period, const handler_t&);
+  static id_t create(duration_t when, const handler_t&);
+  /// create a timer that begins @when and repeats every @period
+  static id_t create(duration_t when, duration_t period, const handler_t&);
   // un-schedule timer, and free it
   static void stop(id_t);
-};
-
-class ITimerControl
-{
   
+  /// initialization
+  typedef delegate<void(duration_t)> start_func_t;
+  typedef delegate<void()> stop_func_t;
+  static void init(const start_func_t&, const stop_func_t&);
+  /// signal from the underlying hardware that it is calibrated and ready to go
+  static void ready();
+  
+  /// handler that processes timer interrupts
+  static void timers_handler();
 };
 
 #endif

--- a/api/kernel/timer.hpp
+++ b/api/kernel/timer.hpp
@@ -1,0 +1,41 @@
+// -*-C++-*-
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef KERNEL_TIMER_HPP
+#define KERNEL_TIMER_HPP
+
+#include <cstdint>
+#include <functional>
+#include <delegate>
+
+class Timers
+{
+public:
+  typedef uint32_t id_t;
+  typedef uint32_t timestamp_t;
+  typedef delegate<void()> handler_t;
+  
+  /// create a timer that begins @when and repeats every @period
+  /// returns a timer id
+  static id_t start(timestamp_t when, timestamp_t period, const handler_t&);
+  // un-schedule timer, and free it
+  static void stop(id_t);
+};
+
+#endif

--- a/api/kernel/timer.hpp
+++ b/api/kernel/timer.hpp
@@ -47,9 +47,9 @@ public:
   
   /// create a one-shot timer that triggers @when from now
   /// returns a timer id
-  static id_t create(duration_t when, const handler_t&);
-  /// create a timer that begins @when and repeats every @period
-  static id_t create(duration_t when, duration_t period, const handler_t&);
+  static id_t oneshot(duration_t when, const handler_t&);
+  /// create a periodic timer that begins @when and repeats every @period
+  static id_t periodic(duration_t when, duration_t period, const handler_t&);
   // un-schedule timer, and free it
   static void stop(id_t);
   

--- a/api/kernel/timer.hpp
+++ b/api/kernel/timer.hpp
@@ -20,19 +20,6 @@
 #ifndef KERNEL_TIMER_HPP
 #define KERNEL_TIMER_HPP
 
-/**
- * 1. There are no restrictions on when timers can be started or stopped
- * 2. A period of 0 means start a one-shot timer
- * 3. Each timer is a separate object living in a "fixed" vector
- * 4. A dead timer is simply a timer which has its handler reset, as well as
- *     having been removed from schedule
- * 5. No timer may be scheduled more than once at a time, as that will needlessly
- *     inflate the schedule container, as well as complicate stopping timers
- * 6. Free timers are allocated from a stack of free timer IDs (or through expanding
- *     the "fixed" vector)
-**/
-
-
 #include <cstdint>
 #include <chrono>
 #include <functional>
@@ -41,9 +28,9 @@
 class Timers
 {
 public:
-  typedef uint32_t id_t;
-  typedef std::chrono::microseconds duration_t;
-  typedef delegate<void()> handler_t;
+  using id_t       = uint32_t;
+  using duration_t = std::chrono::microseconds;
+  using handler_t  = delegate<void(id_t)>;
   
   /// create a one-shot timer that triggers @when from now
   /// returns a timer id

--- a/api/kernel/timer.hpp
+++ b/api/kernel/timer.hpp
@@ -20,6 +20,19 @@
 #ifndef KERNEL_TIMER_HPP
 #define KERNEL_TIMER_HPP
 
+/**
+ * 1. There are no restrictions on when timers can be started or stopped
+ * 2. A period of 0 means start a one-shot timer
+ * 3. Each timer is a separate object living in a "fixed" vector
+ * 4. A dead timer is simply a timer which has its handler reset, as well as
+ *     having been removed from schedule
+ * 5. No timer may be scheduled more than once at a time, as that will needlessly
+ *     inflate the schedule container, as well as complicate stopping timers
+ * 6. Free timers are allocated from a stack of free timer IDs (or through expanding
+ *     the "fixed" vector)
+**/
+
+
 #include <cstdint>
 #include <functional>
 #include <delegate>
@@ -33,9 +46,14 @@ public:
   
   /// create a timer that begins @when and repeats every @period
   /// returns a timer id
-  static id_t start(timestamp_t when, timestamp_t period, const handler_t&);
+  static id_t create(timestamp_t when, timestamp_t period, const handler_t&);
   // un-schedule timer, and free it
   static void stop(id_t);
+};
+
+class ITimerControl
+{
+  
 };
 
 #endif

--- a/api/timer
+++ b/api/timer
@@ -1,0 +1,25 @@
+// -*-C++-*-
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef API_TIMER_HEADER
+#define API_TIMER_HEADER
+
+#include "kernel/timer.hpp"
+
+#endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -70,8 +70,8 @@ OS_OBJECTS = kernel/kernel_start.o kernel/syscalls.o \
 		kernel/interrupts.o kernel/os.o kernel/cpuid.o \
 		kernel/irq_manager.o kernel/pci_manager.o \
 		kernel/elf.o kernel/terminal.o kernel/terminal_disk.o \
-		kernel/vga.o util/memstream.o util/async.o \
-		kernel/debug_new.o kernel/profile.o \
+		kernel/vga.o kernel/debug_new.o kernel/profile.o \
+		kernel/timer.o util/memstream.o util/async.o \
 		crt/c_abi.o crt/string.o crt/quick_exit.o crt/cxx_abi.o crt/mman.o \
 		hw/ide.o hw/pit.o hw/pic.o hw/pci_device.o hw/cpu_freq_sampling.o \
 		hw/ps2.o hw/serial.o hw/cmos.o \

--- a/src/debug/test_service.cpp
+++ b/src/debug/test_service.cpp
@@ -116,7 +116,7 @@ void Service::start()
   printf("Creating repeating timer for 500ms\n");
   static int C = 0;
   for (int i = 0; i < 5000; i++)
-  Timers::create(500ms, 500ms,
+  Timers::periodic(500ms, 500ms,
   [] {
     printf("beep\t");
     C++;

--- a/src/debug/test_service.cpp
+++ b/src/debug/test_service.cpp
@@ -92,9 +92,10 @@ extern "C" {
 }
 
 #include <hw/cpu.hpp>
+#include <timer>
+
 void Service::start()
 {
-  return;
   //printf("static array @ %p size is %u\n", bullshit, sizeof(bullshit));
   //memset(bullshit, 0, sizeof(bullshit));
   //__validate_bullshit("validate_bullshit begin Service::start()");
@@ -106,19 +107,29 @@ void Service::start()
   // print sampling results every 5 seconds
   //hw::PIT::instance().on_repeated_timeout(500ms, print_stack_sampling);
 
-  hw::PIT::instance().on_repeated_timeout(500ms, 
-  [] {
-    print_heap_info();
-    printf("bufstore packets: %u\n", inet->buffers_available());
-  });
+  //Timers::create(500ms, 500ms,
+  //[] {
+  //  print_heap_info();
+  //  printf("bufstore packets: %u\n", inet->buffers_available());
+  //});
 
+  printf("Creating repeating timer for 500ms\n");
+  static int C = 0;
+  for (int i = 0; i < 5000; i++)
+  Timers::create(500ms, 500ms,
+  [] {
+    printf("beep\t");
+    C++;
+    if (C == 10) printf("\n");
+  });
+  
   // boilerplate
   inet = net::new_ipv4_stack(
     { 10,0,0,42 },      // IP
     { 255,255,255,0 },  // Netmask
     { 10,0,0,1 } );     // Gateway
-  hw::PIT::instance().on_repeated_timeout(1500ms, print_tcp_status);
-  hw::PIT::instance().on_timeout_ms(1ms, print_tcp_status);
+  //hw::PIT::instance().on_repeated_timeout(1500ms, print_tcp_status);
+  //hw::PIT::instance().on_timeout_ms(1ms, print_tcp_status);
 
   // Set up a TCP server on port 80
   auto& server = inet->tcp().bind(80);

--- a/src/debug/test_service.cpp
+++ b/src/debug/test_service.cpp
@@ -28,7 +28,7 @@ extern void print_heap_info();
 extern void print_backtrace();
 
 void print_tcp_status() {
-  printf("<Service> TCP STATUS: %u\n", inet->tcp().activeConnections());
+  printf("<Service> TCP STATUS: %u\n", inet->tcp().active_connections());
   print_heap_info();
   print_backtrace();
 }
@@ -94,6 +94,7 @@ extern "C" {
 #include <hw/cpu.hpp>
 void Service::start()
 {
+  return;
   //printf("static array @ %p size is %u\n", bullshit, sizeof(bullshit));
   //memset(bullshit, 0, sizeof(bullshit));
   //__validate_bullshit("validate_bullshit begin Service::start()");
@@ -121,7 +122,7 @@ void Service::start()
 
   // Set up a TCP server on port 80
   auto& server = inet->tcp().bind(80);
-  server.onConnect(
+  server.on_connect(
   [] (auto conn) {
     conn->close();
   });

--- a/src/hw/apic.cpp
+++ b/src/hw/apic.cpp
@@ -106,9 +106,6 @@ namespace hw {
     // use KVMs paravirt EOI if supported
     //kvm_pv_eoi_init();
     
-    // initialize APIC timer
-    extern void apic_init_timer();
-    apic_init_timer();
     // subscribe to APIC-related interrupts
     setup_subs();
   }
@@ -293,8 +290,8 @@ namespace hw {
     // IRQ handler for completed async jobs
     IRQ_manager::cpu(0).subscribe(BSP_LAPIC_IPI_IRQ,
     [] {
-      // copy all the done functions out from queue to our local queue
-      std::deque<smp_done_func> done;
+      // copy all the done functions out from queue to our local vector
+      std::vector<smp_done_func> done;
       lock(smp.flock);
       for (auto& func : smp.completed)
         done.push_back(func);
@@ -305,8 +302,6 @@ namespace hw {
         func();
       }
     });
-    extern void apic_timer_interrupt_handler();
-    IRQ_manager::cpu(0).subscribe(LAPIC_IRQ_BASE, apic_timer_interrupt_handler);
   }
 
   void APIC::reboot()

--- a/src/hw/apic_timer.cpp
+++ b/src/hw/apic_timer.cpp
@@ -15,41 +15,84 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <hw/apic.hpp>
+#include <hw/apic_timer.hpp>
 #include <hw/apic_regs.hpp>
 #include <hw/pit.hpp>
+#include <kernel/irq_manager.hpp>
 #include <cstdio>
+#include <info>
+
+#define TIMER_ONESHOT     0x0
+#define TIMER_PERIODIC    0x20000
+#define TIMER_DEADLINE    0x40000
 
 // vol 3a  10-10
 #define DIVIDE_BY_16     0x3
 
+using namespace std::chrono;
+
 namespace hw
 {
-  void apic_init_timer()
+  static delegate<void()> intr_handler;
+  static uint32_t         ticks_per_micro = 0;
+  
+  void APIC_Timer::init()
   {
-    // divide by 16
+    // decrement only every 16 ticks
     lapic.regs->divider_config.reg = DIVIDE_BY_16;
-    // set initial counter
+    // start in one-shot mode and set the interrupt vector
+    // but also disable interrupts
+    lapic.regs->timer.reg = TIMER_ONESHOT | (LAPIC_IRQ_TIMER+32) | INTR_MASK;
+    
+    // start timer (unmask)
+    INFO("APIC", "Measuring APIC timer...");
     lapic.regs->init_count.reg = 0xFFFFFFFF;
-    // enable timer (unmask)
-    lapic.regs->timer.reg = INTR_MASK | LAPIC_IRQ_TIMER;
+    // 0xFFFFFFFF --> ~68 seconds
+    // 0xFFFFFF   --> ~46 milliseconds
     
-    /// use PIT to measure <time> in one-shot here ///
-    
-    // stop timer
-    lapic.regs->timer.reg &= ~INTR_MASK;
-    
-    // measure difference
-    long diff = lapic.regs->init_count.reg - lapic.regs->cur_count.reg;
-    
-    // program timer to do useful things ...
     // See: Vol3a 10.5.4.1 TSC-Deadline Mode
+    
+    /// use PIT to measure <time> in one-shot ///
+    hw::PIT::instance().on_timeout_ms(milliseconds(10),
+    [] {
+      // measure difference
+      uint32_t diff = lapic.regs->init_count.reg - lapic.regs->cur_count.reg;
+      ticks_per_micro = diff / 10 / 1000;
+      
+      printf("* APIC timer: ticks 10ms: %u\t 1micro: %u\n", 
+            diff, ticks_per_micro);
+      
+      // make sure timer is still disabled
+      lapic.regs->timer.reg |= INTR_MASK;
+      
+      // enable normal timer functionality
+      IRQ_manager::cpu(0).subscribe(LAPIC_IRQ_TIMER, intr_handler);
+    });
   }
   
-  void apic_timer_interrupt_handler()
+  bool APIC_Timer::ready()
   {
-    printf("bang!\n");
-    // stop timer
-    lapic.regs->timer.reg &= ~INTR_MASK;
+    return ticks_per_micro != 0;
+  }
+  
+  void APIC_Timer::set_handler(delegate<void()>& handler)
+  {
+    intr_handler = handler;
+    if (ready()) {
+      IRQ_manager::cpu(0).subscribe(LAPIC_IRQ_TIMER, handler);
+    }
+  }
+  
+  void APIC_Timer::oneshot(uint32_t microsec)
+  {
+    // set initial counter
+    lapic.regs->init_count.reg = microsec * ticks_per_micro;
+    // enable interrupt vector
+    lapic.regs->timer.reg = (lapic.regs->timer.reg & ~INTR_MASK) | TIMER_ONESHOT;
+    
+  }
+  void APIC_Timer::stop()
+  {
+    lapic.regs->timer.reg |= INTR_MASK;
   }
 }

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -42,10 +42,6 @@ extern "C" uint16_t _cpu_sampling_freq_divider_;
 extern caddr_t heap_begin;
 extern caddr_t heap_end;
 
-namespace hw {
-  extern void apic_init_timer();
-}
-
 void OS::start() {
 
   // Initialize serial port

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -24,6 +24,7 @@
 
 #include <hw/acpi.hpp>
 #include <hw/apic.hpp>
+#include <hw/apic_timer.hpp>
 #include <hw/cmos.hpp>
 #include <hw/serial.hpp>
 #include <kernel/pci_manager.hpp>
@@ -39,6 +40,10 @@ hw::Serial& OS::com1 = hw::Serial::port<1>();
 extern "C" uint16_t _cpu_sampling_freq_divider_;
 extern caddr_t heap_begin;
 extern caddr_t heap_end;
+
+namespace hw {
+  extern void apic_init_timer();
+}
 
 void OS::start() {
 
@@ -74,6 +79,9 @@ void OS::start() {
   // Initialize the Interval Timer
   hw::PIT::init();
 
+  // initialize BSP APIC timer
+  hw::APIC_Timer::init();
+
   // Initialize PCI devices
   PCI_manager::init();
 
@@ -81,7 +89,7 @@ void OS::start() {
   MYINFO("Estimating CPU-frequency");
   INFO2("|");
   INFO2("+--(10 samples, %f sec. interval)",
-  (hw::PIT::frequency() / _cpu_sampling_freq_divider_).count());
+        (hw::PIT::frequency() / _cpu_sampling_freq_divider_).count());
   INFO2("|");
 
   // TODO: Debug why actual measurments sometimes causes problems. Issue #246.

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -27,8 +27,9 @@
 #include <hw/apic_timer.hpp>
 #include <hw/cmos.hpp>
 #include <hw/serial.hpp>
-#include <kernel/pci_manager.hpp>
 #include <kernel/irq_manager.hpp>
+#include <kernel/pci_manager.hpp>
+#include <kernel/timer.hpp>
 
 bool OS::power_   {true};
 MHz  OS::cpu_mhz_ {1000};
@@ -79,9 +80,6 @@ void OS::start() {
   // Initialize the Interval Timer
   hw::PIT::init();
 
-  // initialize BSP APIC timer
-  hw::APIC_Timer::init();
-
   // Initialize PCI devices
   PCI_manager::init();
 
@@ -94,8 +92,27 @@ void OS::start() {
 
   // TODO: Debug why actual measurments sometimes causes problems. Issue #246.
   cpu_mhz_ = hw::PIT::CPU_frequency();
-
   INFO2("+--> %f MHz", cpu_mhz_.count());
+
+  // cpu_mhz must be known before we can start timer system
+  /// initialize timers hooked up to APIC timer
+  Timers::init(
+    // timer start function
+    [] (Timers::duration_t when) {
+      // explicit conversion to microseconds
+      hw::APIC_Timer::oneshot(std::chrono::microseconds(when).count());
+    }, 
+    // timer stop function
+    hw::APIC_Timer::stop);
+
+  // initialize BSP APIC timer
+  hw::APIC_Timer::init(
+  [] {
+    // set final interrupt handler
+    hw::APIC_Timer::set_handler(Timers::timers_handler);
+    // signal ready
+    Timers::ready();
+  });
 
   // Initialize CMOS
   cmos::init();

--- a/src/kernel/timer.cpp
+++ b/src/kernel/timer.cpp
@@ -83,13 +83,13 @@ static id_t create_timer(
   sched_timer(when, id);
   return id;
 }
-id_t Timers::create(duration_t when, duration_t period, const handler_t& handler)
-{
-  return create_timer(when, period, handler);
-}
-id_t Timers::create(duration_t when, const handler_t& handler)
+id_t Timers::oneshot(duration_t when, const handler_t& handler)
 {
   return create_timer(when, milliseconds(0), handler);
+}
+id_t Timers::periodic(duration_t when, duration_t period, const handler_t& handler)
+{
+  return create_timer(when, period, handler);
 }
 
 void Timers::stop(id_t id)

--- a/src/kernel/timer.cpp
+++ b/src/kernel/timer.cpp
@@ -2,11 +2,14 @@
 
 #include <map>
 #include <vector>
+#include <hw/apic.hpp>
 
 typedef Timers::id_t        id_t;
 typedef Timers::timestamp_t timestamp_t;
 typedef Timers::handler_t   handler_t;
+
 void sched_timer(timestamp_t when, id_t id);
+void stop_timer();
 
 struct Timer
 {
@@ -20,6 +23,7 @@ struct Timer
 
 static std::vector<Timer> timers;
 static std::vector<id_t>  free_timers;
+static bool  is_running = false;
 
 // timers sorted by timestamp
 static std::multimap<timestamp_t, id_t> scheduled;
@@ -48,7 +52,7 @@ static id_t create_timer(
   sched_timer(when, id);
   return id;
 }
-id_t Timers::start(timestamp_t when, timestamp_t period, const handler_t& handler)
+id_t Timers::create(timestamp_t when, timestamp_t period, const handler_t& handler)
 {
   return create_timer(when, period, handler);
 }
@@ -61,27 +65,88 @@ void Timers::stop(id_t id)
   auto it = scheduled.find(id);
   if (it == scheduled.end())
       return;
+  
+  // in the special case where the timer id is the current front,
+  // we will need to also stop/reset the hardware timer
+  if (it == scheduled.begin()) {
+    stop_timer();
+  }
+  
   scheduled.erase(it);
 }
 
 /// time functions ///
+/// ARCHITECTURE SPECIFIC ///
 #include <kernel/os.hpp>
 
-timestamp_t now()
+static timestamp_t now()
 {
   return (timestamp_t) OS::uptime();
 }
+static void arch_sched(timestamp_t when, handler_t cb)
+{
+  hw::APIC::sched_timer(when, cb);
+}
+static void arch_stop()
+{
+  hw::APIC::stop_timer();
+}
 
+void timers_handler()
+{
+  while (!scheduled.empty())
+  {
+    auto it = scheduled.begin();
+    auto when   = it->first;
+    auto ts_now = now();
+    auto& timer = timers[it->second];
+    
+    if (ts_now >= when) {
+      // erase immediately
+      scheduled.erase(scheduled.begin());
+      
+      // call handler
+      timer.handler();
+      
+      // if the timer died during handler, free its resources
+      if (timer.deferred_destruct) {
+        timer.deferred_destruct = false;
+        timer.handler.reset();
+      }
+      else if (timer.period)
+      {
+        // or, if the timer is recurring, we will want to reschedule it
+        is_running = true;
+        arch_sched(timer.period, timer.handler);
+      }
+      
+    } else {
+      // not yet past time, so schedule it for later
+      is_running = true;
+      arch_sched(when - ts_now, timer.handler);
+      // exit early, because we have nothing more to do, and there is a deferred handler
+      return;
+    }
+  }
+  // if we get here, the list is empty,
+  // and if the hardware timer is running, stop it
+  if (is_running) {
+    is_running = false;
+    arch_stop();
+  }
+}
 void sched_timer(timestamp_t when, id_t id)
 {
-  /*
-  scheduled.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(id),
-      std::forward_as_tuple(when));
-  */
-  scheduled.insert(
-      std::forward_as_tuple(now() + when, id));
+  scheduled.insert(std::forward_as_tuple(now() + when, id));
+  
+  if (is_running == false) {
+    timers_handler();
+  }
+  
+}
+void stop_timer()
+{
+  arch_stop();
 }
 
 /// scheduling ///

--- a/src/kernel/timer.cpp
+++ b/src/kernel/timer.cpp
@@ -1,0 +1,87 @@
+#include <kernel/timer.hpp>
+
+#include <map>
+#include <vector>
+
+typedef Timers::id_t        id_t;
+typedef Timers::timestamp_t timestamp_t;
+typedef Timers::handler_t   handler_t;
+void sched_timer(timestamp_t when, id_t id);
+
+struct Timer
+{
+  Timer(timestamp_t p, handler_t h)
+    : period(p), handler(h), deferred_destruct(false) {}
+  
+  timestamp_t period;
+  handler_t   handler;
+  bool deferred_destruct = false;
+};
+
+static std::vector<Timer> timers;
+static std::vector<id_t>  free_timers;
+
+// timers sorted by timestamp
+static std::multimap<timestamp_t, id_t> scheduled;
+
+static id_t create_timer(
+    timestamp_t when, timestamp_t period, const handler_t& handler)
+{
+  id_t id;
+  
+  if (free_timers.empty()) {
+    id = timers.size();
+    
+    // occupy new slot
+    timers.emplace_back(period, handler);
+  }
+  else {
+    // get free timer slot
+    id = free_timers.back();
+    free_timers.pop_back();
+    
+    // occupy free slot
+    new (&timers[id]) Timer(period, handler);
+  }
+  
+  // immediately schedule the first timer
+  sched_timer(when, id);
+  return id;
+}
+id_t Timers::start(timestamp_t when, timestamp_t period, const handler_t& handler)
+{
+  return create_timer(when, period, handler);
+}
+
+void Timers::stop(id_t id)
+{
+  // mark as free
+  free_timers.push_back(id);
+  // remove from scheduling
+  auto it = scheduled.find(id);
+  if (it == scheduled.end())
+      return;
+  scheduled.erase(it);
+}
+
+/// time functions ///
+#include <kernel/os.hpp>
+
+timestamp_t now()
+{
+  return (timestamp_t) OS::uptime();
+}
+
+void sched_timer(timestamp_t when, id_t id)
+{
+  /*
+  scheduled.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(id),
+      std::forward_as_tuple(when));
+  */
+  scheduled.insert(
+      std::forward_as_tuple(now() + when, id));
+}
+
+/// scheduling ///


### PR DESCRIPTION
Oneshot and periodic timer system that reschedules itself until all timers are handled.

The timer system does not start until the underlying hardware system signals ready. This means that timers will work during service start, even if the hardware calibration process is not yet done. This is the case for the APIC timer, which is calibrated from a 10ms PIT timer.

Long periods would ordinarily overflow the APIC timers tick register, but its saturated, and the timer system corrects itself by starting a new hardware timer if no timers' timestamp were overshot.

The system relies on a correct cpu MHz implementation. The system readjusts every time a timer ticks, which happens at the longest every 2 minutes, so drift is not a problem.