### PR TITLE
[build] Build libos.a as and unikernels within /example with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+project (includeos)
+
+# TODO: should this not be moved into the library itself
+set(INCLUDEOS_INSTALL_DIR $ENV{HOME}/IncludeOS_install/)
+set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+# get new stack protector value
+execute_process(COMMAND awk "BEGIN{srand(); print int(rand()*65536)}"
+                OUTPUT_VARIABLE STACK_PROTECTOR_VALUE)
+string(STRIP ${STACK_PROTECTOR_VALUE} STACK_PROTECTOR_VALUE)
+
+# stackrealign is needed to guarantee 16-byte stack alignment for SSE
+# the compiler seems to be really dumb in this regard, creating a misaligned stack left and right
+set(COMMON_CAPABS "-mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=${STACK_PROTECTOR_VALUE}")
+
+# Various global defines
+# * NO_DEBUG Disables  output from the debug macro
+# * OS_TERMINATE_ON_CONTRACT_VIOLATION provides classic assert-like output from Expects / Ensures
+# * _GNU_SOURCE enables POSIX-extensions in newlib, such as strnlen. ("everything newlib has", ref. cdefs.h)
+set(CAPABS "${COMMON_CAPABS} -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE")
+set(WARNS  "-Wall -Wextra") #-pedantic
+set(DEBUG_OPTS "-ggdb3")
+
+# these kinda work with llvm
+set(CMAKE_CXX_FLAGS "-MMD -target i686-elf ${CAPABS} ${WARNS} -c -m32 -std=c++14 -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION=\"\\\"v0.8.1-709-gf8fccf4\\\"\"")
+set(CMAKE_C_FLAGS "-MMD -target i686-elf ${CAPABS} ${WARNS} -c -m32  -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION=\"\\\"v0.8.1-709-gf8fccf4\\\"\"")
+
+# TODO: use right variables
+option(debug "Build with debugging symbols (OBS: Dramatically increases binary size)" OFF)
+if(debug)
+	list(append CAPABS "-O0")
+	list(append CMAKE_CXX_FLAGS ${DEBUG_OPTS})
+	list(append CPPOPTS "-DGSL_THROW_ON_CONTRACT_VIOLATION")
+endif(debug)
+
+add_subdirectory(src)
+add_subdirectory(vmbuild)
+
+option(examples "Build example unikernels in /examples" ON)
+if(examples)
+	add_subdirectory(examples)
+endif(examples)

--- a/examples/256_color_vga/CMakeLists.txt
+++ b/examples/256_color_vga/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(SERVICE_NAME "\"\\\"IncludeOS Demo Service\\\"\"")
+set(SERVICE "IncludeOS_256_color_vga")
+
+enable_language(ASM_NASM)
+
+# TODO: fix parameter pollution
+set(CMAKE_ASM_NASM_COMPILE_OBJECT "<CMAKE_ASM_NASM_COMPILER> -f elf32 -o <OBJECT> <SOURCE>")
+
+set(SERVICE_SOURCES service.cpp int32.asm ${INCLUDEOS_INSTALL_DIR}/service_name.cpp)
+
+add_executable(256_color_vga ${SERVICE_SOURCES} $<TARGET_OBJECTS:multiboot>)
+
+set_target_properties(256_color_vga PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE_NAME=${SERVICE_NAME}")
+
+set_target_properties(256_color_vga PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
+
+target_link_libraries(256_color_vga ${EXAMPLE_COMMON_LIBRARIES})
+
+add_custom_command(
+	OUTPUT ${SERVICE}.img
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/elf_syms 256_color_vga
+	COMMAND objcopy --update-section .elf_symbols=_elf_symbols.bin 256_color_vga 256_color_vga
+	COMMAND strip --strip-all --remove-section=.comment 256_color_vga
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${CMAKE_BINARY_DIR}/examples/256_color_vga/256_color_vga ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS 256_color_vga
+)
+
+add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(EXAMPLE_CLANG_OPTIONS -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14 -I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/ -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE)
-set(EXAMPLE_LD_OPTIONS -nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld --defsym=__stack_rand_ba=${STACK_PROTECTOR_VALUE} ${INCLUDEOS_INSTALL_DIR}/crt/crtbegin.o ${INCLUDEOS_INSTALL_DIR}/crt/crti.o ${INCLUDEOS_INSTALL_DIR}/multiboot.o)
+
+set(MAX_MEM 128)
+set(EXAMPLE_LD_OPTIONS -nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld --defsym=_MAX_MEM_MIB_=${MAX_MEM} --defsym=__stack_rand_ba=${STACK_PROTECTOR_VALUE} ${INCLUDEOS_INSTALL_DIR}/crt/crtbegin.o ${INCLUDEOS_INSTALL_DIR}/crt/crti.o ${INCLUDEOS_INSTALL_DIR}/multiboot.o)
+
 set(EXAMPLE_LD_LIBS ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/libcxx/libc++.a ${CMAKE_BINARY_DIR}/src/liblibc++abi.a.a ${CMAKE_BINARY_DIR}/src/drivers/libdrivers.a ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/newlib/libc.a ${INCLUDEOS_INSTALL_DIR}/newlib/libm.a ${INCLUDEOS_INSTALL_DIR}/libgcc/libgcc.a ${INCLUDEOS_INSTALL_DIR}/crt/crtend.o ${INCLUDEOS_INSTALL_DIR}/crt/crtn.o)
 
 add_subdirectory(demo_service)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(EXAMPLE_CLANG_OPTIONS -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14 -I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/ -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE)
+set(EXAMPLE_LD_OPTIONS -nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld --defsym=__stack_rand_ba=${STACK_PROTECTOR_VALUE} ${INCLUDEOS_INSTALL_DIR}/crt/crtbegin.o ${INCLUDEOS_INSTALL_DIR}/crt/crti.o ${INCLUDEOS_INSTALL_DIR}/multiboot.o)
+set(EXAMPLE_LD_LIBS ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/libcxx/libc++.a ${CMAKE_BINARY_DIR}/src/liblibc++abi.a.a ${CMAKE_BINARY_DIR}/src/drivers/libdrivers.a ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/newlib/libc.a ${INCLUDEOS_INSTALL_DIR}/newlib/libm.a ${INCLUDEOS_INSTALL_DIR}/libgcc/libgcc.a ${INCLUDEOS_INSTALL_DIR}/crt/crtend.o ${INCLUDEOS_INSTALL_DIR}/crt/crtn.o)
+
+add_subdirectory(demo_service)
+add_subdirectory(dualnic)
+add_subdirectory(smp)
+add_subdirectory(snake)
+#add_subdirectory(STREAM)
+add_subdirectory(tcp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,18 @@
-set(EXAMPLE_CLANG_OPTIONS -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14 -I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/ -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE)
-
 set(MAX_MEM 128)
-set(EXAMPLE_LD_OPTIONS -nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld --defsym=_MAX_MEM_MIB_=${MAX_MEM} --defsym=__stack_rand_ba=${STACK_PROTECTOR_VALUE} ${INCLUDEOS_INSTALL_DIR}/crt/crtbegin.o ${INCLUDEOS_INSTALL_DIR}/crt/crti.o ${INCLUDEOS_INSTALL_DIR}/multiboot.o)
 
-set(EXAMPLE_LD_LIBS ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/libcxx/libc++.a ${CMAKE_BINARY_DIR}/src/liblibc++abi.a.a ${CMAKE_BINARY_DIR}/src/drivers/libdrivers.a ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/newlib/libc.a ${INCLUDEOS_INSTALL_DIR}/newlib/libm.a ${INCLUDEOS_INSTALL_DIR}/libgcc/libgcc.a ${INCLUDEOS_INSTALL_DIR}/crt/crtend.o ${INCLUDEOS_INSTALL_DIR}/crt/crtn.o)
+SET(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS) # this removed -rdynamic from linker output
+SET(CMAKE_CXX_LINK_EXECUTABLE "/usr/bin/ld <OBJECTS> -o  <TARGET> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <LINK_LIBRARIES>")
+
+set(BUILD_SHARED_LIBRARIES OFF)
+set(CMAKE_EXE_LINKER_FLAGS "-static")
+
+set(EXAMPLE_COMPILE_FLAGS "-target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14  -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE")
+
+set(EXAMPLE_LINK_FLAGS "-nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld --defsym=_MAX_MEM_MIB_=${MAX_MEM} --defsym=__stack_rand_ba=${STACK_PROTECTOR_VALUE} ${INCLUDEOS_INSTALL_DIR}/crt/crtbegin.o ${INCLUDEOS_INSTALL_DIR}/crt/crti.o")
+
+set(EXAMPLE_INCLUDES "-I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/")
+
+set(EXAMPLE_COMMON_LIBRARIES os ${INCLUDEOS_INSTALL_DIR}/libcxx/libc++.a libc++abi.a drivers os ${INCLUDEOS_INSTALL_DIR}/newlib/libc.a ${INCLUDEOS_INSTALL_DIR}/newlib/libm.a ${INCLUDEOS_INSTALL_DIR}/libgcc/libgcc.a ${INCLUDEOS_INSTALL_DIR}/crt/crtend.o ${INCLUDEOS_INSTALL_DIR}/crt/crtn.o)
 
 add_subdirectory(demo_service)
 add_subdirectory(dualnic)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,9 +14,10 @@ set(EXAMPLE_INCLUDES "-I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_IN
 
 set(EXAMPLE_COMMON_LIBRARIES os ${INCLUDEOS_INSTALL_DIR}/libcxx/libc++.a libc++abi.a drivers os ${INCLUDEOS_INSTALL_DIR}/newlib/libc.a ${INCLUDEOS_INSTALL_DIR}/newlib/libm.a ${INCLUDEOS_INSTALL_DIR}/libgcc/libgcc.a ${INCLUDEOS_INSTALL_DIR}/crt/crtend.o ${INCLUDEOS_INSTALL_DIR}/crt/crtn.o)
 
+add_subdirectory(256_color_vga)
 add_subdirectory(demo_service)
 add_subdirectory(dualnic)
 add_subdirectory(smp)
 add_subdirectory(snake)
-#add_subdirectory(STREAM)
+add_subdirectory(STREAM)
 add_subdirectory(tcp)

--- a/examples/STREAM/CMakeLists.txt
+++ b/examples/STREAM/CMakeLists.txt
@@ -1,18 +1,23 @@
-# this is a very ugly hack. I wanted to build a test service to have
-# something to check basic functionality against.
-#
-# TODO: use direct library references, remove add_custom_command
-
-set(SERVICE_NAME "\"\\\"STREAM Memory Benchmark\\\"\"")
+set(SERVICE_NAME "\"\\\"Dual NIC Demo Service\\\"\"")
 set(SERVICE "STREAM")
+
+set(SERVICE_SOURCES service.cpp stream.cpp ${INCLUDEOS_INSTALL_DIR}/service_name.cpp)
+
+add_executable(STREAM ${SERVICE_SOURCES} $<TARGET_OBJECTS:multiboot>)
+
+set_target_properties(STREAM PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE_NAME=${SERVICE_NAME}")
+
+set_target_properties(STREAM PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
+
+target_link_libraries(STREAM ${EXAMPLE_COMMON_LIBRARIES})
 
 add_custom_command(
 	OUTPUT ${SERVICE}.img
-	COMMAND /usr/bin/clang++ -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14 -I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/ -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/stream.cpp
-	COMMAND /usr/bin/clang++ -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14 -I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/ -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
-	COMMAND ld -nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld ${INCLUDEOS_INSTALL_DIR}/crt/crtbegin.o ${INCLUDEOS_INSTALL_DIR}/crt/crti.o ${INCLUDEOS_INSTALL_DIR}/multiboot.o service.o .service_name.o ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/libcxx/libc++.a ${CMAKE_BINARY_DIR}/src/liblibc++abi.a.a ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/newlib/libc.a ${INCLUDEOS_INSTALL_DIR}/newlib/libm.a ${INCLUDEOS_INSTALL_DIR}/libgcc/libgcc.a ${INCLUDEOS_INSTALL_DIR}/crt/crtend.o ${INCLUDEOS_INSTALL_DIR}/crt/crtn.o -o ${SERVICE}
-	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
-	DEPENDS service.cpp
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/elf_syms STREAM
+	COMMAND objcopy --update-section .elf_symbols=_elf_symbols.bin STREAM STREAM
+	COMMAND strip --strip-all --remove-section=.comment STREAM
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${CMAKE_BINARY_DIR}/examples/STREAM/STREAM ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS STREAM
 )
 
-add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)
+add_custom_target(${SERVICE}_img ALL DEPENDS ${SERVICE}.img)

--- a/examples/STREAM/CMakeLists.txt
+++ b/examples/STREAM/CMakeLists.txt
@@ -1,0 +1,18 @@
+# this is a very ugly hack. I wanted to build a test service to have
+# something to check basic functionality against.
+#
+# TODO: use direct library references, remove add_custom_command
+
+set(SERVICE_NAME "\"\\\"STREAM Memory Benchmark\\\"\"")
+set(SERVICE "STREAM")
+
+add_custom_command(
+	OUTPUT ${SERVICE}.img
+	COMMAND /usr/bin/clang++ -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14 -I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/ -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/stream.cpp
+	COMMAND /usr/bin/clang++ -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra  -c -m32 -std=c++14 -I${INCLUDEOS_INSTALL_DIR}/libcxx/include -I${INCLUDEOS_INSTALL_DIR}/api/sys -I${INCLUDEOS_INSTALL_DIR}/newlib/include -I${INCLUDEOS_INSTALL_DIR}/api -I${INCLUDEOS_INSTALL_DIR}/mod/GSL/ -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
+	COMMAND ld -nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld ${INCLUDEOS_INSTALL_DIR}/crt/crtbegin.o ${INCLUDEOS_INSTALL_DIR}/crt/crti.o ${INCLUDEOS_INSTALL_DIR}/multiboot.o service.o .service_name.o ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/libcxx/libc++.a ${CMAKE_BINARY_DIR}/src/liblibc++abi.a.a ${CMAKE_BINARY_DIR}/src/libos.a ${INCLUDEOS_INSTALL_DIR}/newlib/libc.a ${INCLUDEOS_INSTALL_DIR}/newlib/libm.a ${INCLUDEOS_INSTALL_DIR}/libgcc/libgcc.a ${INCLUDEOS_INSTALL_DIR}/crt/crtend.o ${INCLUDEOS_INSTALL_DIR}/crt/crtn.o -o ${SERVICE}
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS service.cpp
+)
+
+add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/demo_service/CMakeLists.txt
+++ b/examples/demo_service/CMakeLists.txt
@@ -1,18 +1,23 @@
-# this is a very ugly hack. I wanted to build a test service to have
-# something to check basic functionality against.
-#
-# TODO: use direct library references, remove add_custom_command
-
 set(SERVICE_NAME "\"\\\"IncludeOS Demo Service\\\"\"")
 set(SERVICE "IncludeOS_Demo_Service")
 
+set(SERVICE_SOURCES service.cpp ${INCLUDEOS_INSTALL_DIR}/service_name.cpp)
+
+add_executable(test_service ${SERVICE_SOURCES} $<TARGET_OBJECTS:multiboot>)
+
+set_target_properties(test_service PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE_NAME=${SERVICE_NAME}")
+
+set_target_properties(test_service PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
+
+target_link_libraries(test_service ${EXAMPLE_COMMON_LIBRARIES})
+
 add_custom_command(
 	OUTPUT ${SERVICE}.img
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
-	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE}
-	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
-	DEPENDS service.cpp
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/elf_syms test_service
+	COMMAND objcopy --update-section .elf_symbols=_elf_symbols.bin test_service test_service
+	COMMAND strip --strip-all --remove-section=.comment test_service
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${CMAKE_BINARY_DIR}/examples/demo_service/test_service ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS test_service
 )
 
 add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/demo_service/CMakeLists.txt
+++ b/examples/demo_service/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
 	OUTPUT ${SERVICE}.img
 	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
 	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
-	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
+	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE}
 	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
 	DEPENDS service.cpp
 )

--- a/examples/demo_service/CMakeLists.txt
+++ b/examples/demo_service/CMakeLists.txt
@@ -1,0 +1,18 @@
+# this is a very ugly hack. I wanted to build a test service to have
+# something to check basic functionality against.
+#
+# TODO: use direct library references, remove add_custom_command
+
+set(SERVICE_NAME "\"\\\"IncludeOS Demo Service\\\"\"")
+set(SERVICE "IncludeOS_Demo_Service")
+
+add_custom_command(
+	OUTPUT ${SERVICE}.img
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
+	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS service.cpp
+)
+
+add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/dualnic/CMakeLists.txt
+++ b/examples/dualnic/CMakeLists.txt
@@ -1,18 +1,23 @@
-# this is a very ugly hack. I wanted to build a test service to have
-# something to check basic functionality against.
-#
-# TODO: use direct library references, remove add_custom_command
-
 set(SERVICE_NAME "\"\\\"Dual NIC Demo Service\\\"\"")
-set(SERVICE "dualnic")
+set(SERVICE "dual_nic_service")
+
+set(SERVICE_SOURCES service.cpp ${INCLUDEOS_INSTALL_DIR}/service_name.cpp)
+
+add_executable(dual_nic_service ${SERVICE_SOURCES} $<TARGET_OBJECTS:multiboot>)
+
+set_target_properties(dual_nic_service PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE_NAME=${SERVICE_NAME}")
+
+set_target_properties(dual_nic_service PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
+
+target_link_libraries(dual_nic_service ${EXAMPLE_COMMON_LIBRARIES})
 
 add_custom_command(
 	OUTPUT ${SERVICE}.img
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
-	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
-	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
-	DEPENDS service.cpp
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/elf_syms dual_nic_service
+	COMMAND objcopy --update-section .elf_symbols=_elf_symbols.bin dual_nic_service dual_nic_service
+	COMMAND strip --strip-all --remove-section=.comment dual_nic_service
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${CMAKE_BINARY_DIR}/examples/dualnic/dual_nic_service ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS dual_nic_service
 )
 
-add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)
+add_custom_target(${SERVICE}_img ALL DEPENDS ${SERVICE}.img)

--- a/examples/dualnic/CMakeLists.txt
+++ b/examples/dualnic/CMakeLists.txt
@@ -1,0 +1,18 @@
+# this is a very ugly hack. I wanted to build a test service to have
+# something to check basic functionality against.
+#
+# TODO: use direct library references, remove add_custom_command
+
+set(SERVICE_NAME "\"\\\"Dual NIC Demo Service\\\"\"")
+set(SERVICE "dualnic")
+
+add_custom_command(
+	OUTPUT ${SERVICE}.img
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
+	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS service.cpp
+)
+
+add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/smp/CMakeLists.txt
+++ b/examples/smp/CMakeLists.txt
@@ -1,0 +1,19 @@
+# this is a very ugly hack. I wanted to build a test service to have
+# something to check basic functionality against.
+#
+# TODO: use direct library references, remove add_custom_command
+
+set(SERVICE_NAME "\"\\\"SMP Example Service\\\"\"")
+set(SERVICE "SMP")
+
+add_custom_command(
+	OUTPUT ${SERVICE}.img
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
+	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS service.cpp
+	OUTPUT ${SERVICE}.img
+)
+
+add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/smp/CMakeLists.txt
+++ b/examples/smp/CMakeLists.txt
@@ -1,19 +1,23 @@
-# this is a very ugly hack. I wanted to build a test service to have
-# something to check basic functionality against.
-#
-# TODO: use direct library references, remove add_custom_command
+set(SERVICE_NAME "\"\\\"Dual NIC Demo Service\\\"\"")
+set(SERVICE "smp_service")
 
-set(SERVICE_NAME "\"\\\"SMP Example Service\\\"\"")
-set(SERVICE "SMP")
+set(SERVICE_SOURCES service.cpp ${INCLUDEOS_INSTALL_DIR}/service_name.cpp)
+
+add_executable(smp_service ${SERVICE_SOURCES} $<TARGET_OBJECTS:multiboot>)
+
+set_target_properties(smp_service PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE_NAME=${SERVICE_NAME}")
+
+set_target_properties(smp_service PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
+
+target_link_libraries(smp_service ${EXAMPLE_COMMON_LIBRARIES})
 
 add_custom_command(
 	OUTPUT ${SERVICE}.img
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
-	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
-	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
-	DEPENDS service.cpp
-	OUTPUT ${SERVICE}.img
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/elf_syms smp_service
+	COMMAND objcopy --update-section .elf_symbols=_elf_symbols.bin smp_service smp_service
+	COMMAND strip --strip-all --remove-section=.comment smp_service
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${CMAKE_BINARY_DIR}/examples/smp/smp_service ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS smp_service
 )
 
-add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)
+add_custom_target(${SERVICE}_img ALL DEPENDS ${SERVICE}.img)

--- a/examples/snake/CMakeLists.txt
+++ b/examples/snake/CMakeLists.txt
@@ -1,0 +1,18 @@
+# this is a very ugly hack. I wanted to build a test service to have
+# something to check basic functionality against.
+#
+# TODO: use direct library references, remove add_custom_command
+
+set(SERVICE_NAME "\"\\\"Snake Example Service\\\"\"")
+set(SERVICE "Snake")
+
+add_custom_command(
+	OUTPUT ${SERVICE}.img
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
+	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS service.cpp
+)
+
+add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/snake/CMakeLists.txt
+++ b/examples/snake/CMakeLists.txt
@@ -1,18 +1,23 @@
-# this is a very ugly hack. I wanted to build a test service to have
-# something to check basic functionality against.
-#
-# TODO: use direct library references, remove add_custom_command
+set(SERVICE_NAME "\"\\\"Dual NIC Demo Service\\\"\"")
+set(SERVICE "snake")
 
-set(SERVICE_NAME "\"\\\"Snake Example Service\\\"\"")
-set(SERVICE "Snake")
+set(SERVICE_SOURCES service.cpp ${INCLUDEOS_INSTALL_DIR}/service_name.cpp)
+
+add_executable(snake ${SERVICE_SOURCES} $<TARGET_OBJECTS:multiboot>)
+
+set_target_properties(snake PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE_NAME=${SERVICE_NAME}")
+
+set_target_properties(snake PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
+
+target_link_libraries(snake ${EXAMPLE_COMMON_LIBRARIES})
 
 add_custom_command(
 	OUTPUT ${SERVICE}.img
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
-	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
-	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
-	DEPENDS service.cpp
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/elf_syms snake
+	COMMAND objcopy --update-section .elf_symbols=_elf_symbols.bin snake snake
+	COMMAND strip --strip-all --remove-section=.comment snake
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${CMAKE_BINARY_DIR}/examples/snake/snake ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS snake
 )
 
-add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)
+add_custom_target(${SERVICE}_img ALL DEPENDS ${SERVICE}.img)

--- a/examples/tcp/CMakeLists.txt
+++ b/examples/tcp/CMakeLists.txt
@@ -1,0 +1,18 @@
+# this is a very ugly hack. I wanted to build a test service to have
+# something to check basic functionality against.
+#
+# TODO: use direct library references, remove add_custom_command
+
+set(SERVICE_NAME "\"\\\"IncludeOS TCP Demo\\\"\"")
+set(SERVICE "tcp_demo")
+
+add_custom_command(
+	OUTPUT ${SERVICE}.img
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
+	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
+	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS service.cpp
+)
+
+add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)

--- a/examples/tcp/CMakeLists.txt
+++ b/examples/tcp/CMakeLists.txt
@@ -1,18 +1,23 @@
-# this is a very ugly hack. I wanted to build a test service to have
-# something to check basic functionality against.
-#
-# TODO: use direct library references, remove add_custom_command
+set(SERVICE_NAME "\"\\\"Dual NIC Demo Service\\\"\"")
+set(SERVICE "tcp")
 
-set(SERVICE_NAME "\"\\\"IncludeOS TCP Demo\\\"\"")
-set(SERVICE "tcp_demo")
+set(SERVICE_SOURCES service.cpp ${INCLUDEOS_INSTALL_DIR}/service_name.cpp)
+
+add_executable(tcp ${SERVICE_SOURCES} $<TARGET_OBJECTS:multiboot>)
+
+set_target_properties(tcp PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE_NAME=${SERVICE_NAME}")
+
+set_target_properties(tcp PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
+
+target_link_libraries(tcp ${EXAMPLE_COMMON_LIBRARIES})
 
 add_custom_command(
 	OUTPUT ${SERVICE}.img
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -o service.o ${CMAKE_CURRENT_SOURCE_DIR}/service.cpp
-	COMMAND /usr/bin/clang++ ${EXAMPLE_CLANG_OPTIONS} -DSERVICE_NAME="${SERVICE_NAME}" -o .service_name.o ${INCLUDEOS_INSTALL_DIR}/service_name.cpp
-	COMMAND ld ${EXAMPLE_LD_OPTIONS} service.o .service_name.o ${EXAMPLE_LD_LIBS} -o ${SERVICE} #${CMAKE_BINARY_DIR}/drivers/virtionet.o 
-	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${SERVICE} ${CMAKE_BINARY_DIR}/src/boot/bootloader
-	DEPENDS service.cpp
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/elf_syms tcp
+	COMMAND objcopy --update-section .elf_symbols=_elf_symbols.bin tcp tcp
+	COMMAND strip --strip-all --remove-section=.comment tcp
+	COMMAND ${CMAKE_BINARY_DIR}/vmbuild/vmbuild ${CMAKE_BINARY_DIR}/examples/tcp/tcp ${CMAKE_BINARY_DIR}/src/boot/bootloader
+	DEPENDS tcp
 )
 
-add_custom_target(${SERVICE} ALL DEPENDS ${SERVICE}.img)
+add_custom_target(${SERVICE}_img ALL DEPENDS ${SERVICE}.img)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,14 +17,15 @@ add_custom_command(
 
 # TODO: i wanted to use a glob, but then found out that not everything is included
 set(OS_OBJECTS  kernel/start.asm kernel/kernel_start.cpp kernel/syscalls.cpp
-		kernel/interrupts.asm kernel/os.cpp kernel/cpuid.cpp kernel/memmap.cpp
-		kernel/irq_manager.cpp kernel/pci_manager.cpp
+		kernel/interrupts.asm kernel/os.cpp kernel/os_stdout.cpp kernel/cpuid.cpp
+		kernel/memmap.cpp kernel/irq_manager.cpp kernel/pci_manager.cpp
 		kernel/elf.cpp kernel/terminal.cpp kernel/terminal_disk.cpp
-		kernel/vga.cpp kernel/debug_new.cpp kernel/profile.cpp
-		kernel/timer.cpp kernel/rtc.cpp util/memstream.c util/async.cpp
+		kernel/vga.cpp kernel/debug_new.cpp
+		kernel/profile.cpp kernel/profile_intr.asm
+		kernel/timers.cpp kernel/rtc.cpp util/memstream.c util/async.cpp util/statman.cpp
 		crt/c_abi.c crt/string.c crt/quick_exit.cpp crt/cxx_abi.cpp crt/mman.cpp
 		hw/ide.cpp hw/pit.cpp hw/pic.cpp hw/pci_device.cpp hw/cpu_freq_sampling.cpp
-		hw/ps2.cpp hw/serial.cpp hw/cmos.cpp
+		hw/ps2.cpp hw/serial.cpp hw/cmos.cpp hw/drive.cpp
 		hw/acpi.cpp hw/apic.cpp hw/apic_timer.cpp hw/ioapic.cpp hw/apic_asm.asm
 		hw/apic_revenant.cpp hw/msi.cpp hw/pci_msi.cpp
 		virtio/virtio.cpp virtio/virtio_queue.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,12 +41,11 @@ set(OS_OBJECTS  kernel/start.asm kernel/kernel_start.cpp kernel/syscalls.cpp
 
 add_library(os STATIC ${OS_OBJECTS} apic_boot.o)
 
-# try to build CXXABI:
-# TODO: shouldn't we move that into a new CMakeLists.txt file?
-
 file(GLOB CXX_ABI crt/cxxabi/*.cpp)
 
 add_library(libc++abi.a STATIC ${CXX_ABI})
+
+add_library(libcrt OBJECT crt/crti.s crt/crtn.s)
 
 add_subdirectory(boot)
 add_subdirectory(drivers)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,62 @@
+set(CMAKE_ASM_NASM_OBJECT_FORMAT "elf")
+enable_language(ASM_NASM)
+
+include_directories(${INCLUDEOS_ROOT}/api/sys)
+include_directories(${INCLUDEOS_INSTALL_DIR}/libcxx/include)
+include_directories(${INCLUDEOS_INSTALL_DIR}/newlib/include)
+include_directories(${INCLUDEOS_ROOT}/src/include)
+include_directories(${INCLUDEOS_ROOT}/api)
+include_directories(${INCLUDEOS_ROOT}/mod/GSL/)
+
+add_custom_command(
+	OUTPUT apic_boot.o
+	COMMAND nasm -f bin -o apic_boot.bin ${CMAKE_CURRENT_SOURCE_DIR}/hw/apic_boot.asm
+	COMMAND objcopy -I binary -O elf32-i386 -B i386 apic_boot.bin apic_boot.o
+	DEPENDS hw/apic_boot.asm
+)
+
+# TODO: i wanted to use a glob, but then found out that not everything is included
+set(OS_OBJECTS  kernel/start.asm kernel/kernel_start.cpp kernel/syscalls.cpp
+		kernel/interrupts.asm kernel/os.cpp kernel/cpuid.cpp kernel/memmap.cpp
+		kernel/irq_manager.cpp kernel/pci_manager.cpp
+		kernel/elf.cpp kernel/terminal.cpp kernel/terminal_disk.cpp
+		kernel/vga.cpp kernel/debug_new.cpp kernel/profile.cpp
+		kernel/timer.cpp kernel/rtc.cpp util/memstream.c util/async.cpp
+		crt/c_abi.c crt/string.c crt/quick_exit.cpp crt/cxx_abi.cpp crt/mman.cpp
+		hw/ide.cpp hw/pit.cpp hw/pic.cpp hw/pci_device.cpp hw/cpu_freq_sampling.cpp
+		hw/ps2.cpp hw/serial.cpp hw/cmos.cpp
+		hw/acpi.cpp hw/apic.cpp hw/apic_timer.cpp hw/ioapic.cpp hw/apic_asm.asm
+		hw/apic_revenant.cpp hw/msi.cpp hw/pci_msi.cpp
+		virtio/virtio.cpp virtio/virtio_queue.cpp
+		net/ethernet.cpp net/inet_common.cpp net/ip4/arp.cpp net/ip4/ip4.cpp
+		net/tcp/tcp.cpp net/tcp/connection.cpp net/tcp/connection_states.cpp
+		net/tcp/rttm.cpp net/tcp/listener.cpp
+		net/ip4/icmpv4.cpp net/ip4/udp.cpp net/ip4/udp_socket.cpp
+		net/dns/dns.cpp net/dns/client.cpp net/dhcp/dh4client.cpp
+		net/ip6/ip6.cpp net/ip6/icmp6.cpp net/ip6/udp6.cpp net/ip6/ndp.cpp
+		net/buffer_store.cpp net/inet4.cpp
+		fs/disk.cpp fs/filesystem.cpp fs/mbr.cpp fs/path.cpp
+		fs/ext4.cpp fs/fat.cpp fs/fat_async.cpp fs/fat_sync.cpp fs/memdisk.cpp)
+
+add_library(os STATIC ${OS_OBJECTS} apic_boot.o)
+
+# try to build CXXABI:
+# TODO: shouldn't we move that into a new CMakeLists.txt file?
+
+file(GLOB CXX_ABI crt/cxxabi/*.cpp)
+
+add_library(libc++abi.a STATIC ${CXX_ABI})
+
+add_subdirectory(boot)
+add_subdirectory(drivers)
+
+# TODO: what is this testdisk?
+#
+# build memdisk
+#add_custom_command(
+	#OUTPUT memdisk
+	#COMMAND nasm -f elf -o memdisk ${CMAKE_CURRENT_SOURCE_DIR}/memdisk.asm
+	#DEPENDS memdisk.asm
+	#)
+#
+#add_custom_target(create_memdisk ALL DEPENDS memdisk)

--- a/src/boot/CMakeLists.txt
+++ b/src/boot/CMakeLists.txt
@@ -1,32 +1,6 @@
-#cmake_minimum_required(VERSION 2.8.9)
+add_library(multiboot OBJECT multiboot.cpp)
 
-#project (boot)
-
-#set(INCLUDEOS_INSTALL_DIR /home/andy/IncludeOS_install/)
-#set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../)
-
-#set(CMAKE_CXX_FLAGS "-MMD -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=15583 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION=\"v0.8.1-709-gf8fccf4\"")
-
-#include_directories(${INCLUDEOS_ROOT}/api/sys ${INCLUDEOS_INSTALL_DIR}/libcxx/include ${INCLUDEOS_INSTALL_DIR}/newlib/include ${INCLUDEOS_ROOT}/src/include ${INCLUDEOS_ROOT}/api ${INCLUDEOS_ROOT}/mod/GSL/include)
-
-add_executable(multiboot multiboot.cpp)
-
-# TODO: use prefix to install into the right directory
-install(TARGETS multiboot DESTINATION bin)
-
-# Problem/TODO: the linker always gets the same flags as the compiler (which is expected for GCC). LLVM/Clang does not like it that way and outputs warnings -- still compiles though
-
-# cmake
-# /usr/lib64/ccache/clang++   -MMD -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=15583 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION="v0.8.1-709-gf8fccf4"   CMakeFiles/multiboot.dir/multiboot.cpp.o  -o multiboot -rdynamic
-
-# make
-# /usr/lib64/ccache/clang++ -MMD -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=15583 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -I../api/sys -I/home/andy/IncludeOS_install/libcxx/include -I/home/andy/IncludeOS_install/newlib/include -Iinclude -I../api -I../mod/GSL/include -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION="\"v0.8.1-709-gf8fccf4\"" -o boot/multiboot.o boot/multiboot.cpp
-
-# work on NASM
-
-#enable_language(ASM_NASM)
-
-#include_directories(${INCLUDEOS_ROOT}/api/sys ${INCLUDEOS_INSTALL_DIR}/libcxx/include ${INCLUDEOS_INSTALL_DIR}/newlib/include ${INCLUDEOS_ROOT}/src/include ${INCLUDEOS_ROOT}/src/ ${INCLUDEOS_ROOT}/api ${INCLUDEOS_ROOT}/mod/GSL/include)
+set_target_properties(multiboot PROPERTIES LINK_FLAGS "-nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_INSTALL_DIR}/linker.ld --defsym=__stack_rand_ba=${STACK_PROTECTOR_VALUE}")
 
 #add_executable(bootloader bootloader.asm disk_read_lba.asm)
 

--- a/src/boot/CMakeLists.txt
+++ b/src/boot/CMakeLists.txt
@@ -1,0 +1,39 @@
+#cmake_minimum_required(VERSION 2.8.9)
+
+#project (boot)
+
+#set(INCLUDEOS_INSTALL_DIR /home/andy/IncludeOS_install/)
+#set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../)
+
+#set(CMAKE_CXX_FLAGS "-MMD -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=15583 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION=\"v0.8.1-709-gf8fccf4\"")
+
+#include_directories(${INCLUDEOS_ROOT}/api/sys ${INCLUDEOS_INSTALL_DIR}/libcxx/include ${INCLUDEOS_INSTALL_DIR}/newlib/include ${INCLUDEOS_ROOT}/src/include ${INCLUDEOS_ROOT}/api ${INCLUDEOS_ROOT}/mod/GSL/include)
+
+add_executable(multiboot multiboot.cpp)
+
+# TODO: use prefix to install into the right directory
+install(TARGETS multiboot DESTINATION bin)
+
+# Problem/TODO: the linker always gets the same flags as the compiler (which is expected for GCC). LLVM/Clang does not like it that way and outputs warnings -- still compiles though
+
+# cmake
+# /usr/lib64/ccache/clang++   -MMD -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=15583 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION="v0.8.1-709-gf8fccf4"   CMakeFiles/multiboot.dir/multiboot.cpp.o  -o multiboot -rdynamic
+
+# make
+# /usr/lib64/ccache/clang++ -MMD -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=15583 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -I../api/sys -I/home/andy/IncludeOS_install/libcxx/include -I/home/andy/IncludeOS_install/newlib/include -Iinclude -I../api -I../mod/GSL/include -D_LIBCPP_HAS_NO_THREADS=1 -DOS_VERSION="\"v0.8.1-709-gf8fccf4\"" -o boot/multiboot.o boot/multiboot.cpp
+
+# work on NASM
+
+#enable_language(ASM_NASM)
+
+#include_directories(${INCLUDEOS_ROOT}/api/sys ${INCLUDEOS_INSTALL_DIR}/libcxx/include ${INCLUDEOS_INSTALL_DIR}/newlib/include ${INCLUDEOS_ROOT}/src/include ${INCLUDEOS_ROOT}/src/ ${INCLUDEOS_ROOT}/api ${INCLUDEOS_ROOT}/mod/GSL/include)
+
+#add_executable(bootloader bootloader.asm disk_read_lba.asm)
+
+add_custom_command(
+	OUTPUT bootloader
+	COMMAND nasm -f bin -I${CMAKE_CURRENT_SOURCE_DIR}/../ -o bootloader ${CMAKE_CURRENT_SOURCE_DIR}/bootloader.asm
+	DEPENDS bootloader.asm disk_read_lba.asm
+)
+
+add_custom_target(run ALL DEPENDS bootloader)

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(DRIVERS	virtioblk.cpp virtionet.cpp)
+
+# add a library, this should build all the object files so that those can be included later on
+add_library(drivers ${DRIVERS})

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -30,6 +30,7 @@ SECTIONS
   .multiboot (_ELF_START_ + SIZEOF_HEADERS): {
       PROVIDE(_MULTIBOOT_START_ = .);
       *multiboot.cpp.o(.rodata);
+      *multiboot.o(.rodata);
    }
   PROVIDE ( _TEXT_START_ = . );
   .text (_TEXT_START_ ) :

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -29,7 +29,7 @@ SECTIONS
 
   .multiboot (_ELF_START_ + SIZEOF_HEADERS): {
       PROVIDE(_MULTIBOOT_START_ = .);
-      *multiboot.o(.rodata);
+      *multiboot.cpp.o(.rodata);
    }
   PROVIDE ( _TEXT_START_ = . );
   .text (_TEXT_START_ ) :

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -4,12 +4,15 @@ project (vmbuilder)
 
 # TODO: make sure that CXX is exported before this script is called
 set(SOURCES vmbuild.cpp elf_binary.cpp)
+set(ELF_SYMS_SOURCES elf_syms.cpp)
+
 set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O3")
 
 # TODO: write scripts that automatically find include directories
 include_directories(. ./../api ./../mod/GSL/)
 
 add_executable(vmbuild ${SOURCES})
+add_executable(elf_syms ${ELF_SYMS_SOURCES})
 
 # TODO: use prefix to install into the right directory
-install(TARGETS vmbuild DESTINATION bin)
+install(TARGETS vmbuild elf_syms DESTINATION bin)

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+project (vmbuilder)
+
+# TODO: make sure that CXX is exported before this script is called
+set(SOURCES vmbuild.cpp elf_binary.cpp)
+set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O3")
+
+# TODO: write scripts that automatically find include directories
+include_directories(. ./../api ./../mod/GSL/)
+
+add_executable(vmbuild ${SOURCES})
+
+# TODO: use prefix to install into the right directory
+install(TARGETS vmbuild DESTINATION bin)

--- a/vmbuild/elf.h
+++ b/vmbuild/elf.h
@@ -28,6 +28,15 @@
 #ifndef _ELF_H
 #define	_ELF_H 1
 
+/* C++ needs to know that types and declarations are C, not C++.  */
+#ifdef __cplusplus
+# define __BEGIN_DECLS extern "C" {
+# define __END_DECLS }
+#else
+# define __BEGIN_DECLS
+# define __END_DECLS
+#endif
+
 __BEGIN_DECLS
 
 /* Standard ELF types.  */

--- a/vmbuild/vmbuild.cpp
+++ b/vmbuild/vmbuild.cpp
@@ -34,7 +34,7 @@
 #define SECT_SIZE_ERR  666
 #define DISK_SIZE_ERR  999
 
-bool verb = false;
+bool verb = true;
 #define INFO_(FROM, TEXT, ...) if (verb) printf("%13s ] " TEXT "\n", "[ " FROM, ##__VA_ARGS__)
 #define INFO(X,...) INFO_("Vmbuild", X, ##__VA_ARGS__)
 


### PR DESCRIPTION
This is a rough first prototype that allows building of unikernels
within examples/ with cmake. Lots of room for improvements. Also
an installed ~/IncludeOS_Installation is expected.

To build (on Linux), goto to the unikernel src directory, and do:

~~~
 $ mkdir build
 $ cd build
 $ CXX=/usr/bin/clang++ CC=/usr/bin/clang cmake ./..
 $ make
~~~

To switch configuration switches, use ccmake within the build directory.