### PR TITLE
Making memdisk.py python3 and python2 compatable

### DIFF
--- a/src/memdisk/memdisk.py
+++ b/src/memdisk/memdisk.py
@@ -25,11 +25,11 @@ if args.disk:
     if _platform == "darwin":
       osx_dmg = args.disk + ".dmg"
       call(["hdiutil", "create", "-fs", "MS-DOS", "-o", args.disk, "-srcfolder", args.folder])
-      print "Renaming " + osx_dmg + " => " + image
+      print ("Renaming " + osx_dmg + " => " + image)
       call(["mv", osx_dmg, image])
 
     else:
-      print "Using folder: \t" + args.folder + "\nImage name: \t" + image
+      print ("Using folder: \t" + args.folder + "\nImage name: \t" + image)
       sectors = 16500 # Minimum for FAT16 (otherwise its formatted as FAT12)
       call(["dd", "if=/dev/zero", "of=" + args.disk, "count=" + str(sectors)])
       call(["mkfs.fat", image])


### PR DESCRIPTION
Archlinux by default users python 3+ this causes issues with the memdisk.py script i have modified the script slightly so that it is compatable with python 2.x and 3.x to hopefully resolve some make errors with less pain i have tested the change on an Archlinux and Centos server with positive results.

Before:

```
python -V ->
Python 3.5.2

python src/memdisk/memdisk.py ->
    print "Renaming " + osx_dmg + " => " + image
                    ^
SyntaxError: Missing parentheses in call to 'print'
```

```
python2.7 -V ->
Python 2.7.12

python2.7 src/memdisk/memdisk.py ->
```

After:

```
python src/memdisk/memdisk.py ->
```

Happy to answer any questions if needed :)
Thanks for the great work guys im just staring out in unikernels hope i have more pulls to come :D
