### PR TITLE
Adds missing exit value checks in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ A longer list of features and limitations is on the [wiki feature list](https://
 
 ### Install libraries
 
+**NOTE:** The script will install packages and create a network bridge, and thus will ask for sudo access.
+
 ```
     $ git clone https://github.com/hioa-cs/IncludeOS
     $ cd IncludeOS
-    $ sudo ./install.sh
+    $ ./install.sh
 ```
 
 **The script will:**
@@ -56,8 +58,6 @@ A longer list of features and limitations is on the [wiki feature list](https://
 * Create a network bridge called `include0`, for tap-networking.
 * Build the vmbuilder, which turns your service into a bootable image.
 * Copy `vmbuild` and `qemu-ifup` from the repo, over to `$INCLUDEOS_HOME`.
-
-**NOTE:** The script will install packages, and thus will require sudo access.
 
 Detailed installation instructions for [Vagrant](https://github.com/hioa-cs/IncludeOS/wiki/Vagrant), [OS X](https://github.com/hioa-cs/IncludeOS/wiki/OS-X) and [Ubuntu](https://github.com/hioa-cs/IncludeOS/wiki/Ubuntu) are available in the Wiki, as well as instructions for [building everything from source](https://github.com/hioa-cs/IncludeOS/wiki/Ubuntu#b-completely-build-everything-from-source-slow).
 

--- a/etc/create_bridge.sh
+++ b/etc/create_bridge.sh
@@ -8,11 +8,16 @@ GATEWAY=10.0.0.1
 NETWORK=10.0.0.0
 DHCPRANGE=10.0.0.2,10.0.0.254
 
-brctl addbr $BRIDGE
-ifconfig $BRIDGE $GATEWAY netmask $NETMASK up 
+# Check if bridge already is created
+if brctl show $BRIDGE 2>&1 | grep --silent "No such device"; then
+  sudo brctl addbr $BRIDGE || exit 1
+fi
+
+sudo ifconfig $BRIDGE $GATEWAY netmask $NETMASK up || exit 1
 
 # Håreks cool hack:
 # - First two bytes is fixed to "c001" because it's cool
 # - Last four is the gateway IP, 10.0.0.1
-ifconfig include0 hw ether c0:01:0a:00:00:01
+sudo ifconfig include0 hw ether c0:01:0a:00:00:01 || exit 1
 
+exit 0

--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -15,10 +15,10 @@ case $SYSTEM in
         case $RELEASE in
             "Ubuntu")
                 UBUNTU_VERSION=`lsb_release -rs`
-		if [ $(awk 'BEGIN{ print "'$UBUNTU_VERSION'"<"'16.04'" }') -eq 1 ]; then
+                if [ $(awk 'BEGIN{ print "'$UBUNTU_VERSION'"<"'16.04'" }') -eq 1 ]; then
                     clang_version="3.6"
                     DEPENDENCIES="gcc-5 g++-5"
-                    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+                    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test || exit 1
                 else
                     clang_version="3.8"
                 fi
@@ -26,15 +26,15 @@ case $SYSTEM in
                 DEPENDENCIES="curl make clang-$clang_version nasm bridge-utils qemu jq $DEPENDENCIES"
                 echo ">>> Installing dependencies (requires sudo):"
                 echo "    Packages: $DEPENDENCIES"
-                sudo apt-get update
-                sudo apt-get install -y $DEPENDENCIES
+                sudo apt-get update || exit 1
+                sudo apt-get install -y $DEPENDENCIES || exit 1
                 exit 0;
                 ;;
             "Fedora")
                 DEPENDENCIES="curl make clang nasm bridge-utils qemu jq"
                 echo ">>> Installing dependencies (requires sudo):"
                 echo "    Packages: $DEPENDENCIES"
-                sudo dnf install $DEPENDENCIES
+                sudo dnf install $DEPENDENCIES || exit 1
                 exit 0;
                 ;;
         esac


### PR DESCRIPTION
So this is basically just some additional return / exit value checks in the install scripts to make it more robust. I found most of these problems when trying to install IncludeOS under Debian stable. Most of the build steps failed but the script kept going, and finally outputted "Done! Test your installation with ./test.sh", which was kind of .. not so good. This commit partially solves #620 .

I removed the "sudo" part from the README since the script will use sudo when needed. Using sudo when executing install.sh will also build and install everything as root:root and that is probably not want most users want.

I'm not sure if the check for "sudo" is necessary since all supported systems have sudo installer per default (?). Debian does however not, and that's why I added it.