### PR TITLE
Made IP4::addr independent - moved to ip4 namespace

### DIFF
--- a/api/net/ip4/addr.hpp
+++ b/api/net/ip4/addr.hpp
@@ -1,0 +1,129 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NET_IP4_ADDR_HPP
+#define NET_IP4_ADDR_HPP
+
+#include <gsl.h> // Expects/Ensures
+#include <regex>
+#include <string>
+
+namespace net {
+namespace ip4 {
+
+/** IP4 address representation */
+struct Addr {
+  uint32_t whole;
+
+  Addr() : whole(0) {} // uninitialized
+  Addr(const uint32_t ipv4_addr)
+    : whole(ipv4_addr) {}
+  Addr(const uint8_t p1, const uint8_t p2, const uint8_t p3, const uint8_t p4)
+    : whole(p1 | (p2 << 8) | (p3 << 16) | (p4 << 24)) {}
+
+  /**
+   * @brief Construct an IPv4 address from a {std::string}
+   * object
+   *
+   * @note If the {std::string} object doesn't contain a valid
+   * IPv4 representation then the instance will contain the
+   * address -> 0.0.0.0
+   *
+   * @param ipv4_addr:
+   * A {std::string} object representing an IPv4 address
+   */
+  Addr(const std::string& ipv4_addr)
+    : Addr{}
+  {
+    Expects(ipv4_addr.size() >= 7 && ipv4_addr.size() <= 15); //< [7, 15] minimum and maximum address length
+
+    const static std::regex ipv4_address_pattern
+    {
+      "^(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
+      "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
+      "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
+      "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)$"
+    };
+
+    std::smatch ipv4_parts;
+
+    if (not std::regex_match(ipv4_addr, ipv4_parts, ipv4_address_pattern)) {
+      return;
+    }
+
+    const auto p1 = static_cast<uint8_t>(std::stoi(ipv4_parts[1]));
+    const auto p2 = static_cast<uint8_t>(std::stoi(ipv4_parts[2]));
+    const auto p3 = static_cast<uint8_t>(std::stoi(ipv4_parts[3]));
+    const auto p4 = static_cast<uint8_t>(std::stoi(ipv4_parts[4]));
+
+    whole = p1 | (p2 << 8) | (p3 << 16) | (p4 << 24);
+  }
+
+  inline Addr& operator=(const Addr cpy) noexcept {
+    whole = cpy.whole;
+    return *this;
+  }
+
+  /** Standard comparison operators */
+  bool operator==(const Addr rhs)     const noexcept
+  { return whole == rhs.whole; }
+
+  bool operator==(const uint32_t rhs) const noexcept
+  { return  whole == rhs; }
+
+  bool operator<(const Addr rhs)      const noexcept
+  { return whole < rhs.whole; }
+
+  bool operator<(const uint32_t rhs)  const noexcept
+  { return  whole < rhs; }
+
+  bool operator>(const Addr rhs)      const noexcept
+  { return whole > rhs.whole; }
+
+  bool operator>(const uint32_t rhs)  const noexcept
+  { return  whole > rhs; }
+
+  bool operator!=(const Addr rhs)     const noexcept
+  { return whole != rhs.whole; }
+
+  bool operator!=(const uint32_t rhs) const noexcept
+  { return  whole != rhs; }
+
+  Addr operator & (const Addr rhs)    const noexcept
+  { return Addr(whole & rhs.whole); }
+
+  /** x.x.x.x string representation */
+  std::string str() const {
+    char ipv4_addr[16];
+    sprintf(ipv4_addr, "%1i.%1i.%1i.%1i",
+            (whole >>  0) & 0xFF,
+            (whole >>  8) & 0xFF,
+            (whole >> 16) & 0xFF,
+            (whole >> 24) & 0xFF);
+    return ipv4_addr;
+  }
+
+  std::string to_string() const
+  { return str(); }
+
+} __attribute__((packed)); //< Addr
+
+} // < namespace ip4
+} // < namespace net
+
+
+#endif // < NET_IP4_ADDR_HPP

--- a/api/net/ip4/ip4.hpp
+++ b/api/net/ip4/ip4.hpp
@@ -1,6 +1,6 @@
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
-// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
 // and Alfred Bratterud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,10 +18,9 @@
 #ifndef CLASS_IP4_HPP
 #define CLASS_IP4_HPP
 
-#include <regex>
-#include <string>
 #include <iostream>
 
+#include "addr.hpp"
 #include <common>
 #include <net/ethernet.hpp>
 #include <net/inet.hpp>
@@ -35,104 +34,15 @@ namespace net {
   /** IP4 layer */
   class IP4 {
   public:
+    using addr = ip4::Addr;
+
     /** Initialize. Sets a dummy linklayer out. */
     explicit IP4(Inet<LinkLayer, IP4>&) noexcept;
 
     /** Known transport layer protocols. */
     enum proto { IP4_ICMP=1, IP4_UDP=17, IP4_TCP=6 };
 
-    /** IP4 address representation */
-    struct addr {
-      uint32_t whole;
-      
-      addr() : whole(0) {} // uninitialized
-      addr(const uint32_t ipv4_addr)
-        : whole(ipv4_addr) {}
-      addr(const uint8_t p1, const uint8_t p2, const uint8_t p3, const uint8_t p4)
-        : whole(p1 | (p2 << 8) | (p3 << 16) | (p4 << 24)) {}
 
-      /**
-       * @brief Construct an IPv4 address from a {std::string}
-       * object
-       *
-       * @note If the {std::string} object doesn't contain a valid
-       * IPv4 representation then the instance will contain the
-       * address -> 0.0.0.0
-       *
-       * @param ipv4_addr:
-       * A {std::string} object representing an IPv4 address
-       */
-      addr(const std::string& ipv4_addr)
-        : addr{}
-      {
-      	Expects(ipv4_addr.size() >= 7 && ipv4_addr.size() <= 15); //< [7, 15] minimum and maximum address length
-
-        const static std::regex ipv4_address_pattern
-        {
-          "^(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
-          "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
-          "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
-          "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)$"
-        };
-
-        std::smatch ipv4_parts;
-      
-        if (not std::regex_match(ipv4_addr, ipv4_parts, ipv4_address_pattern)) {
-          return;
-        }
-        
-        const auto p1 = static_cast<uint8_t>(std::stoi(ipv4_parts[1]));
-        const auto p2 = static_cast<uint8_t>(std::stoi(ipv4_parts[2]));
-        const auto p3 = static_cast<uint8_t>(std::stoi(ipv4_parts[3]));
-        const auto p4 = static_cast<uint8_t>(std::stoi(ipv4_parts[4]));
-
-        whole = p1 | (p2 << 8) | (p3 << 16) | (p4 << 24);
-      }
-      
-      inline addr& operator=(const addr cpy) noexcept {
-        whole = cpy.whole;
-        return *this;
-      }
-
-      /** Standard comparison operators */
-      bool operator==(const addr rhs)     const noexcept
-      { return whole == rhs.whole; }
-
-      bool operator==(const uint32_t rhs) const noexcept
-      { return  whole == rhs; }
-
-      bool operator<(const addr rhs)      const noexcept
-      { return whole < rhs.whole; }
-
-      bool operator<(const uint32_t rhs)  const noexcept
-      { return  whole < rhs; }
-
-      bool operator>(const addr rhs)      const noexcept
-      { return whole > rhs.whole; }
-
-      bool operator>(const uint32_t rhs)  const noexcept
-      { return  whole > rhs; }
-
-      bool operator!=(const addr rhs)     const noexcept
-      { return whole != rhs.whole; }
-
-      bool operator!=(const uint32_t rhs) const noexcept
-      { return  whole != rhs; }
-
-      addr operator & (const addr rhs)    const noexcept
-      { return addr(whole & rhs.whole); }
-      
-      /** x.x.x.x string representation */
-      std::string str() const {
-        char ipv4_addr[16];
-        sprintf(ipv4_addr, "%1i.%1i.%1i.%1i",
-                (whole >>  0) & 0xFF,
-                (whole >>  8) & 0xFF, 
-                (whole >> 16) & 0xFF, 
-                (whole >> 24) & 0xFF);
-        return ipv4_addr;
-      }
-    } __attribute__((packed)); //< IP4::addr
 
     static const addr INADDR_ANY;
     static const addr INADDR_BCAST;

--- a/api/net/tcp/common.hpp
+++ b/api/net/tcp/common.hpp
@@ -19,7 +19,7 @@
 #ifndef NET_TCP_COMMON_HPP
 #define NET_TCP_COMMON_HPP
 
-#include <net/ip4/ip4.hpp> // IP4::addr @TODO: include ip4 only for address?
+#include <net/ip4/addr.hpp>
 
 namespace net {
   namespace tcp {
@@ -32,7 +32,7 @@ namespace net {
     // the maximum amount of half-open connections per port (listener)
     static constexpr size_t max_syn_backlog = 64;
 
-    using Address = IP4::addr;
+    using Address = ip4::Addr;
 
     /** A port */
     using port_t = uint16_t;

--- a/api/net/tcp/common.hpp
+++ b/api/net/tcp/common.hpp
@@ -43,6 +43,15 @@ namespace net {
     /** A shared buffer pointer */
     using buffer_t = std::shared_ptr<uint8_t>;
 
+    /**
+     * @brief Creates a shared buffer with a given length
+     *
+     * @param length buffer length
+     * @return a newly created buffer_t
+     */
+    static buffer_t new_shared_buffer(uint64_t length)
+    { return buffer_t(new uint8_t[length], std::default_delete<uint8_t[]>()); }
+
     class Packet;
     using Packet_ptr = std::shared_ptr<Packet>;
 

--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -539,7 +539,7 @@ private:
     Buffer is cleared for data after every reset.
   */
   void read(size_t n, ReadCallback callback) {
-    ReadBuffer buffer = {buffer_t(new uint8_t[n], std::default_delete<uint8_t[]>()), n};
+    ReadBuffer buffer = {new_shared_buffer(n), n};
     read(buffer, callback);
   }
 
@@ -587,7 +587,7 @@ private:
     Immediately tries to write the data to the connection. If not possible, queues the write for processing when possible (FIFO).
   */
   void write(const void* buf, size_t n, WriteCallback callback, bool PUSH) {
-    auto buffer = buffer_t(new uint8_t[n], std::default_delete<uint8_t[]>());
+    auto buffer = new_shared_buffer(n);
     memcpy(buffer.get(), buf, n);
     write(buffer, n, callback, PUSH);
   }

--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -28,6 +28,9 @@
 #include "tcp_errors.hpp"
 #include "write_queue.hpp"
 
+namespace net {
+  class TCP;
+}
 
 namespace net {
 namespace tcp {
@@ -38,7 +41,6 @@ namespace tcp {
   Transist between many states.
 */
 class Connection : public std::enable_shared_from_this<Connection> {
-
   friend class net::TCP;
   friend class Listener;
 

--- a/api/net/tcp/headers.hpp
+++ b/api/net/tcp/headers.hpp
@@ -20,6 +20,7 @@
 #define NET_TCP_HEADERS_HPP
 
 #include "common.hpp"
+#include <net/ip4/addr.hpp>
 
 namespace net {
 namespace tcp {
@@ -86,8 +87,8 @@ struct Header {
   TCP Pseudo header, for checksum calculation
 */
 struct Pseudo_header {
-  IP4::addr saddr;
-  IP4::addr daddr;
+  ip4::Addr saddr;
+  ip4::Addr daddr;
   uint8_t zero;
   uint8_t proto;
   uint16_t tcp_length;


### PR DESCRIPTION
`struct IP4::addr` is now `net::ip4::Addr`, moved inside `net/ip4/addr.hpp`. This is to reduce dependencies.

Also small helper `tcp::buffer_t net::tcp::new_shared_buffer(uint64_t length)` added to `net/tcp/common.hpp`