### PR TITLE
Add 256 color vga demo

### DIFF
--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -47,7 +47,7 @@ popd
 # Build IncludeOS
 echo -e "\n\n>>> Building IncludeOS"
 pushd $INCLUDEOS_SRC/src
-make -j
+make -j2
 make install
 popd
 

--- a/examples/256_color_vga/Makefile
+++ b/examples/256_color_vga/Makefile
@@ -1,0 +1,27 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# The name of your service
+SERVICE = 256_Color_VGA
+SERVICE_NAME = 256 Color VGA
+
+# Your service parts
+FILES = service.cpp
+ASM_FILES = int32.asm
+
+# Your disk image
+DISK=
+
+DRIVERS=
+
+# Your own include-path
+LOCAL_INCLUDES=
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+endif
+
+# Include the installed seed makefile
+include $(INCLUDEOS_INSTALL)/Makeseed

--- a/examples/256_color_vga/README.md
+++ b/examples/256_color_vga/README.md
@@ -1,0 +1,10 @@
+### Snake game
+
+Using VGA text-mode in qemu (or possibly VirtualBox) we can play snake!
+
+```
+make
+./run.sh
+```
+
+Use arrow keys to change the snakes direction. Press spacebar to restart the game.

--- a/examples/256_color_vga/int32.asm
+++ b/examples/256_color_vga/int32.asm
@@ -1,0 +1,225 @@
+; 
+; Protected Mode BIOS Call Functionailty v2.0 - by Napalm
+; -------------------------------------------------------
+; 
+; This is code shows how its POSSIBLE to execute BIOS interrupts
+; by switch out to real-mode and then back into protected mode.
+; 
+; If you wish to use all or part of this code you must agree
+; to the license at the following URL.
+; 
+; License: http://creativecommons.org/licenses/by-sa/2.0/uk/
+;         
+; Notes: This file is in NASM syntax.
+;        Turn off paging before calling these functions.
+;        int32() resets all selectors.
+;
+; C Prototype:
+;	void _cdelc int32(unsigned char intnum, regs16_t *regs);
+; 
+; Example of usage:
+;   regs.ax = 0x0013;
+;   int32(0x10, &regs);
+;   memset((char *)0xA0000, 1, (320*200));
+;   memset((char *)0xA0000 + (100*320+80), 14, 80);
+;   regs.ax = 0x0000;
+;   int32(0x16, &regs);
+;   regs.ax = 0x0003;
+;   int32(0x10, &regs);
+; 
+; 
+[bits 32]
+
+global int32, _int32
+
+struc regs16_t
+	.di	resw 1
+	.si	resw 1
+	.bp	resw 1
+	.sp resw 1
+	.bx	resw 1
+	.dx	resw 1
+	.cx	resw 1
+	.ax	resw 1
+	.gs	resw 1
+	.fs	resw 1
+	.es	resw 1
+	.ds	resw 1
+	.ef resw 1
+endstruc
+
+%define INT32_BASE                             0x7C00
+%define REBASE(x)                              (((x) - reloc) + INT32_BASE)
+%define GDTENTRY(x)                            ((x) << 3)
+%define CODE32                                 GDTENTRY(1)	; 0x08
+%define DATA32                                 GDTENTRY(2)	; 0x10
+%define CODE16                                 GDTENTRY(3)	; 0x18
+%define DATA16                                 GDTENTRY(4)	; 0x20
+%define STACK16                                (INT32_BASE - regs16_t_size)
+
+
+section .text
+	int32: use32                               ; by Napalm
+	_int32:
+		cli                                    ; disable interrupts
+		pusha                                  ; save register state to 32bit stack
+		mov  esi, reloc                        ; set source to code below
+		mov  edi, INT32_BASE                   ; set destination to new base address
+		mov  ecx, (int32_end - reloc)          ; set copy size to our codes size
+		cld                                    ; clear direction flag (so we copy forward)
+		rep  movsb                             ; do the actual copy (relocate code to low 16bit space)
+		jmp INT32_BASE                         ; jump to new code location
+	reloc: use32                               ; by Napalm
+		mov  [REBASE(stack32_ptr)], esp        ; save 32bit stack pointer
+		sidt [REBASE(idt32_ptr)]               ; save 32bit idt pointer
+		sgdt [REBASE(gdt32_ptr)]               ; save 32bit gdt pointer
+		lgdt [REBASE(gdt16_ptr)]               ; load 16bit gdt pointer
+		lea  esi, [esp+0x24]                   ; set position of intnum on 32bit stack
+		lodsd                                  ; read intnum into eax
+		mov  [REBASE(ib)], al                  ; set intrrupt immediate byte from our arguments 
+		mov  esi, [esi]                        ; read regs pointer in esi as source
+		mov  edi, STACK16                      ; set destination to 16bit stack
+		mov  ecx, regs16_t_size                ; set copy size to our struct size
+		mov  esp, edi                          ; save destination to as 16bit stack offset
+		rep  movsb                             ; do the actual copy (32bit stack to 16bit stack)
+		jmp  word CODE16:REBASE(p_mode16)      ; switch to 16bit selector (16bit protected mode)
+	p_mode16: use16
+		mov  ax, DATA16                        ; get our 16bit data selector
+		mov  ds, ax                            ; set ds to 16bit selector
+		mov  es, ax                            ; set es to 16bit selector
+		mov  fs, ax                            ; set fs to 16bit selector
+		mov  gs, ax                            ; set gs to 16bit selector
+		mov  ss, ax                            ; set ss to 16bit selector
+		mov  eax, cr0                          ; get cr0 so we can modify it
+		and  al,  ~0x01                        ; mask off PE bit to turn off protected mode
+		mov  cr0, eax                          ; set cr0 to result
+		jmp  word 0x0000:REBASE(r_mode16)      ; finally set cs:ip to enter real-mode
+	r_mode16: use16
+		xor  ax, ax                            ; set ax to zero
+		mov  ds, ax                            ; set ds so we can access idt16
+		mov  ss, ax                            ; set ss so they the stack is valid
+		lidt [REBASE(idt16_ptr)]               ; load 16bit idt
+		mov  bx, 0x0870                        ; master 8 and slave 112
+		call resetpic                          ; set pic's the to real-mode settings
+		popa                                   ; load general purpose registers from 16bit stack
+		pop  gs                                ; load gs from 16bit stack
+		pop  fs                                ; load fs from 16bit stack
+		pop  es                                ; load es from 16bit stack
+		pop  ds                                ; load ds from 16bit stack
+		sti                                    ; enable interrupts
+		db 0xCD                                ; opcode of INT instruction with immediate byte
+	ib: db 0x00
+		cli                                    ; disable interrupts
+		xor  sp, sp                            ; zero sp so we can reuse it
+		mov  ss, sp                            ; set ss so the stack is valid
+		mov  sp, INT32_BASE                    ; set correct stack position so we can copy back
+		pushf                                  ; save eflags to 16bit stack
+		push ds                                ; save ds to 16bit stack
+		push es                                ; save es to 16bit stack
+		push fs                                ; save fs to 16bit stack
+		push gs                                ; save gs to 16bit stack
+		pusha                                  ; save general purpose registers to 16bit stack
+		mov  bx, 0x2028                        ; master 32 and slave 40
+		call resetpic                          ; restore the pic's to protected mode settings
+		mov  eax, cr0                          ; get cr0 so we can modify it
+		inc  eax                               ; set PE bit to turn on protected mode
+		mov  cr0, eax                          ; set cr0 to result
+		jmp  dword CODE32:REBASE(p_mode32)     ; switch to 32bit selector (32bit protected mode)
+	p_mode32: use32
+		mov  ax, DATA32                        ; get our 32bit data selector
+		mov  ds, ax                            ; reset ds selector
+		mov  es, ax                            ; reset es selector
+		mov  fs, ax                            ; reset fs selector
+		mov  gs, ax                            ; reset gs selector
+		mov  ss, ax                            ; reset ss selector
+		lgdt [REBASE(gdt32_ptr)]               ; restore 32bit gdt pointer
+		lidt [REBASE(idt32_ptr)]               ; restore 32bit idt pointer
+		mov  esp, [REBASE(stack32_ptr)]        ; restore 32bit stack pointer
+		mov  esi, STACK16                      ; set copy source to 16bit stack
+		lea  edi, [esp+0x28]                   ; set position of regs pointer on 32bit stack
+		mov  edi, [edi]                        ; use regs pointer in edi as copy destination
+		mov  ecx, regs16_t_size                ; set copy size to our struct size
+		cld                                    ; clear direction flag (so we copy forward)
+		rep  movsb                             ; do the actual copy (16bit stack to 32bit stack)
+		popa                                   ; restore registers
+		sti                                    ; enable interrupts
+		ret                                    ; return to caller
+		
+	resetpic:                                  ; reset's 8259 master and slave pic vectors
+		push ax                                ; expects bh = master vector, bl = slave vector
+		mov  al, 0x11                          ; 0x11 = ICW1_INIT | ICW1_ICW4
+		out  0x20, al                          ; send ICW1 to master pic
+		out  0xA0, al                          ; send ICW1 to slave pic
+		mov  al, bh                            ; get master pic vector param
+		out  0x21, al                          ; send ICW2 aka vector to master pic
+		mov  al, bl                            ; get slave pic vector param
+		out  0xA1, al                          ; send ICW2 aka vector to slave pic
+		mov  al, 0x04                          ; 0x04 = set slave to IRQ2
+		out  0x21, al                          ; send ICW3 to master pic
+		shr  al, 1                             ; 0x02 = tell slave its on IRQ2 of master
+		out  0xA1, al                          ; send ICW3 to slave pic
+		shr  al, 1                             ; 0x01 = ICW4_8086
+		out  0x21, al                          ; send ICW4 to master pic
+		out  0xA1, al                          ; send ICW4 to slave pic
+		pop  ax                                ; restore ax from stack
+		ret                                    ; return to caller
+		
+	stack32_ptr:                               ; address in 32bit stack after we
+		dd 0x00000000                          ;   save all general purpose registers
+		
+	idt32_ptr:                                 ; IDT table pointer for 32bit access
+		dw 0x0000                              ; table limit (size)
+		dd 0x00000000                          ; table base address
+		
+	gdt32_ptr:                                 ; GDT table pointer for 32bit access
+		dw 0x0000                              ; table limit (size)
+		dd 0x00000000                          ; table base address
+		
+	idt16_ptr:                                 ; IDT table pointer for 16bit access
+		dw 0x03FF                              ; table limit (size)
+		dd 0x00000000                          ; table base address
+		
+	gdt16_base:                                ; GDT descriptor table
+		.null:                                 ; 0x00 - null segment descriptor
+			dd 0x00000000                      ; must be left zero'd
+			dd 0x00000000                      ; must be left zero'd
+			
+		.code32:                               ; 0x01 - 32bit code segment descriptor 0xFFFFFFFF
+			dw 0xFFFF                          ; limit  0:15
+			dw 0x0000                          ; base   0:15
+			db 0x00                            ; base  16:23
+			db 0x9A                            ; present, iopl/0, code, execute/read
+			db 0xCF                            ; 4Kbyte granularity, 32bit selector; limit 16:19
+			db 0x00                            ; base  24:31
+			
+		.data32:                               ; 0x02 - 32bit data segment descriptor 0xFFFFFFFF
+			dw 0xFFFF                          ; limit  0:15
+			dw 0x0000                          ; base   0:15
+			db 0x00                            ; base  16:23
+			db 0x92                            ; present, iopl/0, data, read/write
+			db 0xCF                            ; 4Kbyte granularity, 32bit selector; limit 16:19
+			db 0x00                            ; base  24:31
+			
+		.code16:                               ; 0x03 - 16bit code segment descriptor 0x000FFFFF
+			dw 0xFFFF                          ; limit  0:15
+			dw 0x0000                          ; base   0:15
+			db 0x00                            ; base  16:23
+			db 0x9A                            ; present, iopl/0, code, execute/read
+			db 0x0F                            ; 1Byte granularity, 16bit selector; limit 16:19
+			db 0x00                            ; base  24:31
+			
+		.data16:                               ; 0x04 - 16bit data segment descriptor 0x000FFFFF
+			dw 0xFFFF                          ; limit  0:15
+			dw 0x0000                          ; base   0:15
+			db 0x00                            ; base  16:23
+			db 0x92                            ; present, iopl/0, data, read/write
+			db 0x0F                            ; 1Byte granularity, 16bit selector; limit 16:19
+			db 0x00                            ; base  24:31
+			
+	gdt16_ptr:                                 ; GDT table pointer for 16bit access
+		dw gdt16_ptr - gdt16_base - 1          ; table limit (size)
+		dd gdt16_base                          ; table base address
+		
+	int32_end:                                 ; end marker (so we can copy the code)
+	
+	

--- a/examples/256_color_vga/run.sh
+++ b/examples/256_color_vga/run.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+export GRAPHICS="-vga std"
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/256_color_vga/service.cpp
+++ b/examples/256_color_vga/service.cpp
@@ -1,0 +1,182 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <os>
+#include <cmath>
+#include <hw/ps2.hpp>
+
+// see also: http://www.rohitab.com/discuss/topic/35103-switch-between-real-mode-and-protected-mode/
+
+extern "C" {
+  // define our structure
+  typedef struct __attribute__ ((packed)) {
+    uint16_t di=0, si=0, bp=0, sp=0, bx=0, dx=0, cx=0, ax=0;
+    uint16_t gs=0, fs=0, es=0, ds=0, eflags=0;
+  } regs16_t;
+
+  // tell compiler our int32 function is external
+  extern void int32(unsigned char intnum, regs16_t *regs);
+}
+
+
+
+
+
+template<typename T>
+struct Point
+{
+  T x;
+  T y;
+};
+
+struct Color
+{
+  double r;
+  double g;
+  double b;
+};
+
+Color get_color(const Point<int> &t_point, const Point<double> &t_center, const int t_width, const int t_height, const double t_scale, const int max_iteration)
+{
+  const auto xscaled = t_point.x/(t_width/t_scale) + (t_center.x - (t_scale/2.0 ));
+  const auto yscaled = t_point.y/(t_height/t_scale) + (t_center.y - (t_scale/2.0 ));
+
+  auto x = xscaled;
+  auto y = yscaled;
+
+  int iteration = 0;
+
+  auto stop_iteration = max_iteration;
+
+  while ( iteration < stop_iteration )
+  {
+    if (((x*x) + (y*y)) > (2.0*2.0) && stop_iteration == max_iteration)
+    {
+      stop_iteration = iteration + 5;
+    }
+
+    auto xtemp = (x*x) - (y*y) + xscaled;
+    y = (2.0*x*y) + yscaled;
+    x = xtemp;
+    ++iteration;
+  }
+
+  if (iteration == max_iteration)
+  {
+    return Color{0.0,0.0,0.0};
+  } else {
+    const auto value = ((iteration + 1) - (std::log(std::log(std::fabs(x * y))))/std::log(2.0)); 
+    auto red = 0.0;
+    auto green = 0.0;
+    auto blue = 0.0;
+
+    const auto colorval = std::floor(value * 10.0);
+
+    if (colorval < 256)
+    {
+      red = colorval/256.0;
+    } else {
+      const auto colorband = std::floor( (static_cast<int>(colorval - 256) % 1024) / 256);
+      const auto mod256 = static_cast<int>(colorval) % 256;
+      if (colorband == 0)
+      {
+        red = 1.0;
+        green = mod256 / 255.0;
+        blue = 0.0;
+      } else if (colorband == 1) {
+        red = 1.0;
+        green = 1.0;
+        blue = mod256 / 255.0;
+      } else if (colorband == 2) {
+        red = 1.0;
+        green = 1.0;
+        blue = 1.0 - (mod256/255.0);
+      } else {
+        red = 1.0;
+        green = 1.0 - (mod256/255.0);
+        blue = 0.0;
+      }
+    }
+    return Color{red, green, blue};
+  }
+}
+
+void set_pixel(const Point<int> &t_point, const Color &t_color)
+{
+  *reinterpret_cast<uint8_t*>(0xA0000 + t_point.x + (t_point.y * 320)) = static_cast<uint8_t>(std::floor((t_color.r + t_color.g + t_color.b) / 3 * 255));
+}
+
+void region_calc(const Point<int> &t_tl, const Point<int> &t_br, const int t_width, const int t_height, 
+    const Point<double> &t_center, const double t_scale, const int t_max_iteration)
+{
+  for (auto y = t_tl.y; y < t_br.y; ++y)
+  {
+    for (auto x = t_tl.x; x < t_br.x; ++x)
+    {
+      const auto p = Point<int>{x,y};
+      set_pixel(p, get_color(p, t_center, t_width, t_height, t_scale, t_max_iteration));
+    }
+  }
+}
+
+
+
+// 256 color vga
+void vga_256_test()
+{
+  hw::KBM::init();
+
+  regs16_t regs;
+
+  // switch to 320x200x256 graphics mode
+  regs.ax = 0x0013;
+  int32(0x10, &regs);
+
+  // full screen with blue color (1)
+  memset((char *)0xA0000, 1, (320*200));
+
+  auto center = Point<double>{ 0.001643721971153, -0.822467633298876 };
+  auto scale = 0.0000000001;
+
+  region_calc(Point<int>{0,0}, Point<int>{320,200}, 320, 200, center, scale, 2000);
+}
+
+void screen_test()
+{
+  regs16_t regs;
+
+  // switch to 320x200x256 graphics mode
+  regs.ax = 0x0013;
+  int32(0x10, &regs);
+
+  // draw horizontal line from 100,80 to 100,240 in multiple colors
+  for(int y = 0; y < 200; y++)
+    memset((char *)0xA0000 + (y*320+80), y, 160);
+
+  // wait for key
+  regs.ax = 0x0000;
+  int32(0x16, &regs);
+}
+
+
+void Service::start(const std::string&)
+{
+  vga_256_test();
+//  screen_test();
+}
+
+

--- a/src/seed/Makefile
+++ b/src/seed/Makefile
@@ -11,6 +11,8 @@ ifneq ($(DISK),)
 MEMDISK=memdisk.o
 endif
 
+.SUFFIXES: .asm
+
 # Maximum memory in megabytes
 # Used if memory info is not otherwise available such as via multiboot
 MAX_MEM=128
@@ -73,7 +75,9 @@ PLATFORM_OBJS = $(addprefix $(INSTALL)/platforms/, $(PLATFORM_OBJS_EXT))
 
 
 # Full link list
-OBJS  = $(FILES:.cpp=.o) .service_name.o
+OBJS  = $(ASM_FILES:.asm=.o)
+OBJS  += $(FILES:.cpp=.o) 
+OBJS  += .service_name.o
 
 LIBS =  $(INSTALL)/os.a $(LIBCXX) $(INSTALL)/os.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
 
@@ -169,6 +173,10 @@ crt%.o: $(INSTALL)/crt/crt%.s
 # AS-assembled object files
 %.o: %.s
 	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# nasm-assembled object files
+.asm.o:
+	nasm -f elf -o $@ $<
 
 # Cleanup
 ###################################################


### PR DESCRIPTION
Proof of concept for setting VGA 256 color mode.

1. Adds ability to specify nasm files for assembling and linking into project
2. Adds example that jumps into 16 bit mode to call interrupt 0x10 to set VGA mode and returns back to 32 bit mode and continues execution
3. Draws mandelbrot set to video memory

The VM resets repeatedly if the network driver is enabled. I don't know if the VGA address space of 0xa0000 somehow conflicts with the rest of includeos?