### PR TITLE
Huge optimization for timers, solve ELF-related issue with symbol type

### DIFF
--- a/src/kernel/elf.cpp
+++ b/src/kernel/elf.cpp
@@ -109,12 +109,12 @@ public:
 
   Elf32_Addr getaddr(const std::string& name)
   {
-    for (size_t i = 0; i < symtab.entries; i++) {
-
-      //printf("sym %s\n", sym_name(&symtab[t].base[i]));
-      if (demangle( sym_name(&symtab.base[i]) ) == name)
-          return symtab.base[i].st_value;
-
+    for (size_t i = 0; i < symtab.entries; i++)
+    {
+      auto& sym = symtab.base[i];
+      //if (ELF32_ST_TYPE(sym.st_info) == STT_FUNC)
+      if (demangle( sym_name(&sym) ) == name)
+          return sym.st_value;
     }
     return 0;
   }
@@ -122,6 +122,7 @@ public:
   {
     for (size_t i = 0; i < symtab.entries; i++) {
 
+      if (ELF32_ST_TYPE(symtab.base[i].st_info) == STT_FUNC)
       if (addr >= symtab.base[i].st_value
       && (addr <  symtab.base[i].st_value + symtab.base[i].st_size))
           return &symtab.base[i];

--- a/src/kernel/timer.cpp
+++ b/src/kernel/timer.cpp
@@ -136,8 +136,8 @@ void Timers::timers_handler()
   while (!scheduled.empty())
   {
     auto it = scheduled.begin();
-    auto when   = it->first;
-    id_t id = it->second;
+    auto when = it->first;
+    id_t id   = it->second;
     
     // remove dead timers
     if (timers[id].deferred_destruct) {
@@ -155,33 +155,26 @@ void Timers::timers_handler()
         // erase immediately
         scheduled.erase(it);
         
-        // only process timer if still alive
-        if (timers[id].is_alive()) {
-          // call the users callback function
-          timers[id].callback(id);
-          // if the timers struct was modified in callback, eg. due to
-          // creating a timer, then the timer reference below would have
-          // been invalidated, hence why its BELOW, AND MUST STAY THERE
-          auto& timer = timers[id];
-          
-          // oneshot timers are automatically freed
-          if (timer.deferred_destruct || timer.is_oneshot())
-          {
-            timer.reset();
-            free_timers.push_back(id);
-          }
-          else if (timer.is_oneshot() == false)
-          {
-            // if the timer is recurring, we will simply reschedule it
-            // NOTE: we are carefully using (when + period) to avoid drift
-            scheduled.emplace(std::piecewise_construct,
-                      std::forward_as_tuple(when + timer.period),
-                      std::forward_as_tuple(id));
-          }
-        } else {
-          // timer was already dead
-          timers[id].reset();
+        // call the users callback function
+        timers[id].callback(id);
+        // if the timers struct was modified in callback, eg. due to
+        // creating a timer, then the timer reference below would have
+        // been invalidated, hence why its BELOW, AND MUST STAY THERE
+        auto& timer = timers[id];
+        
+        // oneshot timers are automatically freed
+        if (timer.deferred_destruct || timer.is_oneshot())
+        {
+          timer.reset();
           free_timers.push_back(id);
+        }
+        else if (timer.is_oneshot() == false)
+        {
+          // if the timer is recurring, we will simply reschedule it
+          // NOTE: we are carefully using (when + period) to avoid drift
+          scheduled.emplace(std::piecewise_construct,
+                    std::forward_as_tuple(when + timer.period),
+                    std::forward_as_tuple(id));
         }
         
       } else {

--- a/test/kernel/integration/timers/timers.cpp
+++ b/test/kernel/integration/timers/timers.cpp
@@ -99,12 +99,9 @@ void test_timers()
                 "After 25 sec, 1s timer x 30 == %i times, 2s timer x 15 == %i times",
                 repeat1, repeat2);
 
-      // Make sure this timer iterator is valid
-      Timers::stop(timer1s);
-      // there are still 2 timers left, because the stopped timer above
-      // will be removed deferred (when it would ordinarily trigger)
-      // ALSO: the current timer does not count towards the total active
-      CHECKSERT(Timers::active() == 2, "There are still 2 timers left");
+      // there are no timers active right now, because the current
+      // timer does not count towards the total active
+      CHECKSERT(Timers::active() == 0, "There are no timers left");
 
       Timers::oneshot(1s, 
       [] (auto) {

--- a/test/kernel/integration/timers/timers.cpp
+++ b/test/kernel/integration/timers/timers.cpp
@@ -29,13 +29,15 @@ static int repeat2 = 0;
 void test_timers()
 {
   INFO("Timers", "Testing one-shot timers");
+  // RTC is using a timer to calibrate itself over large periods of time
+  assert(Timers::active() == 1);
   
   // 30 sec. - Test End
   Timers::oneshot(30s, [] (auto) {
       printf("One-shots fired: %i \n", one_shots);
       CHECKSERT(one_shots == 5, "5 one-shot-timers fired");
       CHECKSERT(repeat1 == 25 and repeat2 == 10, "1s. timer fired 25 times, 2s. timer fired 10 times");
-      CHECKSERT(Timers::active() == 0, "This was the last active timer");
+      CHECKSERT(Timers::active() == 1, "This was the last active timer (except RTC)");
       INFO("Timers", "SUCCESS");
     });
 
@@ -99,9 +101,13 @@ void test_timers()
                 "After 25 sec, 1s timer x 30 == %i times, 2s timer x 15 == %i times",
                 repeat1, repeat2);
 
-      // there are no timers active right now, because the current
-      // timer does not count towards the total active
-      CHECKSERT(Timers::active() == 0, "There are no timers left");
+      // Make sure this timer iterator is valid
+      Timers::stop(timer1s);
+      // there are still 3 timers left, because the stopped timer above
+      // will be removed deferred (when it would ordinarily trigger)
+      // ALSO: the current timer does not count towards the total active
+      // AND: RTC uses a timer to calibrate itself over time
+      CHECKSERT(Timers::active() == 3, "There are still 3 timers left");
 
       Timers::oneshot(1s, 
       [] (auto) {


### PR DESCRIPTION
```
Conns/sec 5431.600000  Local clients 0  Timers: 1
*** Listing 12 results (104128 samples) ***
34.84%     36282: VirtioNet::handle_deferred_devices()
 5.39%      5616: VirtioNet::msix_xmit_handler()
 3.68%      3832: VirtioNet::msix_recv_handler()
 3.08%      3211: VirtioNet::recv_packet(unsigned char*, unsigned short)
 2.78%      2892: OS::default_rsprint(char const*, unsigned int)
 2.74%      2857: Timers::oneshot(std::__1::chrono::duration<long long, std::__1::ratio<1ll, 1000000ll> >, delegate<void (unsigned int)> const&)
 2.25%      2342: 0xc3f000ff
 2.12%      2208: net::TCP::bottom(std::__1::shared_ptr<net::Packet>)
 1.38%      1442: net::TCP::transmit(std::__1::shared_ptr<net::tcp::Packet>)
 1.07%      1119: void delegate<void (std::__1::shared_ptr<net::Packet>)>::method_stub<net::Arp, &(net::Arp::transmit(std::__1::shared_ptr<net::Packet>))>(void*, std::__1::shared_ptr<net::Packet>&&)
 1.07%      1112: void delegate<void ()>::method_stub<VirtioNet, &(VirtioNet::msix_recv_handler())>(void*)
 0.98%      1019: void delegate<void ()>::method_stub<VirtioNet, &(VirtioNet::msix_xmit_handler())>(void*)
 0.98%      1019: net::tcp::Connection::create_outgoing_packet()
*** ---------------------- ***
```