### PR TITLE
Fix bug to allow reading large (>4kish) files.

### DIFF
--- a/src/drivers/virtioblk.cpp
+++ b/src/drivers/virtioblk.cpp
@@ -34,7 +34,7 @@ void null_deleter(uint8_t*) {};
 #include <statman>
 
 VirtioBlk::VirtioBlk(hw::PCI_Device& d)
-  : Virtio(d), hw::Drive(), req(queue_size(0), 0, iobase())
+  : Virtio(d), hw::Drive(), req(queue_size(0), 0, iobase()), inflight(0)
 {
   INFO("VirtioBlk", "Driver initializing");
   {


### PR DESCRIPTION
Simply initialise VirtioBlk::inflight to 0 in the constructor, to allow reference count to reach 0 (and fire the callback).