### PR TITLE
install: do not use sudo if not needed

### DIFF
--- a/etc/create_bridge.sh
+++ b/etc/create_bridge.sh
@@ -1,23 +1,43 @@
-#! /bin/sh
+#!/bin/sh
 
 BRIDGE=include0
 NETMASK=255.255.0.0
 GATEWAY=10.0.0.1
 
+# Håreks cool hack:
+# - First two bytes is fixed to "c001" because it's cool
+# - Last four is the gateway IP, 10.0.0.1
+HWADDR=c0:01:0a:00:00:01
+
 # For later use
 NETWORK=10.0.0.0
 DHCPRANGE=10.0.0.2,10.0.0.254
 
-# Check if bridge already is created
-if brctl show $BRIDGE 2>&1 | grep --silent "No such device"; then
+# Check if bridge is created
+if brctl show $BRIDGE 2>&1 | grep -q "No such device"; then
+  echo ">>> Creating network bridge (requires sudo):"
   sudo brctl addbr $BRIDGE || exit 1
+else
+  echo ">>> Network bridge already created"
 fi
 
-sudo ifconfig $BRIDGE $GATEWAY netmask $NETMASK up || exit 1
+# Check if bridge is configured
+if ip -o link show $BRIDGE | grep -q "$HWADDR"; then
+  echo ">>> Network bridge already configured"
 
-# Håreks cool hack:
-# - First two bytes is fixed to "c001" because it's cool
-# - Last four is the gateway IP, 10.0.0.1
-sudo ifconfig include0 hw ether c0:01:0a:00:00:01 || exit 1
+  # Make sure that the bridge is activated
+  if ip -o link show $BRIDGE | grep -q "UP"; then
+    echo ">>> Network bridge already activated"
+  else
+    echo ">>> Activating network bridge (requires sudo):"
+    sudo ifconfig $BRIDGE up || exit 1
+  fi
+else
+  # Configure and activate bridge
+  echo ">>> Configuring network bridge (requires sudo):"
+
+  sudo ifconfig $BRIDGE $GATEWAY netmask $NETMASK up || exit 1
+  sudo ifconfig $BRIDGE hw ether $HWADDR || exit 1
+fi
 
 exit 0

--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -24,10 +24,16 @@ case $SYSTEM in
                 fi
 
                 DEPENDENCIES="curl make clang-$clang_version nasm bridge-utils qemu jq $DEPENDENCIES"
-                echo ">>> Installing dependencies (requires sudo):"
-                echo "    Packages: $DEPENDENCIES"
-                sudo apt-get update || exit 1
-                sudo apt-get install -y $DEPENDENCIES || exit 1
+
+                # Check if packages are installed
+                if dpkg-query -l $DEPENDENCIES > /dev/null 2>&1; then
+                  echo ">>> Required packages are already installed"
+                else
+                  echo ">>> Installing dependencies (requires sudo):"
+                  echo "    Packages: $DEPENDENCIES"
+                  sudo apt-get update || exit 1
+                  sudo apt-get install -y $DEPENDENCIES || exit 1
+                fi
                 exit 0;
                 ;;
             "Fedora")

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ Could not install from bundle. \n"
         exit 1
     fi
 
-    echo -e "\n\n>>> Creating a virtual network, i.e. a bridge. (Requires sudo)"
+    echo
     if ! ./etc/create_bridge.sh; then
         echo -e ">>> Sorry <<< \n\
 Could not create or configure bridge. \n"


### PR DESCRIPTION
* Adds check of installed packages before calling sudo apt-get
  (Ubuntu only)
* Adds check of created / configured bridge before calling
  sudo brctl and sudo ifconfig

You can now run ./install.sh without needing to enter password for sudo if everything is already installed.

**NOTE:** Can someone test this on other platforms? I'm not 100% sure if OS X, Fedora and Arch has the command `ip`. Otherwise we need to add a check for that and always configure the bridge, even if it's not actually needed.