### PR TITLE
Add commandline argument support to Service::start

### DIFF
--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -125,8 +125,6 @@ public:
     return memmap_;
   };
 
-
-
 private:
 
   /** Process multiboot info. Called by 'start' if multibooted **/

--- a/api/kernel/service.hpp
+++ b/api/kernel/service.hpp
@@ -47,10 +47,17 @@ public:
    *        Your service should hook up event handlers to some of the events
    *        (like `Nic::on(HttpConnection, your_callback`))
    */
-  static void start();
-  
-  // ready is called when the kernel is done calibrating stuff and won't be 
-  // doing anything on its own anymore
+  static void start(const std::string&);
+
+  /**
+   * Returns the command-line provided to multiboot
+  **/
+  static const std::string& command_line();
+
+  /**
+   * Ready is called when the kernel is done calibrating stuff and won't be 
+   * doing anything on its own anymore
+  **/
   static void ready();
 
   /**

--- a/examples/STREAM/service.cpp
+++ b/examples/STREAM/service.cpp
@@ -24,7 +24,7 @@ double mysecond()
   return OS::uptime();
 }
 
-void Service::start()
+void Service::start(const std::string&)
 {
   std::cout << "*** Service is up - with OS Included! ***" << std::endl;
   

--- a/examples/demo_service/service.cpp
+++ b/examples/demo_service/service.cpp
@@ -65,7 +65,7 @@ std::string HTML_RESPONSE()
 
 const std::string NOT_FOUND = "HTTP/1.1 404 Not Found\nConnection: close\n\n";
 
-void Service::start()
+void Service::start(const std::string&)
 {
   // Stack with default network interface (eth0) driven by VirtioNet
   // Static IP configuration will get overwritten by DHCP, if found

--- a/examples/dualnic/service.cpp
+++ b/examples/dualnic/service.cpp
@@ -62,9 +62,8 @@ void create_server(net::tcp::Listener& server)
   });
 }
 
-void Service::start() {
-  srand(OS::cycles_since_boot());
-
+void Service::start(const std::string&)
+{
   // Two IP-stack objects
 
   // Stack with network interface (eth0) driven by VirtioNet

--- a/examples/smp/service.cpp
+++ b/examples/smp/service.cpp
@@ -19,7 +19,7 @@
 #include <cassert>
 #include <smp>
 
-void Service::start()
+void Service::start(const std::string&)
 {
   static int completed = 0;
   static uint32_t job = 0;

--- a/examples/snake/service.cpp
+++ b/examples/snake/service.cpp
@@ -45,7 +45,7 @@ void begin_snake()
   });
 }
 
-void Service::start()
+void Service::start(const std::string&)
 {
   // Redirect stdout to vga screen
   // ... even though we aren't really using it after the game starts

--- a/examples/tcp/service.cpp
+++ b/examples/tcp/service.cpp
@@ -51,7 +51,7 @@ void handle_python_on_read(Connection_ptr client, const std::string& response) {
   client->write(response);
 }
 
-void Service::start()
+void Service::start(const std::string&)
 {
   // Stack with default network interface (eth0) driven by VirtioNet
   // Static IP configuration will get overwritten by DHCP, if found

--- a/src/hw/acpi.cpp
+++ b/src/hw/acpi.cpp
@@ -173,7 +173,7 @@ namespace hw {
         this->hpet_base = sdt_ptr + sizeof(SDTHeader);
         break;
       case FACP_t:
-        printf("FACP found: P=%p L=%u\n", sdt, sdt->Length);
+        debug("FACP found: P=%p L=%u\n", sdt, sdt->Length);
         walk_facp((char*) sdt);
         break;
       default:
@@ -288,7 +288,7 @@ namespace hw {
        SLP_EN = 1<<13;
        SCI_EN = 1;
 
-       printf("ACPI: Found shutdown information\n");
+       debug("ACPI: Found shutdown information\n");
        return;
        
     } else {

--- a/test/fs/integration/bufstore/service.cpp
+++ b/test/fs/integration/bufstore/service.cpp
@@ -40,7 +40,7 @@ auto create_packet(BufferStore& bufstore) {
   return std::shared_ptr<Packet>(ptr);
 }
 
-void Service::start()
+void Service::start(const std::string&)
 {
   INFO("Test net::Packet","Starting tests");
 

--- a/test/fs/integration/fat16/fat16.cpp
+++ b/test/fs/integration/fat16/fat16.cpp
@@ -24,7 +24,7 @@
 // Includes std::string internal_banana
 #include "banana.ascii"
 
-void Service::start()
+void Service::start(const std::string&)
 {
   INFO("FAT16", "Running tests for FAT16");
   auto disk = fs::new_shared_memdisk();

--- a/test/fs/integration/fat32/fat32.cpp
+++ b/test/fs/integration/fat32/fat32.cpp
@@ -97,7 +97,7 @@ void test2() {
   });
 }
 
-void Service::start()
+void Service::start(const std::string&)
 {
   auto& device = hw::Dev::disk<1, VirtioBlk>();
   disk = std::make_shared<fs::Disk> (device);

--- a/test/fs/integration/memdisk/bigdisk.cpp
+++ b/test/fs/integration/memdisk/bigdisk.cpp
@@ -23,7 +23,7 @@
 
 const uint64_t SIZE = 256000;
 
-void Service::start()
+void Service::start(const std::string&)
 {
   INFO("MemDisk", "Running tests for MemDisk");
   auto disk = fs::new_shared_memdisk();

--- a/test/fs/integration/memdisk/nosector.cpp
+++ b/test/fs/integration/memdisk/nosector.cpp
@@ -21,7 +21,7 @@
 
 #include <memdisk>
 
-void Service::start()
+void Service::start(const std::string&)
 {
   INFO("MemDisk", "Running tests for MemDisk");
   auto disk = fs::new_shared_memdisk();

--- a/test/fs/integration/memdisk/twosector.cpp
+++ b/test/fs/integration/memdisk/twosector.cpp
@@ -21,7 +21,7 @@
 
 #include <memdisk>
 
-void Service::start()
+void Service::start(const std::string&)
 {
   INFO("MemDisk", "Running tests for MemDisk");
   auto disk = fs::new_shared_memdisk();

--- a/test/fs/integration/virtio_block/service.cpp
+++ b/test/fs/integration/virtio_block/service.cpp
@@ -25,7 +25,7 @@ void list_partitions(decltype(disk));
 
 #define MYINFO(X,...) INFO("VirtioBlk",X,##__VA_ARGS__)
 
-void Service::start()
+void Service::start(const std::string&)
 {
   // instantiate memdisk with FAT filesystem
   auto& device = hw::Dev::disk<1, VirtioBlk>();

--- a/test/hw/integration/cmos/service.cpp
+++ b/test/hw/integration/cmos/service.cpp
@@ -24,7 +24,7 @@
 
 using namespace std::chrono;
 
-void Service::start()
+void Service::start(const std::string&)
 {
 
   INFO("Test CMOS","Testing C runtime \n");

--- a/test/hw/integration/ide/service.cpp
+++ b/test/hw/integration/ide/service.cpp
@@ -21,7 +21,7 @@
 #include <fs/fat.hpp>
 #include <hw/ide.hpp>
 
-void Service::start()
+void Service::start(const std::string&)
 {
   printf("TESTING Disks\n\n");
 

--- a/test/hw/integration/serial/service.cpp
+++ b/test/hw/integration/serial/service.cpp
@@ -21,7 +21,7 @@
 
 using namespace std::chrono;
 
-void Service::start()
+void Service::start(const std::string&)
 {
 
   auto& com1 = hw::Serial::port<1>();

--- a/test/hw/integration/virtio_queue/service.cpp
+++ b/test/hw/integration/virtio_queue/service.cpp
@@ -28,12 +28,6 @@
 #include <lest.hpp>
 #include <virtio/virtio.hpp>
 
-int clock_gettime(clockid_t clk_id, struct timespec *tp){
-  (void*)clk_id;
-  (void*)tp;
-  return 0;
-};
-
 using namespace std;
 
 const lest::test virtio_tests[] = {
@@ -87,7 +81,7 @@ const lest::test virtio_tests[] = {
 
 #define MYINFO(X,...) INFO("Test STL",X,##__VA_ARGS__)
 
-void Service::start()
+void Service::start(const std::string&)
 {
 
   CHECK( lest::run(virtio_tests, {"-p"}) == 0, "All tests passed" );

--- a/test/kernel/integration/timers/service.cpp
+++ b/test/kernel/integration/timers/service.cpp
@@ -25,7 +25,7 @@ static int one_shots = 0;
 static int repeat1 = 0;
 static int repeat2 = 0;
 
-void Service::start()
+void Service::start(const std::string&)
 {
   INFO("Timers", "Testing one-shot timers");
   

--- a/test/mod/gsl/service.cpp
+++ b/test/mod/gsl/service.cpp
@@ -214,7 +214,7 @@ const lest::test test_basic_gsl[] = {
   },
 };
 
-void Service::start()
+void Service::start(const std::string&)
 {
   MYINFO ("Starting LEST-tests");
   // Lest takes command line params as vector
@@ -225,6 +225,4 @@ void Service::start()
   assert(not failed);
 
   MYINFO("SUCCESS");
-
-
 }

--- a/test/net/integration/ethernet/service.cpp
+++ b/test/net/integration/ethernet/service.cpp
@@ -19,7 +19,7 @@
 
 #include "ethernet_module_test.hpp"
 
-void Service::start()
+void Service::start(const std::string&)
 {
   const auto number_of_failed_tests = lest::run(ethernet_module_test, {"-p"});
 

--- a/test/net/integration/ipv4/service.cpp
+++ b/test/net/integration/ipv4/service.cpp
@@ -19,7 +19,7 @@
 
 #include "ipv4_module_test.hpp"
 
-void Service::start()
+void Service::start(const std::string&)
 {
   const auto number_of_failed_tests = lest::run(ipv4_module_test, {"-p"});
 

--- a/test/net/integration/tcp/service.cpp
+++ b/test/net/integration/tcp/service.cpp
@@ -130,7 +130,7 @@ struct Buffer {
   std::string str() { return {data, size};}
 };
 
-void Service::start()
+void Service::start(const std::string&)
 {
   IP4::addr A1 (255, 255, 255, 255);
   IP4::addr B1 (  0, 255, 255, 255);

--- a/test/net/integration/transmit/service.cpp
+++ b/test/net/integration/transmit/service.cpp
@@ -24,7 +24,7 @@ using namespace std;
 using namespace net;
 auto& timer = hw::PIT::instance();
 
-void Service::start()
+void Service::start(const std::string&)
 {
   static auto inet =
     net::new_ipv4_stack<>({ 10,0,0,42 },      // IP

--- a/test/net/integration/udp/service.cpp
+++ b/test/net/integration/udp/service.cpp
@@ -24,7 +24,7 @@
 using namespace net;
 std::unique_ptr<Inet4<VirtioNet> > inet;
 
-void Service::start()
+void Service::start(const std::string&)
 {
   inet = new_ipv4_stack(
       {  10,  0,  0, 42 },   // IP

--- a/test/stl/integration/crt/service.cpp
+++ b/test/stl/integration/crt/service.cpp
@@ -52,9 +52,8 @@ __attribute__ ((constructor)) void foo(void)
 
 
 
-void Service::start()
+void Service::start(const std::string&)
 {
-
   INFO("Test CRT","Testing C runtime \n");
 
   CHECKSERT(_test_glob3 == 0xfa7ca7, "Global C constructors in service");
@@ -69,5 +68,4 @@ void Service::start()
 
 
   INFO("Test CRT", "SUCCESS");
-
 }

--- a/test/stl/integration/exceptions/service.cpp
+++ b/test/stl/integration/exceptions/service.cpp
@@ -62,7 +62,7 @@ const lest::test tests[] = {
   },
 };
 
-void Service::start()
+void Service::start(const std::string&)
 {
   MYINFO ("Running LEST-tests");
   auto failed = lest::run(tests, {"-p"});

--- a/test/stl/integration/stl/service.cpp
+++ b/test/stl/integration/stl/service.cpp
@@ -92,9 +92,8 @@ const lest::test specification[] =
 
 #define MYINFO(X,...) INFO("Test STL",X,##__VA_ARGS__)
 
-void Service::start()
+void Service::start(const std::string&)
 {
-
   // Wonder when these are used...?
   std::set_terminate([](){ printf("CUSTOM TERMINATE Handler \n"); });
   std::set_new_handler([](){ printf("CUSTOM NEW Handler \n"); });

--- a/test/stress/stress/service.cpp
+++ b/test/stress/stress/service.cpp
@@ -69,12 +69,11 @@ std::string html() {
 
 const std::string NOT_FOUND = "HTTP/1.1 404 Not Found \n Connection: close\n\n";
 
-extern char _end;
-
 uint64_t TCP_BYTES_RECV = 0;
 uint64_t TCP_BYTES_SENT = 0;
 
-void Service::start() {
+void Service::start(const std::string&)
+{
   // Assign a driver (VirtioNet) to a network interface (eth0)
   // @note: We could determine the appropirate driver dynamically, but then we'd
   // have to include all the drivers into the image, which  we want to avoid.


### PR DESCRIPTION
`void Service::start(const std::string& args);`

Not split into separate arguments because we will probably just send in JSON string.