### PR TITLE
Cmake: Change INCLUDEOS_INSTALL to INCLUDEOS_PREFIX

### DIFF
--- a/etc/scripts/qemu_cmd.sh
+++ b/etc/scripts/qemu_cmd.sh
@@ -11,9 +11,9 @@ else
 fi
 
 export macaddress="c0:01:0a:00:00:2a"
-INCLUDEOS_HOME=${INCLUDEOS_HOME-/usr/local}
+INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
 
-export qemu_ifup="$INCLUDEOS_HOME/includeos/scripts/qemu-ifup"
+export qemu_ifup="$INCLUDEOS_PREFIX/includeos/scripts/qemu-ifup"
 
 export NET=${NET-"-device virtio-net,netdev=net0,mac=$macaddress -netdev tap,id=net0,script=$qemu_ifup"}
 export SMP=${SMP-"-smp 1"}

--- a/etc/service.cmake
+++ b/etc/service.cmake
@@ -7,6 +7,13 @@
 # COMPILER / Build options
 #
 
+# IncludeOS install location
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
+endif()
+
+# TODO: Verify that the OS libraries exist
+
 # Fail on GCC
 if(CMAKE_COMPILER_IS_GNUCC)
 	# currently gcc is not supported due to problems cross-compiling a unikernel

--- a/seed/CMakeLists.txt
+++ b/seed/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 2.8.9)
 
 # IncludeOS install location
-if (NOT DEFINED ENV{INCLUDEOS_ROOT})
-  set(INCLUDEOS_ROOT /usr/local)
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
 endif()
 
 # Human-readable name of your service
 set(SERVICE_NAME "IncludeOS seed")
 
-# Name of your service binary
+# Name of your service boinary
 set(BINARY       "seed")
 
 # Maximum memory can be hard-coded into the binary
@@ -17,11 +17,35 @@ set(MAX_MEM 128)
 
 # Source files to be linked with OS library parts to form bootable image
 set(SOURCES
-    service.cpp
-    )
+  service.cpp # ...add more here
+  )
+
+#
+# Service CMake options
+# (uncomment to enable)
+#
+
+# MISC:
 
 # To add your own include paths:
-#set(LOCAL_INCLUDES ".")
+# set(LOCAL_INCLUDES ".")
+
+# Adding memdisk (expects my.disk to exist in current dir):
+# set(MEMDISK ${CMAKE_SOURCE_DIR}/my.disk)
+
+# DRIVERS / PLUGINS:
+
+set(DRIVERS
+  # virtionet   # Virtio networking
+  # virtioblock # Virtio block device
+  # ... Others from IncludeOS/src/drivers
+  )
+
+set(PLUGINS
+  # syslogd    # Syslog over UDP
+  # ...others
+  )
+
 
 # include service build script
-include(${INCLUDEOS_ROOT}/includeos/service.cmake)
+include($ENV{INCLUDEOS_PREFIX}/includeos/service.cmake)

--- a/seed/CMakeLists.txt
+++ b/seed/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 # Human-readable name of your service
 set(SERVICE_NAME "IncludeOS seed")
 
-# Name of your service boinary
+# Name of your service binary
 set(BINARY       "seed")
 
 # Maximum memory can be hard-coded into the binary

--- a/seed/cmake_build.sh
+++ b/seed/cmake_build.sh
@@ -2,6 +2,6 @@
 INSTALL=`pwd`
 mkdir -p build
 pushd build
-cmake .. -DINCLUDEOS_INSTALL=$INCLUDEOS_INSTALL -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL
+cmake .. -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL
 make install
 popd

--- a/seed/cmake_build.sh
+++ b/seed/cmake_build.sh
@@ -2,6 +2,6 @@
 INSTALL=`pwd`
 mkdir -p build
 pushd build
-cmake .. -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL
+cmake .. -DINCLUDEOS_INSTALL=$INCLUDEOS_INSTALL -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL
 make install
 popd

--- a/seed/run.sh
+++ b/seed/run.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 set -
-INCLUDEOS_HOME=${INCLUDEOS_HOME-/usr/local}
-sudo $INCLUDEOS_HOME/includeos/scripts/create_bridge.sh
+INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
+sudo $INCLUDEOS_PREFIX/includeos/scripts/create_bridge.sh
 
 FILE=$1
 shift
-source $INCLUDEOS_HOME/includeos/scripts/run.sh $FILE ${*}
+source $INCLUDEOS_PREFIX/includeos/scripts/run.sh $FILE ${*}

--- a/test/fs/integration/fat16/CMakeLists.txt
+++ b/test/fs/integration/fat16/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-if (NOT DEFINED ENV{INCLUDEOS_ROOT})
-  set(INCLUDEOS_ROOT /usr/local)
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(INCLUDEOS_PREFIX /usr/local)
 else()
-  set(INCLUDEOS_ROOT $ENV{INCLUDEOS_ROOT})
+  set(INCLUDEOS_PREFIX $ENV{INCLUDEOS_PREFIX})
 endif()
 
 set(SERVICE_NAME "FAT16 test")
@@ -12,9 +12,8 @@ set(MAX_MEM 128)
 set(SOURCES
     fat16.cpp
   )
-#set(LOCAL_INCLUDES ".")
 
 set(MEMDISK ${CMAKE_SOURCE_DIR}/my.disk)
 
 # include service build script
-include(${INCLUDEOS_ROOT}/includeos/service.cmake)
+include(${INCLUDEOS_PREFIX}/includeos/service.cmake)

--- a/test/fs/integration/fat32/CMakeLists.txt
+++ b/test/fs/integration/fat32/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-if (NOT DEFINED ENV{INCLUDEOS_ROOT})
-  set(INCLUDEOS_ROOT /usr/local)
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(INCLUDEOS_PREFIX /usr/local)
 else()
-  set(INCLUDEOS_ROOT $ENV{INCLUDEOS_ROOT})
+  set(INCLUDEOS_PREFIX $ENV{INCLUDEOS_PREFIX})
 endif()
 
 set(SERVICE_NAME "FAT32 test")
@@ -17,4 +17,4 @@ set(SOURCES
 option(libvirtioblk "" ON)
 
 # include service build script
-include(${INCLUDEOS_ROOT}/includeos/service.cmake)
+include(${INCLUDEOS_PREFIX}/includeos/service.cmake)

--- a/test/fs/integration/memdisk/CMakeLists.txt
+++ b/test/fs/integration/memdisk/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-if (NOT DEFINED ENV{INCLUDEOS_ROOT})
-  set(INCLUDEOS_ROOT /usr/local)
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(INCLUDEOS_PREFIX /usr/local)
 else()
-  set(INCLUDEOS_ROOT $ENV{INCLUDEOS_ROOT})
+  set(INCLUDEOS_PREFIX $ENV{INCLUDEOS_PREFIX})
 endif()
 
 set(SERVICE_NAME "Memdisk test")
@@ -17,4 +17,4 @@ set(SOURCES
 set(MEMDISK ${CMAKE_SOURCE_DIR}/sector0.disk)
 
 # include service build script
-include(${INCLUDEOS_ROOT}/includeos/service.cmake)
+include(${INCLUDEOS_PREFIX}/includeos/service.cmake)

--- a/test/fs/integration/virtio_block/CMakeLists.txt
+++ b/test/fs/integration/virtio_block/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-if (NOT DEFINED ENV{INCLUDEOS_ROOT})
-  set(INCLUDEOS_ROOT /usr/local)
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(INCLUDEOS_PREFIX /usr/local)
 else()
-  set(INCLUDEOS_ROOT $ENV{INCLUDEOS_ROOT})
+  set(INCLUDEOS_PREFIX $ENV{INCLUDEOS_PREFIX})
 endif()
 
 set(SERVICE_NAME "VirtioBlk test")
@@ -14,7 +14,8 @@ set(SOURCES
   )
 #set(LOCAL_INCLUDES ".")
 
-option(libvirtioblk "" ON)
+#option(libvirtioblk "" ON)
+set(DRIVERS virtioblk)
 
 # include service build script
-include(${INCLUDEOS_ROOT}/includeos/service.cmake)
+include(${INCLUDEOS_PREFIX}/includeos/service.cmake)

--- a/test/kernel/integration/kprint/CMakeLists.txt
+++ b/test/kernel/integration/kprint/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-if (NOT DEFINED ENV{INCLUDEOS_ROOT})
-  set(INCLUDEOS_ROOT /usr/local)
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
 endif()
 
-MESSAGE(STATUS "CMake root: " ${INCLUDEOS_ROOT})
+MESSAGE(STATUS "CMake root: " $ENV{INCLUDEOS_PREFIX})
 
 set(SERVICE_NAME "kprint test")
 set(BINARY       "test_kprint")
@@ -15,4 +15,4 @@ set(SOURCES
 #set(LOCAL_INCLUDES ".")
 
 # include service build script
-include(${INCLUDEOS_ROOT}/includeos/service.cmake)
+include($ENV{INCLUDEOS_PREFIX}/includeos/service.cmake)

--- a/test/net/integration/dhcp/CMakeLists.txt
+++ b/test/net/integration/dhcp/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-if (NOT DEFINED ENV{INCLUDEOS_ROOT})
-  set(INCLUDEOS_ROOT /usr/local)
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
 endif()
 
-MESSAGE(STATUS "CMake root: " ${INCLUDEOS_ROOT})
+MESSAGE(STATUS "IncludeOS prefix: " $ENV{INCLUDEOS_PREFIX})
 
 set(SERVICE_NAME "IncludeOS DHCP test")
 set(BINARY       "test_dhcp")
@@ -14,7 +14,7 @@ set(SOURCES
     )
 
 # Enable virtionet driver
-option(libvirtionet "" ON)
+set(DRIVERS virtionet)
 
 # include service build script
-include(${INCLUDEOS_ROOT}/includeos/service.cmake)
+include($ENV{INCLUDEOS_PREFIX}/includeos/service.cmake)


### PR DESCRIPTION
I'm doing this to avoid confusion with the old $INCLUDEOS_INSTALL, which meant the contents of the folder where all of IncludeOS is installed. $INCLUDEOS_PREFIX is intended to reflect the $CMAKE_INSTALL_PREFIX supplied when installing IncludeOS with cmake, which defaults to `/usr/local`