### PR TITLE
clang++ as compiler binary name is supported for seed projects

### DIFF
--- a/src/seed/Makefile
+++ b/src/seed/Makefile
@@ -40,7 +40,7 @@ INC_NEWLIB=$(INSTALL)/newlib/include
 INC_LIBCXX=$(INSTALL)/libcxx/include
 
 CC  = $(shell command -v clang-3.8 || command -v clang-3.6) -target i686-elf
-CPP = $(shell command -v clang++-3.8 || command -v clang++-3.6) -target i686-elf
+CPP = $(shell command -v clang++-3.8 || command -v clang++-3.6 || command -v clang++) -target i686-elf
 ifndef LD_INC
 	LD_INC = ld
 endif

--- a/src/seed/Makelib
+++ b/src/seed/Makelib
@@ -22,7 +22,7 @@ INC_NEWLIB=$(INSTALL)/newlib/include
 INC_LIBCXX=$(INSTALL)/libcxx/include
 
 CC  = $(shell command -v clang-3.8 || command -v clang-3.6) -target i686-elf
-CPP = $(shell command -v clang++-3.8 || command -v clang++-3.6) -target i686-elf
+CPP = $(shell command -v clang++-3.8 || command -v clang++-3.6 || command -v clang++) -target i686-elf
 
 ifndef AR_INC
 	AR_INC = ar


### PR DESCRIPTION
In src/Makefile clang++ is already allowed as compiler, but not in seed projects.

This change would be nice for arch linux users.