### PR TITLE
Improved use of INCLUDEOS_SRC in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ IncludeOS is free software, with "no warranties or restrictions of any kind".
 
 ## Build status
 
-|        | Build from bundle                                                                                                                                             | Build from source |
-|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| Master | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_master_bundle)](https://jenkins.includeos.org/job/shield_master_bundle/) | Coming soon       |
-| Dev    | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_dev_bundle)](https://jenkins.includeos.org/job/shield_dev_bundle/)      | Coming soon       |
+|        | Build from bundle                                                                                                                                             |
+|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Master | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_master_bundle)](https://jenkins.includeos.org/job/shield_master_bundle/) |
+| Dev    | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_dev_bundle)](https://jenkins.includeos.org/job/shield_dev_bundle/)      |
 
 ### Key features
 

--- a/test/fs/integration/fat16/test.py
+++ b/test/fs/integration/fat16/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 from subprocess import call

--- a/test/fs/integration/fat32/test.py
+++ b/test/fs/integration/fat32/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 from subprocess import call

--- a/test/fs/integration/memdisk/test.py
+++ b/test/fs/integration/memdisk/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 from subprocess import call

--- a/test/fs/integration/virtio_block/test.py
+++ b/test/fs/integration/virtio_block/test.py
@@ -3,7 +3,8 @@ import sys
 import subprocess
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 subprocess.call(['./image.sh'])
 

--- a/test/hw/integration/serial/test.py
+++ b/test/hw/integration/serial/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 from subprocess import call

--- a/test/hw/integration/virtio_queue/Makefile
+++ b/test/hw/integration/virtio_queue/Makefile
@@ -11,6 +11,14 @@ FILES = service.cpp
 
 LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest -I$(PWD)/mod/GSL/include
 
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest) -I$(abspath $(current_dir)/../../../../mod/GSL/include)
+else
+LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest -I$(INCLUDEOS_SRC)/mod/GSL/include
+endif
+
 # Your disk image
 DISK=
 

--- a/test/kernel/integration/custom_init/Makefile
+++ b/test/kernel/integration/custom_init/Makefile
@@ -9,7 +9,13 @@ SERVICE_NAME = Custom pre-service initialization
 # Your service parts
 FILES = service.cpp custom_init1.cpp custom_init2.cpp custom_init3.cpp
 
-LOCAL_INCLUDES = -I$(INCLUDEOS_SRC)/test/lest/include/lest
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
+LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # Your disk image
 DISK=

--- a/test/kernel/integration/custom_init/test.py
+++ b/test/kernel/integration/custom_init/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/kernel/integration/memmap/Makefile
+++ b/test/kernel/integration/memmap/Makefile
@@ -9,7 +9,13 @@ SERVICE_NAME = Memmap Test Service
 # Your service parts
 FILES = service.cpp
 
-LOCAL_INCLUDES = -I$(INCLUDEOS_SRC)/test/lest/include/lest
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
+LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # Your disk image
 DISK=

--- a/test/kernel/integration/memmap/test.py
+++ b/test/kernel/integration/memmap/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/kernel/integration/timers/test.py
+++ b/test/kernel/integration/timers/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/mod/gsl/Makefile
+++ b/test/mod/gsl/Makefile
@@ -11,6 +11,14 @@ FILES = service.cpp
 
 LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/mod/GSL/include -I$(INCLUDEOS_SRC)/test/lest/include/lest
 
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest) -I$(abspath $(current_dir)/../../../../mod/GSL/include)
+else
+LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest -I$(INCLUDEOS_SRC)/mod/GSL/include
+endif
+
 # Your disk image
 DISK=
 

--- a/test/mod/gsl/test.py
+++ b/test/mod/gsl/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/net/integration/bufstore/test.py
+++ b/test/net/integration/bufstore/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/net/integration/dhcp/test.py
+++ b/test/net/integration/dhcp/test.py
@@ -4,7 +4,8 @@ import sys
 import os
 import subprocess
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/net/integration/ethernet/Makefile
+++ b/test/net/integration/ethernet/Makefile
@@ -9,7 +9,13 @@ SERVICE_NAME=Ethernet Module Test
 # Your service parts
 FILES=service.cpp
 
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
 LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # Your disk image
 DISK=

--- a/test/net/integration/ethernet/test.py
+++ b/test/net/integration/ethernet/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/net/integration/ipv4/Makefile
+++ b/test/net/integration/ipv4/Makefile
@@ -9,7 +9,13 @@ SERVICE_NAME=IPv4 Module Test
 # Your service parts
 FILES=service.cpp
 
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
 LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # Your disk image
 DISK=

--- a/test/net/integration/ipv4/test.py
+++ b/test/net/integration/ipv4/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/net/integration/tcp/test.py
+++ b/test/net/integration/tcp/test.py
@@ -4,7 +4,8 @@ import socket
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/net/integration/transmit/test.py
+++ b/test/net/integration/transmit/test.py
@@ -2,7 +2,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/net/integration/udp/test.py
+++ b/test/net/integration/udp/test.py
@@ -3,7 +3,9 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
+print 'includeos_src: {0}'.format(includeos_src)
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/platform/integration/unik/Makefile
+++ b/test/platform/integration/unik/Makefile
@@ -9,7 +9,13 @@ SERVICE_NAME = Test Unik platform initialization
 # Your service parts
 FILES = service.cpp
 
-LOCAL_INCLUDES = -I$(INCLUDEOS_SRC)/test/lest/include/lest
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
+LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # Your disk image
 DISK=

--- a/test/platform/integration/unik/test.py
+++ b/test/platform/integration/unik/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/stl/integration/crt/test.py
+++ b/test/stl/integration/crt/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/stl/integration/exceptions/Makefile
+++ b/test/stl/integration/exceptions/Makefile
@@ -12,7 +12,13 @@ FILES = service.cpp
 # Your disk image
 DISK=
 
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
 LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # IncludeOS location
 ifndef INCLUDEOS_INSTALL

--- a/test/stl/integration/exceptions/test.py
+++ b/test/stl/integration/exceptions/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/stl/integration/stl/Makefile
+++ b/test/stl/integration/stl/Makefile
@@ -9,7 +9,13 @@ SERVICE_NAME = IncludeOS basic STL test
 # Your service parts
 FILES = service.cpp
 
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
 LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # Your disk image
 DISK=

--- a/test/stl/integration/stl/test.py
+++ b/test/stl/integration/stl/test.py
@@ -3,7 +3,8 @@
 import sys
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/stress/Makefile
+++ b/test/stress/Makefile
@@ -9,7 +9,13 @@ SERVICE_NAME = IncludeOS stress test
 # Your service parts
 FILES = service.cpp
 
+# IncludeOS_SRC location
+ifndef INCLUDEOS_SRC
+current_dir := $(shell pwd)
+LOCAL_INCLUDES=-I$(abspath $(current_dir)/../../../lest/include/lest)
+else
 LOCAL_INCLUDES=-I$(INCLUDEOS_SRC)/test/lest/include/lest
+endif
 
 # Your disk image
 DISK=

--- a/test/stress/run.sh
+++ b/test/stress/run.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh stresstest.img
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh test_stresstest.img

--- a/test/stress/test.py
+++ b/test/stress/test.py
@@ -5,7 +5,8 @@ import time
 import subprocess
 import os
 
-includeos_src = os.environ['INCLUDEOS_SRC']
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src + "/test")
 
 import vmrunner

--- a/test/vmrunner.py
+++ b/test/vmrunner.py
@@ -337,7 +337,7 @@ class vm:
 
 print color.HEADER("IncludeOS vmrunner initializing tests")
 print color.INFO(nametag), "Validating test service"
-validate_test.load_schema(os.environ["INCLUDEOS_SRC"] + "/test/vm.schema.json")
+validate_test.load_schema(os.environ.get("INCLUDEOS_SRC", os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0]) + "/test/vm.schema.json")
 validate_test.has_required_stuff(".")
 
 default_spec = {"image" : "test.img"}


### PR DESCRIPTION
- Removed a lot of default values where INLUDEOS_SRC was set to $HOME. 
- Now all test.py no longer require INCLUDEOS_SRC to be set in order to run. They figure out the path based on the scripts location.
- Makefiles were also updated to figure this out on their own. Makefiles till require you to be in the same directory to run them. 

There are still some smaller dependencies on INCLUDEOS_SRC in some installation scripts. I will get to those later. 

I still advice INCLUDEOS_SRC to be set if not installing to the default location ($HOME)