### PR TITLE
Add support for Arch Linux (and its flavors).

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ A longer list of features and limitations is on the [wiki feature list](https://
     $ sudo ./install.sh
 ```
 
+Or if you are running Arch Linux (or one of its flavors):
+
+```
+    $ git clone https://github.com/hioa-cs/IncludeOS
+    $ cd IncludeOS
+    $ ./install.sh
+```
+
 **The script will:**
 
 * Install the required dependencies: `curl make clang-3.8 nasm bridge-utils qemu`.

--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -37,6 +37,14 @@ case $SYSTEM in
                 sudo dnf install $DEPENDENCIES
                 exit 0;
                 ;;
+            "Arch")
+                DEPENDENCIES="curl make clang nasm bridge-utils qemu jq"
+                echo ">>> Installing dependencies (requires sudo):"
+                echo "    Packages: $DEPENDENCIES"
+                sudo pacman -Syyu
+                sudo pacman -S $DEPENDENCIES
+                exit 0;
+                ;;
         esac
 esac
 

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,9 @@ check_os_support() {
                     export INCLUDEOS_SRC=`pwd`
                     return 0;
                     ;;
+                "Arch")
+                    return 0;
+                    ;;
             esac
     esac
     return 1;
@@ -35,7 +38,7 @@ check_os_support() {
 # check if system is supported at all
 if ! check_os_support $SYSTEM $RELEASE; then
     echo -e ">>> Sorry <<< \n\
-Currently only Ubuntu, Fedora and OSX are actively supported for *building* IncludeOS. \n\
+Currently only Ubuntu, Fedora, Arch, and OSX are actively supported for *building* IncludeOS. \n\
 On other Linux distros it shouldn't be that hard to get it to work - take a look at\n \
 ./etc/install_from_bundle.sh \n"
     exit 1


### PR DESCRIPTION
This simple patch enables setting up IncludeOS on Arch Linux and its flavors.