### PR TITLE
Add Linux Mint to supported distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ check_os_support() {
             ;;
         "Linux")
             case $RELEASE in
-                "Ubuntu")
+                "Ubuntu"|"LinuxMint")
                     return 0;
                     ;;
                 "Fedora")


### PR DESCRIPTION
Linux Mint binary and packet-compatible with Ubuntu, so it can be simple handled as Ubuntu.