### PR TITLE
WIP: Work on external builds (3rd party unikernels)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,12 @@ if(examples)
 	add_subdirectory(examples)
 endif(examples)
 
-install(DIRECTORY api/ DESTINATION include/api
-	FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY api/ DESTINATION include/api)
 
 enable_testing()
 add_subdirectory(test)
+
+configure_file(etc/Makefile.seed.in Makeseed)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Makeseed DESTINATION share/includeos)
+
+install(DIRECTORY mod/GSL/gsl DESTINATION include/gsl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,8 @@ configure_file(etc/Makefile.seed.in Makeseed)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Makeseed DESTINATION share/includeos)
 
 install(DIRECTORY mod/GSL/gsl DESTINATION include/gsl)
+
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_PACKAGE_VERSION ${OS_VERSION})
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Ingve")
+include(CPack)

--- a/cmake/cross_compiled_libraries.txt
+++ b/cmake/cross_compiled_libraries.txt
@@ -18,6 +18,7 @@ if (from_bundle)
 	set(LIBCXX_INCLUDE_DIR ${PRECOMPILED_DIR}libcxx/include/)
 	set(LIBCXX_LIB_DIR ${PRECOMPILED_DIR}/libcxx/)
 	add_library(libcxx STATIC IMPORTED)
+	add_dependencies(libcxx PrecompiledLibraries)
 	set_target_properties(libcxx PROPERTIES IMPORTED_LOCATION ${LIBCXX_LIB_DIR}/libc++.a)
 
 	set(NEWLIB_INCLUDE_DIR ${PRECOMPILED_DIR}/newlib/include/)
@@ -27,12 +28,15 @@ if (from_bundle)
 
 	add_library(libc STATIC IMPORTED)
 	set_target_properties(libc PROPERTIES IMPORTED_LOCATION ${NEWLIB_LIB_DIR}/libc.a)
+	add_dependencies(libc PrecompiledLibraries)
 
 	add_library(libm STATIC IMPORTED)
 	set_target_properties(libm PROPERTIES IMPORTED_LOCATION ${NEWLIB_LIB_DIR}/libm.a)
+	add_dependencies(libm PrecompiledLibraries)
 
 	add_library(libgcc STATIC IMPORTED)
 	set_target_properties(libgcc PROPERTIES IMPORTED_LOCATION ${LIBGCC_LIB_DIR}/libgcc.a)
+	add_dependencies(libgcc PrecompiledLibraries)
 
 	set(CRTEND ${PRECOMPILED_DIR}/crt/crtend.o)
 	set(CRTBEGIN ${PRECOMPILED_DIR}/crt/crtbegin.o)

--- a/cmake/cross_compiled_libraries.txt
+++ b/cmake/cross_compiled_libraries.txt
@@ -53,16 +53,37 @@ else(from_bundle)
 			    INSTALL_COMMAND make install
 	)
 
+	set(gcc_version "6.2.0")
+	ExternalProject_Add(gcc
+			    PREFIX gcc
+			    URL "ftp://ftp.nluug.nl/mirror/languages/gcc/releases/gcc-${gcc_version}/gcc-${gcc_version}.tar.gz"
+			    CONFIGURE_COMMAND <SOURCE_DIR>/configure --target=${TARGET} --prefix=${PREFIX} --disable-nls --enable-languages=c,c++ --without-headers
+			    BUILD_COMMAND make all-gcc all-target-libgcc -j ${num_jobs}
+			    UPDATE_COMMAND "<SOURCE_DIR>/contrib/download_prerequisites"
+			    INSTALL_COMMAND make install-gcc install-target-libgcc
+	)
+
+	set(newlib_version "2.4.0")
+	ExternalProject_Add(newlib
+			    PREFIX newlib
+			    URL "ftp://sourceware.org/pub/newlib/newlib-${newlib_version}.tar.gz"
+			    CONFIGURE_COMMAND <SOURCE_DIR>/configure --target=${TARGET} --prefix=${PREFIX} --enable-newlib-io-long-long AS_FOR_TARGET=as LD_FOR_TARGET=ld AR_FOR_TARGET=ar RANLIB_FOR_TARGET=ranlib
+			    BUILD_COMMAND make all -j ${num_jobs}
+			    PATCH_COMMAND "patch -p0 < ${INCLUDEOS_ROOT}/etc/newlib_clang.patch"
+			    INSTALL_COMMAND make install
+	)
+
+	# TODO: the build_llvm32 script looks a lot tougher than this.
+	
+
 	# add this for now, still working on performing all cross-compilation steps
-	message(FATAL_ERROR "not fully supported yet")
+	# message(FATAL_ERROR "not fully supported yet")
 endif(from_bundle)
 
 # installation instructions
-install(DIRECTORY ${LIBCXX_INCLUDE_DIR} DESTINATION include/libcxx
-	FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY ${LIBCXX_INCLUDE_DIR} DESTINATION include/libcxx)
 
-install(DIRECTORY ${NEWLIB_INCLUDE_DIR} DESTINATION include/newlib
-	FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY ${NEWLIB_INCLUDE_DIR} DESTINATION include/newlib)
 
 install(FILES ${CRTEND} ${CRTBEGIN} DESTINATION share/includeos)
 

--- a/etc/Makefile.seed.in
+++ b/etc/Makefile.seed.in
@@ -65,7 +65,7 @@ stripped: CAPABS = $(CAPABS_COMMON) -O2
 STRIPPED=--strip-debug
 
 CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE
-LDOPTS = -nostdlib -melf_i386 -N --eh-frame-hdr --script=$(INSTALL)/share/includeos/linker.ld --defsym _MAX_MEM_MIB_=$(MAX_MEM) --defsym=__stack_rand_ba=`date +%s`
+LDOPTS = -nostdlib -melf_i386 -N --eh-frame-hdr --script=$(INSTALL)/share/includeos/linker.ld --defsym _MAX_MEM_MIB_=$(MAX_MEM) --defsym=__stack_rand_ba=`date +%s` -L$(INSTALL)/lib -L$(INSTALL)/lib/includeos-drivers
 
 # Objects
 ###################################################
@@ -76,12 +76,8 @@ CRTI_OBJ = $(INSTALL)/share/includeos/crti.o
 CRTN_OBJ = $(INSTALL)/share/includeos/crtn.o
 MULTIBOOT = $(INSTALL)/share/includeos/multiboot.cpp.o
 
-DRIVER_OBJS_EXT = $(DRIVERS:=.o)
-DRIVER_OBJS = $(addprefix $(INSTALL)/drivers/, $(DRIVER_OBJS_EXT))
-
 PLATFORM_OBJS_EXT = $(PLATFORM:=.o)
 PLATFORM_OBJS = $(addprefix $(INSTALL)/platforms/, $(PLATFORM_OBJS_EXT))
-
 
 # Full link list
 OBJS  =  $(FILES:.cpp=.o)
@@ -136,7 +132,7 @@ minimal: CPPOPTS += -Os
 
 
 # Link the service with the os
-link_service: $(OBJS) $(LIBS) $(DRIVER_OBJS) $(PLATFORM_OBJS)
+link_service: $(OBJS) $(LIBS) $(PLATFORM_OBJS)
 
 # build memdisk only when MEMDISK is set
 ifneq ($(MEMDISK),)
@@ -147,7 +143,7 @@ ifneq ($(MEMDISK),)
 endif
 
 	@echo "\n>> Linking service with OS"
-	$(LD_INC) $(LDOPTS) $(OS_PRE) $(OBJS) $(DRIVER_OBJS) $(PLATFORM_OBJS) $(EXTRA_LIBS) $(LIBS) $(OS_POST) $(MEMDISK) -o $(SERVICE)
+	$(LD_INC) $(LDOPTS) $(OS_PRE) $(OBJS) $(PLATFORM_OBJS) $(EXTRA_LIBS) $(LIBS) $(OS_POST) $(MEMDISK) -o $(SERVICE)
 
 # Save debugging symbols to separate file
 preserve_debug:

--- a/etc/Makefile.seed.in
+++ b/etc/Makefile.seed.in
@@ -1,0 +1,208 @@
+#################################################
+#          IncludeOS SERVICE makefile           #
+#################################################
+
+# IncludeOS location
+ifndef INCLUDEOS_INSTALL
+	INCLUDEOS_INSTALL=${CMAKE_INSTALL_PREFIX}
+endif
+
+ifneq ($(DISK),)
+MEMDISK=memdisk.o
+endif
+
+.SUFFIXES: .asm
+
+# Maximum memory in megabytes
+# Used if memory info is not otherwise available such as via multiboot
+ifeq ($(MAX_MEM),)
+MAX_MEM=128
+endif
+
+# Shorter name
+INSTALL = $(INCLUDEOS_INSTALL)
+
+# Compiler and linker options
+###################################################
+CAPABS_COMMON = -mstackrealign -msse3 -fstack-protector-strong -DOS_TERMINATE_ON_CONTRACT_VIOLATION $(LOCAL_DEFS)
+WARNS  = -Wall -Wextra #-pedantic
+DEBUG_OPTS = -ggdb3 -v
+
+OPTIONS = $(WARNS) $(CAPABS) $(EXTRA_FLAGS)
+
+# External Libraries
+###################################################
+LIBC_OBJ = $(INSTALL)/lib/libc.a
+LIBG_OBJ = $(INSTALL)/lib/libg.a
+LIBM_OBJ = $(INSTALL)/lib/libm.a
+
+LIBGCC = $(INSTALL)/lib/libgcc.a
+LIBCXX = $(INSTALL)/lib/libc++.a $(INSTALL)/lib/libc++abi.a
+
+
+INC_NEWLIB=$(INSTALL)/include/newlib
+INC_LIBCXX=$(INSTALL)/include/libcxx
+
+CC  = $(shell command -v clang-3.8 || command -v clang-3.6) -target i686-elf
+CPP = $(shell command -v clang++-3.8 || command -v clang++-3.6 || command -v clang++) -target i686-elf
+ifndef LD_INC
+	LD_INC = ld
+endif
+ifndef OBJCOPY_INC
+	OBJCOPY_INC=objcopy
+endif
+ifndef STRIP_INC
+	STRIP_INC = strip
+endif
+
+INCLUDES = $(LOCAL_INCLUDES) -I$(INC_LIBCXX) -I$(INSTALL)/include/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/include/api/posix -I$(INSTALL)/include/api -I$(INSTALL)/include/gsl
+
+all:      CAPABS = $(CAPABS_COMMON) -O2
+debug:    CAPABS = $(CAPABS_COMMON) -O0
+stripped: CAPABS = $(CAPABS_COMMON) -O2
+
+# by default, don't use strip because it has caused us some problems
+STRIPPED=--strip-debug
+
+CPPOPTS = $(CAPABS) $(WARNS) -c -m32 -std=c++14 $(INCLUDES) -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE
+LDOPTS = -nostdlib -melf_i386 -N --eh-frame-hdr --script=$(INSTALL)/share/includeos/linker.ld --defsym _MAX_MEM_MIB_=$(MAX_MEM) --defsym=__stack_rand_ba=`date +%s`
+
+# Objects
+###################################################
+
+CRTBEGIN_OBJ = $(INSTALL)/share/includeos/crtbegin.o
+CRTEND_OBJ = $(INSTALL)/share/includeos/crtend.o
+CRTI_OBJ = $(INSTALL)/share/includeos/crti.o
+CRTN_OBJ = $(INSTALL)/share/includeos/crtn.o
+MULTIBOOT = $(INSTALL)/share/includeos/multiboot.cpp.o
+
+DRIVER_OBJS_EXT = $(DRIVERS:=.o)
+DRIVER_OBJS = $(addprefix $(INSTALL)/drivers/, $(DRIVER_OBJS_EXT))
+
+PLATFORM_OBJS_EXT = $(PLATFORM:=.o)
+PLATFORM_OBJS = $(addprefix $(INSTALL)/platforms/, $(PLATFORM_OBJS_EXT))
+
+
+# Full link list
+OBJS  =  $(FILES:.cpp=.o)
+OBJS  += .service_name.o
+
+LIBS =  $(INSTALL)/lib/libos.a $(LIBCXX) $(INSTALL)/lib/libos.a $(LIBC_OBJ) $(LIBM_OBJ) $(LIBGCC)
+
+OS_PRE = $(CRTBEGIN_OBJ) $(CRTI_OBJ) $(MULTIBOOT)
+OS_POST = $(CRTEND_OBJ) $(CRTN_OBJ)
+
+DEPS = $(OBJS:.o=.d)
+
+# Complete build
+###################################################
+# A complete build includes:
+# - a "service", to be linked with OS-objects (OS included)
+.PHONY: all stripped debug debug-info debug-all memdisk service
+
+all: LDOPTS += --strip-debug
+all: STRIPPED=--strip-all
+all: service
+
+stripped: LDOPTS  += -s
+stripped: STRIPPED=--strip-all
+stripped: service
+
+# Build like "all" but with debugging output (i.e. the 'debug'-macro) enabled
+debug-info: CAPABS += -UNO_DEBUG
+debug-info: service
+
+# Build with debugging symbols (OBS: Dramatically increases binary size)
+debug: CCOPTS  += $(DEBUG_OPTS)
+debug: CPPOPTS += $(DEBUG_OPTS)
+debug: OBJ_LIST += $(LIBG_OBJ)
+debug: CPPOPTS += -O0
+debug: STRIPPED=
+debug: link_service preserve_debug service
+
+# Build with debugging symbols + debugging ouput, i.e. "debug" + "debug-info"
+debug-all: CAPABS += -UNO_DEBUG
+debug-all: CCOPTS  += $(DEBUG_OPTS)
+debug-all: CPPOPTS += $(DEBUG_OPTS)
+debug-all: OBJ_LIST += $(LIBG_OBJ)
+debug-all: CPPOPTS += -O0
+debug-all: service
+
+minimal: stripped
+minimal: CPPOPTS += -Os
+
+# Service
+###################################################
+
+
+# Link the service with the os
+link_service: $(OBJS) $(LIBS) $(DRIVER_OBJS) $(PLATFORM_OBJS)
+
+# build memdisk only when MEMDISK is set
+ifneq ($(MEMDISK),)
+	@echo "\n>> Creating memdisk"
+	python $(INSTALL)/share/includeos/memdisk/memdisk.py --file $(INSTALL)/share/includeos/memdisk/memdisk.asm $(DISK)
+	@echo "\n>> Assembling memdisk"
+	nasm -f elf $(INSTALL)/share/includeos/memdisk/memdisk.asm -o $(MEMDISK)
+endif
+
+	@echo "\n>> Linking service with OS"
+	$(LD_INC) $(LDOPTS) $(OS_PRE) $(OBJS) $(DRIVER_OBJS) $(PLATFORM_OBJS) $(EXTRA_LIBS) $(LIBS) $(OS_POST) $(MEMDISK) -o $(SERVICE)
+
+# Save debugging symbols to separate file
+preserve_debug:
+	@echo "\n>> Saving debugging symbols"
+	$(OBJCOPY_INC) --only-keep-debug $(SERVICE) $(SERVICE).debug
+	$(OBJCOPY_INC) --add-gnu-debuglink=$(SERVICE).debug $(SERVICE)
+
+service: link_service
+	@echo "\n>> Adding symbol section"
+	$(INSTALL)/bin/elf_syms $(SERVICE)
+	$(OBJCOPY_INC) --update-section .elf_symbols=_elf_symbols.bin $(SERVICE) $(SERVICE)
+	$(RM) _elf_symbols.bin
+
+# stripping must be done after symbol section work
+ifneq ($(STRIPPED),)
+	$(STRIP_INC) $(STRIPPED) --remove-section=.comment $(SERVICE)
+endif
+	@echo "\n>> Building" $(SERVICE).img
+	$(INSTALL)/bin/vmbuild $(SERVICE) $(INSTALL)/share/includeos/bootloader
+
+.service_name.o: $(INSTALL)/share/includeos/service_name.cpp
+	$(CPP) $(CPPOPTS) -DSERVICE="\"$(SERVICE)\"" -DSERVICE_NAME="\"$(SERVICE_NAME)\"" -o $@ $<
+
+servicefile:
+	@echo $(SERVICE).img
+
+kernelfile:
+	@echo $(SERVICE)
+
+# Object files
+###################################################
+
+# Runtime
+crt%.o: $(INSTALL)/crt/crt%.s
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# General C++-files to object files
+%.o: %.cpp
+	$(CPP) -MMD $(CPPOPTS) -o $@ $<
+
+# nasm-assembled object files
+%.o: %.asm
+	nasm -f elf -o $@ $<
+
+%.o: %.c
+	$(CC) -MMD $(WARNS) $(CAPABS) $(EXTRA_FLAGS) -c -m32 -std=gnu11 -I$(INSTALL)/include/api/sys -I$(INC_NEWLIB) -I$(INSTALL)/include/api/posix -o $@ $<
+
+# AS-assembled object files
+%.o: %.s
+	$(CPP) $(CPPOPTS) -x assembler-with-cpp $<
+
+# Cleanup
+###################################################
+clean:
+	$(RM) $(OBJS) $(DEPS)
+	$(RM) $(SERVICE) $(SERVICE).img $(SERVICE).debug $(MEMDISK)
+
+-include $(DEPS)

--- a/etc/Makefile.seed.in
+++ b/etc/Makefile.seed.in
@@ -43,8 +43,8 @@ LIBCXX = $(INSTALL)/lib/libc++.a $(INSTALL)/lib/libc++abi.a
 INC_NEWLIB=$(INSTALL)/include/newlib
 INC_LIBCXX=$(INSTALL)/include/libcxx
 
-CC  = $(shell command -v clang-3.8 || command -v clang-3.6) -target i686-elf
-CPP = $(shell command -v clang++-3.8 || command -v clang++-3.6 || command -v clang++) -target i686-elf
+CC  = ${CMAKE_C_COMPILER}
+CPP = ${CMAKE_CXX_COMPILER}
 ifndef LD_INC
 	LD_INC = ld
 endif

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,8 +25,7 @@ function(add_example id example_name example_description example_sources)
 	set_target_properties(${id} PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
 
 	target_link_libraries(${id} ${EXAMPLE_COMMON_LIBRARIES})
-	add_dependencies(${id} crti)
-	add_dependencies(${id} crtn)
+	add_dependencies(${id} crti crtn libcxx libc libm)
 
 	add_custom_command(
 		OUTPUT ${example_name}.img

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,11 +7,11 @@ set(BUILD_SHARED_LIBRARIES OFF)
 set(CMAKE_EXE_LINKER_FLAGS "-static")
 set(SERVICE_STUB "${INCLUDEOS_ROOT}/src/seed/service_name.cpp")
 
-set(EXAMPLE_COMPILE_FLAGS "-target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 -Wall -Wextra -c -m32 -std=c++14 -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE")
+set(EXAMPLE_COMPILE_FLAGS "-target i686-elf -mstackrealign -msse3 -fstack-protector-strong -O2 ${WARNS} -c -m32 -std=c++14 -D_LIBCPP_HAS_NO_THREADS=1 -D_GNU_SOURCE")
 
 set(EXAMPLE_LINK_FLAGS "-nostdlib -melf_i386 -N --eh-frame-hdr --script=${INCLUDEOS_ROOT}/src/linker.ld --defsym=_MAX_MEM_MIB_=${MAX_MEM} --defsym=__stack_rand_ba=${STACK_PROTECTOR_VALUE} ${CRTBEGIN} ${CMAKE_BINARY_DIR}/src/crti.o")
 
-set(EXAMPLE_INCLUDES "-I${LIBCXX_INCLUDE_DIR} -I${INCLUDEOS_ROOT}/api/sys -I${NEWLIB_INCLUDE_DIR} -I${INCLUDEOS_ROOT}/api -I${INCLUDEOS_ROOT}/mod/GSL/")
+set(EXAMPLE_INCLUDES ${LIBCXX_INCLUDE_DIR} ${INCLUDEOS_ROOT}/api/sys ${NEWLIB_INCLUDE_DIR} ${INCLUDEOS_ROOT}/api ${INCLUDEOS_ROOT}/mod/GSL/)
 
 set(CRTN ${CMAKE_BINARY_DIR}/src/crtn.o)
 
@@ -20,11 +20,14 @@ set(EXAMPLE_COMMON_LIBRARIES os libcxx c++abi os libc libm libgcc ${CRTEND} ${CR
 function(add_example id example_name example_description example_sources)
 	add_executable(${id} ${example_sources} $<TARGET_OBJECTS:multiboot>)
 
-	set_target_properties(${id} PROPERTIES COMPILE_FLAGS "${EXAMPLE_COMPILE_FLAGS} ${EXAMPLE_INCLUDES} -DSERVICE=\\\"${example_name}\\\" -DSERVICE_NAME=${example_description}")
+	set_target_properties(${id} PROPERTIES COMPILE_FLAGS ${EXAMPLE_COMPILE_FLAGS})
 
 	set_target_properties(${id} PROPERTIES LINK_FLAGS "${EXAMPLE_LINK_FLAGS}")
 
+	target_compile_definitions(${id} PUBLIC SERVICE="${example_name}" SERVICE_NAME=${example_description})
+	target_include_directories(${id} PUBLIC ${EXAMPLE_INCLUDES})
 	target_link_libraries(${id} ${EXAMPLE_COMMON_LIBRARIES})
+
 	add_dependencies(${id} crti crtn libcxx libc libm)
 
 	add_custom_command(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(os STATIC ${OS_OBJECTS} apic_boot.o)
 file(GLOB CXX_ABI crt/cxxabi/*.cpp)
 
 add_library(c++abi STATIC ${CXX_ABI})
+add_dependencies(c++abi libcxx)
 
 add_custom_command(
 	OUTPUT ${INCLUDEOS_ROOT}/src/crti.o

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,3 +75,5 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/crtn.o DESTINATION share/includeos)
 install(DIRECTORY ${INCLUDEOS_ROOT}/src/memdisk/ DESTINATION share/includeos/memdisk
         FILES_MATCHING PATTERN "*.*")
 
+install(FILES seed/service_name.cpp DESTINATION share/includeos)
+install(FILES linker.ld DESTINATION share/includeos)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,14 +53,14 @@ add_library(c++abi STATIC ${CXX_ABI})
 
 add_custom_command(
 	OUTPUT ${INCLUDEOS_ROOT}/src/crti.o
-	COMMAND clang++ -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=1477679669 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -I../api/sys -Iinclude -I../api -I../api/posix -I../mod/GSL -I../mod/fiber/include -D_LIBCPP_HAS_NO_THREADS=1 -x assembler-with-cpp ${INCLUDEOS_ROOT}/src/crt/crti.s -o crti.o
+	COMMAND ${CMAKE_CXX_COMPILER} -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=1477679669 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -I../api/sys -Iinclude -I../api -I../api/posix -I../mod/GSL -I../mod/fiber/include -D_LIBCPP_HAS_NO_THREADS=1 -x assembler-with-cpp ${INCLUDEOS_ROOT}/src/crt/crti.s -o crti.o
 	DEPENDS crt/crti.s
 )
 add_custom_target(crti DEPENDS crti.o)
 
 add_custom_command(
 	OUTPUT ${INCLUDEOS_ROOT}/src/crtn.o
-	COMMAND clang++ -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=1477679669 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -I../api/sys -Iinclude -I../api -I../api/posix -I../mod/GSL -I../mod/fiber/include -D_LIBCPP_HAS_NO_THREADS=1 -x assembler-with-cpp ${INCLUDEOS_ROOT}/src/crt/crtn.s -o crtn.o
+	COMMAND ${CMAKE_CXX_COMPILER} -target i686-elf -mstackrealign -msse3 -fstack-protector-strong -D_STACK_GUARD_VALUE_=1477679669 -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE -Wall -Wextra  -c -m32 -std=c++14 -I../api/sys -Iinclude -I../api -I../api/posix -I../mod/GSL -I../mod/fiber/include -D_LIBCPP_HAS_NO_THREADS=1 -x assembler-with-cpp ${INCLUDEOS_ROOT}/src/crt/crtn.s -o crtn.o
 	DEPENDS crt/crtn.s
 )
 add_custom_target(crtn DEPENDS crtn.o)

--- a/src/boot/CMakeLists.txt
+++ b/src/boot/CMakeLists.txt
@@ -13,3 +13,4 @@ add_custom_command(
 add_custom_target(run ALL DEPENDS bootloader)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bootloader DESTINATION share/includeos)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/multiboot.dir/multiboot.cpp.o DESTINATION share/includeos)

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -12,7 +12,9 @@ set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O3")
 include_directories(. ./../api ./../mod/GSL/)
 
 add_executable(vmbuild ${SOURCES})
+add_dependencies(vmbuild libcxx)
 add_executable(elf_syms ${ELF_SYMS_SOURCES})
+add_dependencies(elf_syms libcxx)
 
 # TODO: use prefix to install into the right directory
 install(TARGETS vmbuild elf_syms DESTINATION bin)

--- a/vmbuild/vmbuild.cpp
+++ b/vmbuild/vmbuild.cpp
@@ -34,7 +34,7 @@
 #define SECT_SIZE_ERR  666
 #define DISK_SIZE_ERR  999
 
-bool verb = true;
+bool verb = false;
 #define INFO_(FROM, TEXT, ...) if (verb) printf("%13s ] " TEXT "\n", "[ " FROM, ##__VA_ARGS__)
 #define INFO(X,...) INFO_("Vmbuild", X, ##__VA_ARGS__)
 
@@ -108,11 +108,11 @@ int main(int argc, char** argv) {
   }
 
   if (stat_boot.st_size != SECT_SIZE) {
-    INFO("Boot sector not exactly one sector in size (%lld bytes, expected %i)",
+    INFO("Boot sector not exactly one sector in size (%ld bytes, expected %i)",
          stat_boot.st_size, SECT_SIZE);
     return SECT_SIZE_ERR;
   }
-  INFO("Size of bootloader: %lld\t" , stat_boot.st_size);
+  INFO("Size of bootloader: %ld\t" , stat_boot.st_size);
 
   // Validate service binary location
   if (stat(elf_binary_path.c_str(), &stat_binary) == -1) {
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
   intmax_t binary_sectors = stat_binary.st_size / SECT_SIZE;
   if (stat_binary.st_size & (SECT_SIZE-1)) binary_sectors += 1;
 
-  INFO("Size of service: \t%lld bytes" , stat_binary.st_size);
+  INFO("Size of service: \t%ld bytes" , stat_binary.st_size);
 
   const decltype(binary_sectors) img_size_sect  {1 + binary_sectors+1};
   const decltype(binary_sectors) img_size_bytes {img_size_sect * SECT_SIZE};


### PR DESCRIPTION
I'm trying to make icrd compile as external project. So far it works except libvirtnet.a support (as now this is a libarry, not an object file).

How to: from within checkout-out includeos project:

~~~ bash
$ mkdir build
$ cd build
$ CMAKE_INSTALL_PREFIX=~/tmp CXX=/usr/bin/clang++ CC=/usr/bin/clang cmake ./..
$ make
$ make install
~~~

Now everything will be installed into ~/tmp , including a custom Makeseed

Then checkout ircd and change its Makefile  (mostly adapt path to Makeseed file):

~~~
iff --git a/Makefile b/Makefile
index fe9eb34..27f77c7 100644
--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,18 @@ FILES = service.cpp ircd.cpp client.cpp client_new.cpp client_msg.cpp client_cmd
 DISK=
 
 # Drivers to be used with service
-DRIVERS=virtionet
+DRIVERS=
 
 # Your own include-path
 LOCAL_INCLUDES=
 
 # IncludeOS location
 ifndef INCLUDEOS_INSTALL
-INCLUDEOS_INSTALL=$(HOME)/IncludeOS_install
+INCLUDEOS_INSTALL=$(HOME)/tmp/
 endif
 
 # Include the installed seed makefile
-include $(INCLUDEOS_INSTALL)/Makeseed
+include $(INCLUDEOS_INSTALL)/share/includeos/Makeseed
 
 # Disable crash context buffer
 #CPPOPTS += -DDISABLE_CRASH_CONTEXT
~~~

`make` should do it now.