### PR TITLE
profile: Move fixedvec into its own header file

### DIFF
--- a/api/utility/fixedvec.hpp
+++ b/api/utility/fixedvec.hpp
@@ -1,0 +1,66 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef UTIL_FIXEDVEC_HPP
+#define UTIL_FIXEDVEC_HPP
+
+/**
+ * High performance no-heap fixed vector
+ * 
+ **/
+
+#include <cstdint>
+#include <cstring>
+
+template <typename T, int N>
+struct fixedvector {
+  
+  void add(const T& e) noexcept {
+    element[count] = e;
+    count++;
+  }
+  
+  void clear() noexcept {
+    count = 0;
+  }
+  uint32_t size() const noexcept {
+    return count;
+  }
+  
+  T* first() noexcept {
+    return &element[0];
+  }
+  T* end() noexcept {
+    return &element[count];
+  }
+  
+  bool free_capacity() const noexcept {
+    return count < N;
+  }
+  
+  void clone(T* src, uint32_t size) {
+    memcpy(element, src, size * sizeof(T));
+    count = size;
+  }
+  
+  uint32_t count = 0;
+  T element[N];
+};
+
+
+#endif

--- a/src/kernel/profile.cpp
+++ b/src/kernel/profile.cpp
@@ -1,56 +1,36 @@
-#include <profile>
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+#include <profile>
 #include <common>
 #include <hw/pit.hpp>
 #include <kernel/elf.hpp>
 #include <kernel/irq_manager.hpp>
+#include <utility/fixedvec.hpp>
 #include <unordered_map>
 #include <cassert>
-#include <cstdint>
 #include <algorithm>
 
 #define BUFFER_COUNT    1024
-
-template <typename T, int N>
-struct fixedvector {
-  
-  void add(const T& e) noexcept {
-    assert(count < N);
-    element[count] = e;
-    count++;
-  }
-  
-  void clear() noexcept {
-    count = 0;
-  }
-  uint32_t size() const noexcept {
-    return count;
-  }
-  
-  T* first() noexcept {
-    return &element[0];
-  }
-  T* end() noexcept {
-    return &element[count];
-  }
-  
-  bool free_capacity() const noexcept {
-    return count < N;
-  }
-  
-  void clone(T* src, uint32_t size) {
-    memcpy(element, src, size * sizeof(T));
-    count = size;
-  }
-  
-  uint32_t count = 0;
-  T element[N];
-};
 static fixedvector<uintptr_t, BUFFER_COUNT>* sampler_queue;
 static fixedvector<uintptr_t, BUFFER_COUNT>* transfer_queue;
 
 typedef uint32_t func_sample;
-std::unordered_map<uintptr_t, func_sample> sampler_dict;
+static std::unordered_map<uintptr_t, func_sample> sampler_dict;
 static func_sample sampler_total = 0;
 static int  lockless_sampler = 0;
 static bool sampler_discard; // discard results as long as true


### PR DESCRIPTION
Fixed vector needs its own header in order to be testable