### PR TITLE
Add docker based image builder / runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 *.ropeproject
 nbproject
 
+!Dockerfile
+
 src/apic_boot.bin
 src/bootloader
 src/TAGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get -y install \
+    git \
+    net-tools \
+    sudo \
+    wget \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home -s /bin/bash ubuntu
+RUN adduser ubuntu sudo
+RUN echo -n 'ubuntu:ubuntu' | chpasswd
+
+# Enable passwordless sudo for users under the "sudo" group
+RUN sed -i.bkp -e \
+      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
+      /etc/sudoers
+
+USER ubuntu
+
+ADD . /home/ubuntu/IncludeOS
+WORKDIR /home/ubuntu/IncludeOS
+
+RUN sudo apt-get update && \
+    sudo do_bridge="" ./etc/install_all_source.sh \
+&& sudo rm -rf /var/lib/apt/lists/*
+
+VOLUME /service
+WORKDIR /service
+
+CMD ./run.sh

--- a/etc/install_all_source.sh
+++ b/etc/install_all_source.sh
@@ -28,6 +28,7 @@ export binutils_version=2.26
 [ ! -v do_newlib ] && do_newlib=1
 [ ! -v do_includeos ] &&  do_includeos=1
 [ ! -v do_llvm ] &&  do_llvm=1
+[ ! -v do_bridge ] &&  do_bridge=1
 # TODO: These should be determined by inspecting if local llvm repo is up-to-date
 
 [ ! -v install_llvm_dependencies ] &&  export install_llvm_dependencies=1
@@ -100,9 +101,11 @@ if [ ! -z $do_includeos ]; then
     echo -e   "        Packages: $DEPS_RUN \n"
     sudo apt-get install -y $DEPS_RUN
 
-    # Set up the IncludeOS network bridge
-    echo -e "\n\n >>> Create IncludeOS network bridge  *Requires sudo* \n"
-    sudo $INCLUDEOS_SRC/etc/create_bridge.sh
+    if [ ! -z $do_bridge]; then
+        # Set up the IncludeOS network bridge
+        echo -e "\n\n >>> Create IncludeOS network bridge  *Requires sudo* \n"
+        sudo $INCLUDEOS_SRC/etc/create_bridge.sh
+    fi
 
     # Copy qemu-ifup til install loc.
     pushd $INCLUDEOS_SRC/etc

--- a/seed/docker_run.sh
+++ b/seed/docker_run.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+set -e
+
+script_dir="$( cd "$( dirname "${bash_source[0]}" )" && pwd )"
+docker run --privileged -v $script_dir:/service -it includeos "$@"


### PR DESCRIPTION
This allows the following workflow to run a new IncludeOS service:

```
$ cp -r seed/ <service_path>
$ cd <service_path> && ./docker_run.sh
```

The `./docker_run.sh` script passes arguments through to docker (if no arguments are passed, it will call `run.sh`):
    - to build an image (without running): `./docker_run.sh make`
    - to start a new bash session: `./docker_run.sh bash`

Two unresolved issues:

1. I couldn't figure out how to bind ports on a running service to the docker host. This means that if you want to `curl` / `ping` the service, you need to start a bash shell in the container and build / test inside the container. If someone knows how to get this working, I would be more than happy to improve this.

2. `./docker_run.sh` assumes that the image is tagged with `includeos`. This tag is not present in the docker hub right now, so the command will fail if such an image is not uploaded.