### PR TITLE
profile: Adds ScopedProfiler

### DIFF
--- a/api/profile
+++ b/api/profile
@@ -119,6 +119,16 @@ class ScopedProfiler
     uint64_t    cycles_average;
   };
 
+
+  // The guard to use, before calling rdtsc
+  static enum class Guard
+  {
+    NOT_SELECTED,
+    LFENCE,
+    MFENCE,
+    NOT_AVAILABLE,
+  } guard;
+
   // Use plain array for performance (cache locality)
   // Increase size if there is a need to profile more than 64 scopes
   static std::array<Entry, 64> entries;

--- a/api/profile
+++ b/api/profile
@@ -7,9 +7,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@
 #define API_PROFILE_HEADER
 
 #include <cstdint>
+#include <array>
 #include <string>
 #include <vector>
 
@@ -35,27 +36,92 @@ struct StackSampler
   // sets up stack sampling configuration and internal timer
   // the stack sampling will happen in the background afterwards
   static void begin();
-  
+
   // total number of waking samples taken
   static uint64_t samples_total();
-  
+
   // total number of samples taken while asleep
   static uint64_t samples_asleep();
-  
+
   // retrieve N top results/hotspots
   static std::vector<Sample> results(int N);
-  
+
   // enable or disable sample-taking
   // eg. disable sampling during stack sample result printout
   static void set_mask(bool);
-  
+
   enum mode_t {
     MODE_CURRENT,
     MODE_CALLER,
   };
-  
+
   // set sampling mode
   static void set_mode(mode_t);
+};
+
+/**
+ * @brief Scoped Profiler
+ *
+ * Measures the average execution time of a scope
+ *
+ * Example:
+ * Create a ScopedProfiler in the scope that should be measuered:
+ *
+ * void my_function()
+ * {
+ *   ScopedProfiler sp;
+ *
+ *   do_stuff();
+ *   do_more_stuff();
+ * }
+ *
+ * Call ScopedProfiler::get_statistics() to get a formatted std::string of
+ * statistics
+ *
+ */
+class ScopedProfiler
+{
+ public:
+  ScopedProfiler();
+  ~ScopedProfiler();
+
+  // No copying or moving
+  ScopedProfiler(const ScopedProfiler&) = delete;
+  ScopedProfiler& operator=(const ScopedProfiler&) = delete;
+  ScopedProfiler(ScopedProfiler&&) = delete;
+  ScopedProfiler& operator=(ScopedProfiler&&) = delete;
+
+  /**
+   * @brief Returns profiling statistics as a formatted std::string
+   *
+   * Formats the output like:
+   *
+   *  Average Time (us) | Samples | Function Name
+   *  --------------------------------------------------------------------------------
+   *         172.768148 |    1212 | Foo::my_function()
+   *          40.603411 |    1223 | Foo::my_other_function()
+   *          15.460829 |     602 | Bar::Bar()
+   *          15.189189 |     600 | Bar::~Bar()
+   *  --------------------------------------------------------------------------------
+   *
+   */
+  static std::string get_statistics();
+
+ private:
+  uint64_t tick_start;
+
+  struct Entry
+  {
+    void*       function_address;  // This identifies an Entry
+                                   // function_address == 0 => the Entry is unused
+    std::string function_name;
+    unsigned    num_samples;
+    uint64_t    cycles_average;
+  };
+
+  // Use plain array for performance (cache locality)
+  // Increase size if there is a need to profile more than 64 scopes
+  static std::array<Entry, 64> entries;
 };
 
 #endif

--- a/examples/scoped_profiler/Makefile
+++ b/examples/scoped_profiler/Makefile
@@ -1,0 +1,27 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# The name of your service
+SERVICE = Scoped_Profiler_Demo
+SERVICE_NAME = IncludeOS Scoped Profiler Demo
+
+# Your service parts
+FILES = service.cpp
+
+# Your disk image
+DISK=
+
+# Your own include-path
+LOCAL_INCLUDES=
+
+# Add networking driver
+DRIVERS=virtionet
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+endif
+
+# Include the installed seed makefile
+include $(INCLUDEOS_INSTALL)/Makeseed

--- a/examples/scoped_profiler/README.md
+++ b/examples/scoped_profiler/README.md
@@ -1,0 +1,25 @@
+### IncludeOS Scoped Profiler Demo
+
+Add `ScopedProfiler sp;` in the scopes that you want to profile. Don't forget to `#include <profile>`.
+
+Rebuild / install IncludeOS:
+
+```
+cd IncludeOS/src
+make
+make install
+```
+
+Build and run this service:
+
+```
+cd IncludeOS/examples/scoped_profiler
+make
+./run.sh
+```
+
+Make something happen in the OS and then use wget or curl to `GET /profile` to see statistics:
+
+```
+curl 10.0.0.42/profile
+```

--- a/examples/scoped_profiler/run.sh
+++ b/examples/scoped_profiler/run.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/scoped_profiler/service.cpp
+++ b/examples/scoped_profiler/service.cpp
@@ -1,0 +1,87 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <os>
+#include <net/inet4>
+#include <timers>
+#include <profile>
+#include <string>
+
+using namespace std::chrono;
+
+std::string create_html_response(const std::string& message)
+{
+  return "HTTP/1.1 200 OK\n"
+         "Date: Mon, 01 Jan 1970 00:00:01 GMT\n"
+         "Server: IncludeOS prototype 4.0\n"
+         "Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT\n"
+         "Content-Type: text/html; charset=UTF-8\n"
+         "Content-Length: " + std::to_string(message.size()) + "\n"
+         "Accept-Ranges: bytes\n"
+         "Connection: close\n"
+         "\n"
+         + message;
+}
+
+void Service::start(const std::string&)
+{
+  // DHCP on interface 0
+  auto& inet = net::Inet4::ifconfig<0>(10.0);
+
+  // static IP in case DHCP fails
+  net::Inet4::ifconfig(
+    { 10,0,0,42 },     // IP
+    { 255,255,255,0 }, // Netmask
+    { 10,0,0,1 },      // Gateway
+    { 10,0,0,1 });     // DNS
+
+  // Set up a TCP server on port 80
+  auto& server = inet.tcp().bind(80);
+
+  server.on_accept([](auto socket)
+  {
+    (void)socket;  // Not used
+    return true;
+  });
+
+  server.on_connect([](auto conn)
+  {
+    conn->on_read(1024, [conn](net::tcp::buffer_t buf, size_t n)
+    {
+      auto data = std::string(reinterpret_cast<char*>(buf.get()), n);
+      if (data.find("GET /profile ") != std::string::npos)
+      {
+        auto profile_statistics = ScopedProfiler::get_statistics();
+        auto response = create_html_response(profile_statistics + "\n");
+        conn->write(response.data(), response.size());
+      }
+      else
+      {
+        auto response = create_html_response("Hello\n");
+        conn->write(response.data(), response.size());
+      }
+    });
+
+    conn->on_disconnect([](auto conn, auto reason)
+    {
+      (void)reason;  // Not used
+      conn->close();
+    });
+  });
+
+  printf("*** TEST SERVICE STARTED ***\n");
+}

--- a/examples/scoped_profiler/service.cpp
+++ b/examples/scoped_profiler/service.cpp
@@ -52,12 +52,6 @@ void Service::start(const std::string&)
   // Set up a TCP server on port 80
   auto& server = inet.tcp().bind(80);
 
-  server.on_accept([](auto socket)
-  {
-    (void)socket;  // Not used
-    return true;
-  });
-
   server.on_connect([](auto conn)
   {
     conn->on_read(1024, [conn](net::tcp::buffer_t buf, size_t n)

--- a/src/kernel/profile.cpp
+++ b/src/kernel/profile.cpp
@@ -291,13 +291,10 @@ ScopedProfiler::~ScopedProfiler()
 
 std::string ScopedProfiler::get_statistics()
 {
-  // TODO: Make available in api/hw/cpu* ?
-  extern double _CPUFreq_;
-
   std::ostringstream ss;
 
   // Add header
-  ss << " Average Time (us) | Samples | Function Name \n";
+  ss << " CPU Cycles (average) | Samples | Function Name \n";
   ss << "--------------------------------------------------------------------------------\n";
 
   // Calculate the number of used entries
@@ -326,10 +323,8 @@ std::string ScopedProfiler::get_statistics()
     {
       const auto& entry = entries[i];
 
-      auto time_in_us = entry.cycles_average / _CPUFreq_;
-
-      ss.width(18);
-      ss << time_in_us << " | ";
+      ss.width(21);
+      ss << entry.cycles_average << " | ";
 
       ss.width(7);
       ss << entry.num_samples << " | ";


### PR DESCRIPTION
Notes:

* Calls cpuid before rdtsc due to http://stackoverflow.com/a/2918125/969365 (not sure if it's actually needed though)
* Not sure if we really need to add an example service. If you don't want it I can remove it.

I also did some testing before and after the "ptrstuff" commits (on bd60272f4d12c5530ef175ea472de8eca07f97fc and on adcf38c3f3df5cddd4e7592a719950df5d5fa70d):

Before:
```
--------------------------------------------------------------------------------
         29.366431 |    6013 | VirtioNet::msix_recv_handler()
         15.438494 |    3003 | VirtioNet::msix_xmit_handler()
--------------------------------------------------------------------------------
```

After:
```
 Average Time (us) | Samples | Function Name
--------------------------------------------------------------------------------
         26.893452 |    6013 | VirtioNet::msix_recv_handler()
         15.070289 |    3003 | VirtioNet::msix_xmit_handler()
--------------------------------------------------------------------------------
```