### PR TITLE
test: verify no clear bits can be found when all bits are set

### DIFF
--- a/test/util/unit/membitmap.cpp
+++ b/test/util/unit/membitmap.cpp
@@ -16,6 +16,7 @@ CASE( "All bits set in 32-bits of chunk data" )
   
   EXPECT( bmp.first_set() ==  0 );
   EXPECT( bmp.last_set()  == 31 );
+  EXPECT( bmp.first_free() == -1);
 }
 CASE( "Set and verify each individual bit in 32-bits chunk" )
 {


### PR DESCRIPTION
Increases test coverage for membitmap.hpp from 96.4% to 98.2%