### PR TITLE
Added new container fixed_queue and corresponding unit tests

### DIFF
--- a/api/util/fixed_queue.hpp
+++ b/api/util/fixed_queue.hpp
@@ -1,0 +1,95 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FIXEDQUEUE_H_INCLUDED
+#define FIXEDQUEUE_H_INCLUDED
+
+#include <array>
+#include <type_traits>
+
+namespace util
+{
+
+template<typename T, size_t N> class fixed_queue
+{
+public:
+	using buffer_t = std::array<T, N>;
+
+	explicit fixed_queue() : index_(0)
+	{
+		static_assert(N > 0, "fixed_queue size should be larger than zero!");
+	};
+
+	~fixed_queue() {};
+
+	fixed_queue(const fixed_queue&) = default;
+	fixed_queue(fixed_queue&&) = default;
+
+	fixed_queue& operator= (const fixed_queue&) = default;
+	fixed_queue& operator= (fixed_queue&&) = default;
+
+	void push_back(const T& val)
+		noexcept(std::is_trivially_copy_assignable<T>::value)
+	{
+		++index_;
+		buff_[index_ % N] = val;
+	}
+
+	void push_back(T&& val)
+		noexcept(std::is_trivially_move_assignable<T>::value)
+	{
+		++index_;
+		buff_[index_ % N] = std::move(val);
+	}
+
+	T& front() noexcept { return buff_[index_ % N]; }
+	T& back() noexcept { return buff_[(index_ + 1) % N]; }
+
+	template<typename F> void fold(F&& func)
+		noexcept(noexcept(func(front())))
+	{
+		for (size_t i = 0, max = index_ < N ? index_ : N ; i < max; ++i)
+			std::forward<F>(func)(buff_[(index_ - i) % N]);
+	}
+private:
+	size_t index_;
+	buffer_t buff_;
+};
+
+template<typename T, size_t N> T merge_ring_range(
+	fixed_queue<T, N>& client_agents
+)
+{
+	T ret;
+
+	size_t capacity{};
+	client_agents.fold(
+		[&capacity](const auto& s) noexcept -> void
+		{ capacity += s.capacity(); }
+	);
+	ret.reserve(capacity);
+
+	client_agents.fold(
+		[&ret](const auto& val) -> void { ret += val; }
+	);
+
+	return ret;
+}
+
+}
+
+#endif // FIXEDQUEUE_H_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_SOURCES
   ${TEST}/net/unit/tcp_write_queue.cpp
   ${TEST}/posix/unit/fd_map_test.cpp
   ${TEST}/util/unit/delegate.cpp
+  ${TEST}/util/unit/fixed_queue.cpp
   ${TEST}/util/unit/fixed_vector.cpp
   ${TEST}/util/unit/ringbuffer.cpp
   #${TEST}/util/unit/statman.cpp

--- a/test/util/unit/fixed_queue.cpp
+++ b/test/util/unit/fixed_queue.cpp
@@ -125,7 +125,7 @@ CASE("Test fixed_queue for pod types")
 		std::numeric_limits<float>::max()
 	);
 
-},
+}
 CASE("Test fixed_queue with range types")
 {
 	auto& le = lest_env;

--- a/test/util/unit/fixed_queue.cpp
+++ b/test/util/unit/fixed_queue.cpp
@@ -1,0 +1,137 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <util/fixed_queue.hpp>
+
+#include <common.cxx>
+#include <string>
+
+template<typename T, size_t N> void test_basic(
+	lest::env& lest_env,
+	T val_a,
+	T val_b
+)
+{
+SETUP("fixed_queue test_basic")
+{
+	util::fixed_queue<T, N> fq;
+
+	SECTION("fold on uninitialized")
+	{
+		size_t count_folds{};
+		fq.fold([&count_folds](const auto& val) -> void { ++count_folds; });
+		EXPECT(count_folds == 0);
+	}
+
+	SECTION("push_back(), compare to front() and back()")
+	{
+		fq.push_back(val_b);
+		for (size_t i = 0; i < N - 1; ++i)
+			fq.push_back(val_a);
+
+		EXPECT(fq.back() == val_b);
+
+		fq.push_back(val_b);
+		EXPECT(fq.front() == val_b);
+
+		EXPECT((N == 1 || (fq.back() != val_b)));
+	}
+
+	SECTION("fold assign")
+	{
+		fq.fold([val_a](auto& val) { val = val_a; });
+
+		fq.fold([&lest_env, val_a](auto val)
+		{
+			EXPECT(val == val_a);
+		}
+		);
+	}
+}
+}
+
+template<typename T, size_t N> void test_range(
+	lest::env& lest_env,
+	T val_a,
+	T val_b
+)
+{
+SETUP("fixed_queue test_range")
+{
+	test_basic<T, N>(lest_env, val_a, val_b);
+
+	util::fixed_queue<T, N> fq;
+
+	if (N == 1)
+	{
+		SECTION("merge range of size 1")
+		{
+			fq.push_back(val_a);
+			auto res = merge_ring_range(fq);
+			EXPECT(res == val_a);
+			return;
+		}
+	}
+	else if (N == 2)
+	{
+		SECTION("merge range of size 2")
+		{
+			fq.push_back(val_b);
+			fq.push_back(val_a);
+			auto res = merge_ring_range(fq);
+			EXPECT(res == val_a + val_b);
+			return;
+		}
+	}
+
+	SECTION("merge range of size > 2")
+	{
+		fq.push_back(val_b);
+		for (size_t i = 0; i < N - 2; ++i)
+			fq.push_back(val_a);
+		fq.push_back(val_b);
+
+		auto manual = val_b;
+		for (size_t i = 0; i < N - 2; ++i)
+			manual += val_a;
+		manual += val_b;
+
+		auto res = merge_ring_range(fq);
+		EXPECT(res == manual);
+	}
+}
+}
+
+CASE("Test fixed_queue for pod types")
+{
+	test_basic<int, 1>(lest_env, 7, 5);
+	test_basic<float, 3>(
+		lest_env,
+		std::numeric_limits<float>::min(),
+		std::numeric_limits<float>::max()
+	);
+
+},
+CASE("Test fixed_queue with range types")
+{
+	auto& le = lest_env;
+	test_range<std::string, 1>(le, "short", "a bit longer, and even more");
+	test_range<std::string, 2>(le, "short", "a bit longer, and even more");
+	test_range<std::string, 3>(le, "short", "a bit longer, and even more");
+	test_range<std::string, 5>(le, "short", "a bit longer, and even more");
+	test_range<std::string, 100>(le, "short", "a bit longer, and even more");
+}

--- a/test/util/unit/fixed_queue.cpp
+++ b/test/util/unit/fixed_queue.cpp
@@ -15,9 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <common.cxx>
 #include <util/fixed_queue.hpp>
 
-#include <common.cxx>
 #include <string>
 
 template<typename T, size_t N> void test_basic(


### PR DESCRIPTION
First in, first out.
Static size wrapping. 
No copy, only overwrite preexisting elements.
type safe.