### PR TITLE
Fixes incorrect cpuid call

### DIFF
--- a/api/kernel/cpuid.hpp
+++ b/api/kernel/cpuid.hpp
@@ -20,13 +20,6 @@
 #define KERNEL_CPUID_HPP
 
 struct CPUID {
-  struct cpuid_t {
-    unsigned int EAX;
-    unsigned int EBX;
-    unsigned int ECX;
-    unsigned int EDX;
-  };
-  
   static bool isAmdCpu();
   static bool isIntelCpu();
   static bool hasRDRAND();

--- a/src/kernel/cpuid.cpp
+++ b/src/kernel/cpuid.cpp
@@ -87,7 +87,12 @@
 #define EDX_RDTSCP                  (1 << 27)   // RDTSCP and IA32_TSC_AUX
 #define EDX_64_BIT                  (1 << 29)   // 64-bit Architecture
 
-using cpuid_t = CPUID::cpuid_t;
+struct cpuid_t {
+  unsigned int EAX;
+  unsigned int EBX;
+  unsigned int ECX;
+  unsigned int EDX;
+}; //< cpuid_t
 
 // EBX/RBX needs to be preserved depending on the memory model and use of PIC
 static cpuid_t
@@ -119,7 +124,7 @@ bool CPUID::hasRDRAND() {
   if (!isAmdCpu() && !isIntelCpu()) {
     return false;
   }
-  
-  cpuid_t info = cpuid_info(0, 0);
+
+  cpuid_t info = cpuid_info(1, 0);
   return (info.ECX & ECX_RDRAND) != 0;
 }


### PR DESCRIPTION
Also moves struct cpuid_t from cpuid.hpp to cpuid.cpp as it's only used internally

--

@fwsGonzo also mentioned:

> honestly, we wanted to redo the whole cpuid thing for a while now
> its less than a days work to do it right, and there are a few other parts of our code that will need it, such as kvm paravirtual stuff
> but no one is working on it right now

If I could get some input on how you want it done (does it need to support _all_ cpu features?) and other requirements (can a hypervisor change cpuid during runtime / after boot, or can one assume that the result of a cpuid call is always the same?), then I could probably get it done.

I got a few ideas of how to implement it. Export an enum class with all features `enum class Feature { SSE3, FPU, ... };` and a single static function `bool hasFeature(Feature f);`. Internally in cpuid.cpp you'll have a mapping from Feature to FeatureInfo, where FeatureInfo describes which registers and values are to be used when calling cpuid and which registers and bitmask to use when retrieving the result. cpuid.cpp can also make use of a cache to avoid calling cpuid multiple times with same input, given that a hypervisor is not allowed to change the result of cpuid during runtime.