### PR TITLE
kernel: draft of cpuid rewrite

### DIFF
--- a/api/kernel/cpuid.hpp
+++ b/api/kernel/cpuid.hpp
@@ -19,10 +19,86 @@
 #ifndef KERNEL_CPUID_HPP
 #define KERNEL_CPUID_HPP
 
-struct CPUID {
-  static bool isAmdCpu();
-  static bool isIntelCpu();
-  static bool hasRDRAND();
-}; //< CPUID
+namespace CPUID
+{
+  enum class Feature
+  {
+    // ------------------------------------------------------------------------
+    // Processor Info and Feature Bits
+    // ------------------------------------------------------------------------
+    SSE3,              // Streaming SIMD Extensions 3
+    PCLMULQDQ,         // PCLMULQDQ Instruction
+    DTES64,            // 64-Bit Debug Store Area
+    MONITOR,           // MONITOR/MWAIT
+    DS_CPL,            // CPL Qualified Debug Store
+    VMX,               // Virtual Machine Extensions
+    SMX,               // Safer Mode Extensions
+    EST,               // Enhanced SpeedStep Technology
+    TM2,               // Thermal Monitor 2
+    SSSE3,             // Supplemental Streaming SIMD Extensions 3
+    CNXT_ID,           // L1 Context ID
+    FMA,               // Fused Multiply Add
+    CX16,              // CMPXCHG16B Instruction
+    XTPR,              // xTPR Update Control
+    PDCM,              // Perf/Debug Capability MSR
+    PCID,              // Process-context Identifiers
+    DCA,               // Direct Cache Access
+    SSE4_1,            // Streaming SIMD Extensions 4.1
+    SSE4_2,            // Streaming SIMD Extensions 4.2
+    X2APIC,            // Extended xAPIC Support
+    MOVBE,             // MOVBE Instruction
+    POPCNT,            // POPCNT Instruction
+    TSC_DEADLINE,      // Local APIC supports TSC Deadline
+    AES,               // AESNI Instruction
+    XSAVE,             // XSAVE/XSTOR States
+    OSXSAVE,           // OS Enabled Extended State Management
+    AVX,               // AVX Instructions
+    F16C,              // 16-bit Floating Point Instructions
+    RDRAND,            // RDRAND Instruction
+
+    FPU,               // Floating-Point Unit On-Chip
+    VME,               // Virtual 8086 Mode Extensions
+    DE,                // Debugging Extensions
+    PSE,               // Page Size Extension
+    TSC,               // Time Stamp Counter
+    MSR,               // Model Specific Registers
+    PAE,               // Physical Address Extension
+    MCE,               // Machine-Check Exception
+    CX8,               // CMPXCHG8 Instruction
+    APIC,              // APIC On-Chip
+    SEP,               // SYSENTER/SYSEXIT instructions
+    MTRR,              // Memory Type Range Registers
+    PGE,               // Page Global Bit
+    MCA,               // Machine-Check Architecture
+    CMOV,              // Conditional Move Instruction
+    PAT,               // Page Attribute Table
+    PSE_36,            // 36-bit Page Size Extension
+    PSN,               // Processor Serial Number
+    CLFLUSH,           // CLFLUSH Instruction
+    DS,                // Debug Store
+    ACPI,              // Thermal Monitor and Software Clock Facilities
+    MMX,               // MMX Technology
+    FXSR,              // FXSAVE and FXSTOR Instructions
+    SSE,               // Streaming SIMD Extensions
+    SSE2,              // Streaming SIMD Extensions 2
+    SS,                // Self Snoop
+    HTT,               // Multi-Threading
+    TM,                // Thermal Monitor
+    PBE,               // Pending Break Enable
+
+    // ------------------------------------------------------------------------
+    // Extended Processor Info and Feature Bits (not complete)
+    // ------------------------------------------------------------------------
+    SYSCALL,           // SYSCALL/SYSRET
+    NX,                // Execute Disable Bit
+    PDPE1GB,           // 1 GB Pages
+    RDTSCP,            // RDTSCP and IA32_TSC_AUX
+    LM,                // Long mode (64-bit Architecture)
+  };
+
+  bool isAmdCpu();
+  bool isIntelCpu();
+  bool hasFeature(Feature f);
+} //< CPUID
 
 #endif //< KERNEL_CPUID_HPP

--- a/src/kernel/cpuid.cpp
+++ b/src/kernel/cpuid.cpp
@@ -17,114 +17,201 @@
 
 #include <kernel/cpuid.hpp>
 #include <cstring>
+#include <cstdint>
+#include <array>
 
-#define ECX_SSE3                    (1 << 0)    // Streaming SIMD Extensions 3
-#define ECX_PCLMULQDQ               (1 << 1)    // PCLMULQDQ Instruction
-#define ECX_DTES64                  (1 << 2)    // 64-Bit Debug Store Area
-#define ECX_MONITOR                 (1 << 3)    // MONITOR/MWAIT
-#define ECX_DS_CPL                  (1 << 4)    // CPL Qualified Debug Store
-#define ECX_VMX                     (1 << 5)    // Virtual Machine Extensions
-#define ECX_SMX                     (1 << 6)    // Safer Mode Extensions
-#define ECX_EST                     (1 << 7)    // Enhanced SpeedStep Technology
-#define ECX_TM2                     (1 << 8)    // Thermal Monitor 2
-#define ECX_SSSE3                   (1 << 9)    // Supplemental Streaming SIMD Extensions 3
-#define ECX_CNXT_ID                 (1 << 10)   // L1 Context ID
-#define ECX_FMA                     (1 << 12)   // Fused Multiply Add
-#define ECX_CX16                    (1 << 13)   // CMPXCHG16B Instruction
-#define ECX_XTPR                    (1 << 14)   // xTPR Update Control
-#define ECX_PDCM                    (1 << 15)   // Perf/Debug Capability MSR
-#define ECX_PCID                    (1 << 17)   // Process-context Identifiers
-#define ECX_DCA                     (1 << 18)   // Direct Cache Access
-#define ECX_SSE41                   (1 << 19)   // Streaming SIMD Extensions 4.1
-#define ECX_SSE42                   (1 << 20)   // Streaming SIMD Extensions 4.2
-#define ECX_X2APIC                  (1 << 21)   // Extended xAPIC Support
-#define ECX_MOVBE                   (1 << 22)   // MOVBE Instruction
-#define ECX_POPCNT                  (1 << 23)   // POPCNT Instruction
-#define ECX_TSC                     (1 << 24)   // Local APIC supports TSC Deadline
-#define ECX_AESNI                   (1 << 25)   // AESNI Instruction
-#define ECX_XSAVE                   (1 << 26)   // XSAVE/XSTOR States
-#define ECX_OSXSAVE                 (1 << 27)   // OS Enabled Extended State Management
-#define ECX_AVX                     (1 << 28)   // AVX Instructions
-#define ECX_F16C                    (1 << 29)   // 16-bit Floating Point Instructions
-#define ECX_RDRAND                  (1 << 30)   // RDRAND Instruction
+namespace
+{
+  using namespace CPUID;
 
-#define EDX_FPU                     (1 << 0)    // Floating-Point Unit On-Chip
-#define EDX_VME                     (1 << 1)    // Virtual 8086 Mode Extensions
-#define EDX_DE                      (1 << 2)    // Debugging Extensions
-#define EDX_PSE                     (1 << 3)    // Page Size Extension
-#define EDX_TSC                     (1 << 4)    // Time Stamp Counter
-#define EDX_MSR                     (1 << 5)    // Model Specific Registers
-#define EDX_PAE                     (1 << 6)    // Physical Address Extension
-#define EDX_MCE                     (1 << 7)    // Machine-Check Exception
-#define EDX_CX8                     (1 << 8)    // CMPXCHG8 Instruction
-#define EDX_APIC                    (1 << 9)    // APIC On-Chip
-#define EDX_SEP                     (1 << 11)   // SYSENTER/SYSEXIT instructions
-#define EDX_MTRR                    (1 << 12)   // Memory Type Range Registers
-#define EDX_PGE                     (1 << 13)   // Page Global Bit
-#define EDX_MCA                     (1 << 14)   // Machine-Check Architecture
-#define EDX_CMOV                    (1 << 15)   // Conditional Move Instruction
-#define EDX_PAT                     (1 << 16)   // Page Attribute Table
-#define EDX_PSE36                   (1 << 17)   // 36-bit Page Size Extension
-#define EDX_PSN                     (1 << 18)   // Processor Serial Number
-#define EDX_CLFLUSH                 (1 << 19)   // CLFLUSH Instruction
-#define EDX_DS                      (1 << 21)   // Debug Store
-#define EDX_ACPI                    (1 << 22)   // Thermal Monitor and Software Clock Facilities
-#define EDX_MMX                     (1 << 23)   // MMX Technology
-#define EDX_FXSR                    (1 << 24)   // FXSAVE and FXSTOR Instructions
-#define EDX_SSE                     (1 << 25)   // Streaming SIMD Extensions
-#define EDX_SSE2                    (1 << 26)   // Streaming SIMD Extensions 2
-#define EDX_SS                      (1 << 27)   // Self Snoop
-#define EDX_HTT                     (1 << 28)   // Multi-Threading
-#define EDX_TM                      (1 << 29)   // Thermal Monitor
-#define EDX_PBE                     (1 << 31)   // Pending Break Enable
+  enum class Register { EAX, EBX, ECX, EDX };
 
-// ------------------------------------------------------------------------------------------------
-// Extended Function 0x01
+  struct FeatureInfo
+  {
+    // Input when calling cpuid (eax and ecx)
+    const uint32_t func;
+    const uint32_t subfunc;
 
-#define EDX_SYSCALL                 (1 << 11)   // SYSCALL/SYSRET
-#define EDX_XD                      (1 << 20)   // Execute Disable Bit
-#define EDX_1GB_PAGE                (1 << 26)   // 1 GB Pages
-#define EDX_RDTSCP                  (1 << 27)   // RDTSCP and IA32_TSC_AUX
-#define EDX_64_BIT                  (1 << 29)   // 64-bit Architecture
+    // Register and bit that holds the result
+    const Register register_;
+    const uint32_t bitmask;
+  };
 
-struct cpuid_t {
-  unsigned int EAX;
-  unsigned int EBX;
-  unsigned int ECX;
-  unsigned int EDX;
-}; //< cpuid_t
+  constexpr auto get_feature_info(Feature f)
+  {
+    using Register::EAX;
+    using Register::EBX;
+    using Register::ECX;
+    using Register::EDX;
 
-// EBX/RBX needs to be preserved depending on the memory model and use of PIC
-static cpuid_t
-cpuid_info(unsigned func, unsigned subfunc) {
-  cpuid_t info;
-  asm volatile ("cpuid"
-    : "=a"(info.EAX), "=b"(info.EBX), "=c"(info.ECX), "=d"(info.EDX)
-    : "a"(func), "c"(subfunc) : "%eax", "%ebx", "%ecx", "%edx");
-  return info;
-}
+    // Use switch-case so that the we get compiler warnings if
+    // we forget to add information for features that we have declared
+    switch (f)
+    {
+      // ----------------------------------------------------------------------
+      // EAX=1: Processor Info and Feature Bits
+      // ----------------------------------------------------------------------
+      case Feature::SSE3:         return FeatureInfo { 1, 0, ECX, 1u <<  0 }; // Streaming SIMD Extensions 3
+      case Feature::PCLMULQDQ:    return FeatureInfo { 1, 0, ECX, 2u <<  0 }; // PCLMULQDQ Instruction
+      case Feature::DTES64:       return FeatureInfo { 1, 0, ECX, 1u <<  2 }; // 64-Bit Debug Store Area
+      case Feature::MONITOR:      return FeatureInfo { 1, 0, ECX, 1u <<  3 }; // MONITOR/MWAIT
+      case Feature::DS_CPL:       return FeatureInfo { 1, 0, ECX, 1u <<  4 }; // CPL Qualified Debug Store
+      case Feature::VMX:          return FeatureInfo { 1, 0, ECX, 1u <<  5 }; // Virtual Machine Extensions
+      case Feature::SMX:          return FeatureInfo { 1, 0, ECX, 1u <<  6 }; // Safer Mode Extensions
+      case Feature::EST:          return FeatureInfo { 1, 0, ECX, 1u <<  7 }; // Enhanced SpeedStep Technology
+      case Feature::TM2:          return FeatureInfo { 1, 0, ECX, 1u <<  8 }; // Thermal Monitor 2
+      case Feature::SSSE3:        return FeatureInfo { 1, 0, ECX, 1u <<  9 }; // Supplemental Streaming SIMD Extensions 3
+      case Feature::CNXT_ID:      return FeatureInfo { 1, 0, ECX, 1u << 10 }; // L1 Context ID
+      case Feature::FMA:          return FeatureInfo { 1, 0, ECX, 1u << 12 }; // Fused Multiply Add
+      case Feature::CX16:         return FeatureInfo { 1, 0, ECX, 1u << 13 }; // CMPXCHG16B Instruction
+      case Feature::XTPR:         return FeatureInfo { 1, 0, ECX, 1u << 14 }; // xTPR Update Control
+      case Feature::PDCM:         return FeatureInfo { 1, 0, ECX, 1u << 15 }; // Perf/Debug Capability MSR
+      case Feature::PCID:         return FeatureInfo { 1, 0, ECX, 1u << 17 }; // Process-context Identifiers
+      case Feature::DCA:          return FeatureInfo { 1, 0, ECX, 1u << 18 }; // Direct Cache Access
+      case Feature::SSE4_1:       return FeatureInfo { 1, 0, ECX, 1u << 19 }; // Streaming SIMD Extensions 4.1
+      case Feature::SSE4_2:       return FeatureInfo { 1, 0, ECX, 1u << 20 }; // Streaming SIMD Extensions 4.2
+      case Feature::X2APIC:       return FeatureInfo { 1, 0, ECX, 1u << 21 }; // Extended xAPIC Support
+      case Feature::MOVBE:        return FeatureInfo { 1, 0, ECX, 1u << 22 }; // MOVBE Instruction
+      case Feature::POPCNT:       return FeatureInfo { 1, 0, ECX, 1u << 23 }; // POPCNT Instruction
+      case Feature::TSC_DEADLINE: return FeatureInfo { 1, 0, ECX, 1u << 24 }; // Local APIC supports TSC Deadline
+      case Feature::AES:          return FeatureInfo { 1, 0, ECX, 1u << 25 }; // AESNI Instruction
+      case Feature::XSAVE:        return FeatureInfo { 1, 0, ECX, 1u << 26 }; // XSAVE/XSTOR States
+      case Feature::OSXSAVE:      return FeatureInfo { 1, 0, ECX, 1u << 27 }; // OS Enabled Extended State Management
+      case Feature::AVX:          return FeatureInfo { 1, 0, ECX, 1u << 28 }; // AVX Instructions
+      case Feature::F16C:         return FeatureInfo { 1, 0, ECX, 1u << 29 }; // 16-bit Floating Point Instructions
+      case Feature::RDRAND:       return FeatureInfo { 1, 0, ECX, 1u << 30 }; // RDRAND Instruction
 
-bool CPUID::isAmdCpu() {
-  cpuid_t info = cpuid_info(0, 0);
-  return
-     memcmp((char*) &info.EBX, "htuA", 4) == 0
-  && memcmp((char*) &info.EDX, "itne", 4) == 0
-  && memcmp((char*) &info.ECX, "DMAc", 4) == 0;
-}
+      case Feature::FPU:          return FeatureInfo { 1, 0, EDX, 1u <<  0 }; // Floating-Point Unit On-Chip
+      case Feature::VME:          return FeatureInfo { 1, 0, EDX, 1u <<  1 }; // Virtual 8086 Mode Extensions
+      case Feature::DE:           return FeatureInfo { 1, 0, EDX, 1u <<  2 }; // Debugging Extensions
+      case Feature::PSE:          return FeatureInfo { 1, 0, EDX, 1u <<  3 }; // Page Size Extension
+      case Feature::TSC:          return FeatureInfo { 1, 0, EDX, 1u <<  4 }; // Time Stamp Counter
+      case Feature::MSR:          return FeatureInfo { 1, 0, EDX, 1u <<  5 }; // Model Specific Registers
+      case Feature::PAE:          return FeatureInfo { 1, 0, EDX, 1u <<  6 }; // Physical Address Extension
+      case Feature::MCE:          return FeatureInfo { 1, 0, EDX, 1u <<  7 }; // Machine-Check Exception
+      case Feature::CX8:          return FeatureInfo { 1, 0, EDX, 1u <<  8 }; // CMPXCHG8 Instruction
+      case Feature::APIC:         return FeatureInfo { 1, 0, EDX, 1u <<  9 }; // APIC On-Chip
+      case Feature::SEP:          return FeatureInfo { 1, 0, EDX, 1u << 11 }; // SYSENTER/SYSEXIT instructions
+      case Feature::MTRR:         return FeatureInfo { 1, 0, EDX, 1u << 12 }; // Memory Type Range Registers
+      case Feature::PGE:          return FeatureInfo { 1, 0, EDX, 1u << 13 }; // Page Global Bit
+      case Feature::MCA:          return FeatureInfo { 1, 0, EDX, 1u << 14 }; // Machine-Check Architecture
+      case Feature::CMOV:         return FeatureInfo { 1, 0, EDX, 1u << 15 }; // Conditional Move Instruction
+      case Feature::PAT:          return FeatureInfo { 1, 0, EDX, 1u << 16 }; // Page Attribute Table
+      case Feature::PSE_36:       return FeatureInfo { 1, 0, EDX, 1u << 17 }; // 36-bit Page Size Extension
+      case Feature::PSN:          return FeatureInfo { 1, 0, EDX, 1u << 18 }; // Processor Serial Number
+      case Feature::CLFLUSH:      return FeatureInfo { 1, 0, EDX, 1u << 19 }; // CLFLUSH Instruction
+      case Feature::DS:           return FeatureInfo { 1, 0, EDX, 1u << 21 }; // Debug Store
+      case Feature::ACPI:         return FeatureInfo { 1, 0, EDX, 1u << 22 }; // Thermal Monitor and Software Clock Facilities
+      case Feature::MMX:          return FeatureInfo { 1, 0, EDX, 1u << 23 }; // MMX Technology
+      case Feature::FXSR:         return FeatureInfo { 1, 0, EDX, 1u << 24 }; // FXSAVE and FXSTOR Instructions
+      case Feature::SSE:          return FeatureInfo { 1, 0, EDX, 1u << 25 }; // Streaming SIMD Extensions
+      case Feature::SSE2:         return FeatureInfo { 1, 0, EDX, 1u << 26 }; // Streaming SIMD Extensions 2
+      case Feature::SS:           return FeatureInfo { 1, 0, EDX, 1u << 27 }; // Self Snoop
+      case Feature::HTT:          return FeatureInfo { 1, 0, EDX, 1u << 28 }; // Multi-Threading
+      case Feature::TM:           return FeatureInfo { 1, 0, EDX, 1u << 29 }; // Thermal Monitor
+      case Feature::PBE:          return FeatureInfo { 1, 0, EDX, 1u << 31 }; // Pending Break Enable
 
-bool CPUID::isIntelCpu() {
-  cpuid_t info = cpuid_info(0, 0);
-  return
-     memcmp((char*) &info.EBX, "Genu", 4) == 0
-  && memcmp((char*) &info.EDX, "ineI", 4) == 0
-  && memcmp((char*) &info.ECX, "ntel", 4) == 0;
-}
-
-bool CPUID::hasRDRAND() {
-  if (!isAmdCpu() && !isIntelCpu()) {
-    return false;
+      // ----------------------------------------------------------------------
+      // EAX=80000001h: Extended Processor Info and Feature Bits (not complete)
+      // ----------------------------------------------------------------------
+      case Feature::SYSCALL:      return FeatureInfo { 0x80000001, 0, EDX, 1u << 11 }; // SYSCALL/SYSRET
+      case Feature::NX:           return FeatureInfo { 0x80000001, 0, EDX, 1u << 20 }; // Execute Disable Bit
+      case Feature::PDPE1GB:      return FeatureInfo { 0x80000001, 0, EDX, 1u << 26 }; // 1 GB Pages
+      case Feature::RDTSCP:       return FeatureInfo { 0x80000001, 0, EDX, 1u << 27 }; // RDTSCP and IA32_TSC_AUX
+      case Feature::LM:           return FeatureInfo { 0x80000001, 0, EDX, 1u << 29 }; // 64-bit Architecture
+    }
   }
 
-  cpuid_t info = cpuid_info(1, 0);
-  return (info.ECX & ECX_RDRAND) != 0;
+  // Holds results of call to cpuid
+  struct cpuid_t
+  {
+    uint32_t EAX;
+    uint32_t EBX;
+    uint32_t ECX;
+    uint32_t EDX;
+  }; //< cpuid_t
+
+  cpuid_t cpuid(uint32_t func, uint32_t subfunc)
+  {
+    // Cache up to 4 results
+    struct cpuid_cache_t
+    {
+      // cpuid input
+      uint32_t func;
+      uint32_t subfunc;
+
+      // cpuid output
+      cpuid_t result;
+
+      // valid or not in cache
+      bool valid;
+    };
+    static std::array<cpuid_cache_t, 4> cache = {};
+
+    // Check cache for cpuid result
+    for (const auto& cached : cache)
+    {
+      if (cached.valid &&
+          cached.func == func &&
+          cached.subfunc == subfunc)
+      {
+        return cached.result;
+      }
+    }
+
+    // Call cpuid
+    // EBX/RBX needs to be preserved depending on the memory model and use of PIC
+    cpuid_t result;
+    asm volatile ("cpuid"
+      : "=a"(result.EAX), "=b"(result.EBX), "=c"(result.ECX), "=d"(result.EDX)
+      : "a"(func), "c"(subfunc) : "%eax", "%ebx", "%ecx", "%edx");
+
+    // Try to find an empty spot in the cache
+    for (auto& cached : cache)
+    {
+      if (!cached.valid)
+      {
+        cached.func = func;
+        cached.subfunc = subfunc;
+        cached.result = result;
+        cached.valid = true;
+        break;
+      }
+    }
+
+    return result;
+  }
+
+} //< namespace
+
+bool CPUID::isAmdCpu()
+{
+  auto result = cpuid(0, 0);
+  return
+     memcmp(reinterpret_cast<char*>(&result.EBX), "htuA", 4) == 0
+  && memcmp(reinterpret_cast<char*>(&result.EDX), "itne", 4) == 0
+  && memcmp(reinterpret_cast<char*>(&result.ECX), "DMAc", 4) == 0;
+}
+
+bool CPUID::isIntelCpu()
+{
+  auto result = cpuid(0, 0);
+  return
+     memcmp(reinterpret_cast<char*>(&result.EBX), "Genu", 4) == 0
+  && memcmp(reinterpret_cast<char*>(&result.EDX), "ineI", 4) == 0
+  && memcmp(reinterpret_cast<char*>(&result.ECX), "ntel", 4) == 0;
+}
+
+bool CPUID::hasFeature(Feature f)
+{
+  const auto feature_info = get_feature_info(f);
+  const auto cpuid_result = cpuid(feature_info.func, feature_info.subfunc);
+
+  switch (feature_info.register_)
+  {
+    case Register::EAX: return (cpuid_result.EAX & feature_info.bitmask) != 0;
+    case Register::EBX: return (cpuid_result.EBX & feature_info.bitmask) != 0;
+    case Register::ECX: return (cpuid_result.ECX & feature_info.bitmask) != 0;
+    case Register::EDX: return (cpuid_result.EDX & feature_info.bitmask) != 0;
+  }
 }


### PR DESCRIPTION
First draft of cpuid rewrite. Open questions:

- Is the cache necessary? I did some research and found that cpuid is a pretty expensive call, but maybe the overhead of the cache makes it useless.
- Maybe add vendor information to each `FeatureInfo` since not all features are applicable to both Intel and AMD CPUs. At the moment the user needs to first check `isIntelCpu` or `isAmdCpu` before asking for a specific feature (if the feature is not applicable to both).