### PR TITLE
Cmake dev

### DIFF
--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -3,13 +3,13 @@ cmake_minimum_required(VERSION 2.8.9)
 project (vmbuilder)
 
 # TODO: make sure that CXX is exported before this script is called
-set(SOURCES vmbuild.cpp)
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -O3")
+set(SOURCES vmbuild.cpp elf_binary.cpp)
+set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O3")
 
-include_directories(.)
+# TODO: write scripts that automatically find include directories
+include_directories(. ./../api ./../mod/GSL/include)
 
 add_executable(vmbuild ${SOURCES})
 
-# TODO: move install towards cmake
-
+# TODO: use prefix to install into the right directory
 install(TARGETS vmbuild DESTINATION bin)

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+project (vmbuilder)
+
+# TODO: make sure that CXX is exported before this script is called
+set(SOURCES vmbuild.cpp)
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -O3")
+
+include_directories(.)
+
+add_executable(vmbuild ${SOURCES})
+
+# TODO: move install towards cmake
+
+install(TARGETS vmbuild DESTINATION bin)


### PR DESCRIPTION
add a fairly minimal CMakeLists.txt file for vmbuild.

Note: you have to pass in the to-be-used compiler through an environmental variable, i.e.

~~~ sh
$  mkdir build
$ cd build
$ CXX=`which clang++` cmake ./../vmbuild
$ make
$ make install
~~~

and make install currently installs into /usr/local/bin (can be changed with the PREFIX environmental variable). But this keeps the old build system intact, so it's mostly perfect for starting to test out a cmake-based build system.