### PR TITLE
TCP now forces close when retransmission limit is reached

### DIFF
--- a/api/kernel/rtc.hpp
+++ b/api/kernel/rtc.hpp
@@ -7,9 +7,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,10 +26,13 @@ class RTC
 {
 public:
   using timestamp_t = int64_t;
-  
+
   /// returns a 64-bit unix timestamp of the current time
   static timestamp_t get();
-  
+
+  static timestamp_t now()
+  { return get(); }
+
   /// start an auto-calibration process
   static void init();
 };

--- a/src/net/tcp/connection.cpp
+++ b/src/net/tcp/connection.cpp
@@ -739,7 +739,7 @@ void Connection::rtx_timeout(uint32_t) {
   // experimental
   if(rto_limit_reached()) {
     debug("<TCP::Connection::rtx_timeout> RTX attempt limit reached, closing.\n");
-    close();
+    abort();
     return;
   }
 


### PR DESCRIPTION
Also added `RTC::now()`