### PR TITLE
Tests: Readded block test, make clean in install_from_bundle

### DIFF
--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -47,6 +47,7 @@ popd
 # Build IncludeOS
 echo -e "\n\n>>> Building IncludeOS"
 pushd $INCLUDEOS_SRC/src
+make clean
 make -j2
 make install
 popd

--- a/test/kernel/integration/block/service.cpp
+++ b/test/kernel/integration/block/service.cpp
@@ -51,7 +51,7 @@ void Service::start(const std::string&)
       Expects(sleeps < 10);
     });
 
-  Timers::oneshot(std::chrono::seconds(12), [](auto){
+  Timers::oneshot(std::chrono::seconds(15), [](auto){
       Expects(sleeps >= 10);
       INFO("Test","SUCCESS");
     });

--- a/test/kernel/integration/block/vm.json
+++ b/test/kernel/integration/block/vm.json
@@ -1,0 +1,3 @@
+{"image" : "test_block.img",
+ "time_sensitive" : "True"
+}

--- a/test/kernel/integration/block/vm1.json
+++ b/test/kernel/integration/block/vm1.json
@@ -1,1 +1,0 @@
-{"image" : "test_block.img" }

--- a/test/net/integration/dhcp/vm.json
+++ b/test/net/integration/dhcp/vm.json
@@ -1,5 +1,6 @@
 {
   "image" : "test_dhcp.img",
   "net" : [{"device" : "virtio", "mac" : "c0:01:0a:00:00:2a"}],
-  "cpu"   : "host"
+  "cpu"   : "host",
+  "time_sensitive" : "True"
 }

--- a/test/skipped_tests.json
+++ b/test/skipped_tests.json
@@ -2,7 +2,5 @@
   {"name": "hw/integration/serial",
     "reason": "Serial input from vmrunner to vm does not work yet"},
   {"name": "net/integration/transmit",
-   "reason": "The test suffers from UDP packet loss which is expected. "},
-  {"name": "kernel/integration/block",
-   "reason": "The test requires time to be correct, but running tests in parallell seems to skew the clock. "}
+   "reason": "The test suffers from UDP packet loss which is expected. "}
 ]

--- a/test/test.py
+++ b/test/test.py
@@ -187,24 +187,6 @@ class Test:
     return
 
 
-def unit_tests():
-  """Perform unit tests"""
-  global test_count
-  test_count += 1
-  if ("unit" in args.skip):
-    print pretty.WARNING("Unit tests skipped")
-    return 0
-  print pretty.HEADER("Building and running unit tests")
-  build_status = Test(".", name="Unit test build", command=["make"], clean = args.clean).start().wait_status()
-  unit_status = Test(".", name="Unit tests", command = ["./test.lest"]).start().wait_status()
-
-  if (build_status or unit_status) and args.fail:
-    print pretty.FAIL("Unit tests failed")
-    sys.exit(max(build_status, unit_status))
-
-  return max(build_status, unit_status)
-
-
 def stress_test():
   """Perform stresstest"""
   global test_count
@@ -392,10 +374,9 @@ def main():
     else:
         types_to_run = test_types
     stress = stress_test() if "stress" in types_to_run else 0
-    unit = unit_tests() if "unit" in types_to_run else 0
     misc = misc_working() if "misc" in types_to_run else 0
 
-    status = max(integration, stress, unit, misc)
+    status = max(integration, stress, misc)
     if (status == 0):
         print pretty.SUCCESS(str(test_count - status) + " / " + str(test_count)
                             +  " tests passed, exiting with code 0")


### PR DESCRIPTION
- Enabled the block test as it can now run alone.
- test.py no longer has a unit test category as that is handled by cmake.
- install_from_bundle.sh now runs make clean before make.