### PR TITLE
Pointing shellscript shebang to env-bash instead of hardcoding bash

### DIFF
--- a/etc/to-be-installed/run.sh
+++ b/etc/to-be-installed/run.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 if [[ $# -lt 1 ]]; then
     echo "Usage: IMAGE.img [debug]"

--- a/examples/256_color_vga/run.sh
+++ b/examples/256_color_vga/run.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 export GRAPHICS="-vga std"
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/STREAM/run.sh
+++ b/examples/STREAM/run.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 make
 export MEM="-m 256" # we need a little bit of extra RAM to run these tests
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/demo_service/run.sh
+++ b/examples/demo_service/run.sh
@@ -1,2 +1,2 @@
-#! /bin/bash
+#! /usr/bin/env bash
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/dualnic/run.sh
+++ b/examples/dualnic/run.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 export QEMU_EXTRA="-device virtio-net,netdev=net1 -netdev user,id=net1 -redir tcp:8002::80"
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh dualnic.img

--- a/examples/scoped_profiler/run.sh
+++ b/examples/scoped_profiler/run.sh
@@ -1,2 +1,2 @@
-#! /bin/bash
+#! /usr/bin/env bash
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/smp/run.sh
+++ b/examples/smp/run.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 export SMP="-smp 4"
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/snake/run.sh
+++ b/examples/snake/run.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 export GRAPHICS="-vga std"
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh `make servicefile`

--- a/examples/tcp/run.sh
+++ b/examples/tcp/run.sh
@@ -1,2 +1,2 @@
-#! /bin/bash
+#! /usr/bin/env bash
 source ${INCLUDEOS_HOME-$HOME/IncludeOS_install}/etc/run.sh tcp_demo.img


### PR DESCRIPTION
…this partially solves compatibility with osx (doesn't fix everything, but is a step in the right direction)

The -v operation, used in etc/to-be-installed/qemu_cmd.sh, was added in bash version 4
OSX has bash 3 by default because of licensing. This can be fixed on the user's end by
installing the new bash and updating the login shell. (This is a reasonable thing to say
the end user is responsible for on their own, and not that of this project.)

```
brew install bash
sudo vim /etc/shells
# while in vim add the listing: /usr/local/bin/bash
chsh -s /usr/local/bin/bash
```

However, on *our* end, many shell scripts hard-code the osx version of bash in the shebang.
Ergo "`#! /bin/bash`" needs to be changed in a number of places to "`#! /usr/bin/env bash`"
which will respect the user's preferred bash.

Otherwise the user sees this when attempting to run the examples:

```
You should now get a boot message from the virtual machine:
egrep: /proc/cpuinfo: No such file or directory
>>> KVM: OFF
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 16: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 17: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 18: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 19: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 20: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 21: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 22: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 23: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 24: [: -v: unary operator expected
/Users/paulbaker/IncludeOS_install/etc/qemu_cmd.sh: line 25: [: -v: unary operator expected
```