### PR TITLE
Add optional profilers to OS start, fix issue where ScopedProfiler constructor could be moved around

### DIFF
--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -144,6 +144,9 @@ public:
   static void block();
 
 
+  /** The main event loop. Check interrupts, timers etc., and do callbacks. */
+  static void event_loop();
+
 private:
 
   /** Process multiboot info. Called by 'start' if multibooted **/
@@ -156,9 +159,6 @@ private:
 
   /** Indicate if the OS is running. */
   static bool power_;
-
-  /** The main event loop. Check interrupts, timers etc., and do callbacks. */
-  static void event_loop();
 
   static MHz cpu_mhz_;
 

--- a/api/profile
+++ b/api/profile
@@ -82,7 +82,15 @@ struct StackSampler
 class ScopedProfiler
 {
  public:
-  ScopedProfiler();
+  inline ScopedProfiler(const char* nme = nullptr)
+    : name(nme)
+  {
+    record();
+    // memory clobbered make sure ScopedProfilers aren't moved around
+    asm volatile("" : : : "memory");
+  }
+  
+  void record();
   ~ScopedProfiler();
 
   // No copying or moving
@@ -109,11 +117,13 @@ class ScopedProfiler
 
  private:
   uint64_t tick_start;
+  const char*    name;
 
   struct Entry
   {
     void*       function_address;  // This identifies an Entry
                                    // function_address == 0 => the Entry is unused
+    const char* name;
     std::string function_name;
     unsigned    num_samples;
     uint64_t    cycles_average;

--- a/src/kernel/kernel_start.cpp
+++ b/src/kernel/kernel_start.cpp
@@ -55,4 +55,7 @@ extern "C" void kernel_start(uintptr_t magic, uintptr_t addr)  {
 
   // Initialize OS including devices
   OS::start(magic, addr);
+  
+  // Starting event loop from here allows us to profile OS::start
+  OS::event_loop();
 }

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -34,11 +34,14 @@
 #include <kernel/rng.hpp>
 #include <kernel/cpuid.hpp>
 #include <statman>
-#include <profile>
 #include <vector>
 
 #define SOFT_RESET_MAGIC   0xFEE1DEAD
 //#define ENABLE_PROFILERS
+
+#ifdef ENABLE_PROFILERS
+#include <profile>
+#endif
 
 extern "C" uint16_t _cpu_sampling_freq_divider_;
 extern uintptr_t heap_begin;
@@ -78,8 +81,9 @@ extern "C" uintptr_t get_cpu_esp();
 
 void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
 
-  ScopedProfiler sp1{}; // makes OS boot faster O_o
-
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp1{};
+#endif
   atexit(default_exit);
   default_stdout_handlers();
 

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -34,9 +34,11 @@
 #include <kernel/rng.hpp>
 #include <kernel/cpuid.hpp>
 #include <statman>
+#include <profile>
 #include <vector>
 
 #define SOFT_RESET_MAGIC   0xFEE1DEAD
+//#define ENABLE_PROFILERS
 
 extern "C" uint16_t _cpu_sampling_freq_divider_;
 extern uintptr_t heap_begin;
@@ -75,6 +77,8 @@ static uint64_t* os_cycles_total = nullptr;
 extern "C" uintptr_t get_cpu_esp();
 
 void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
+
+  ScopedProfiler sp1{}; // makes OS boot faster O_o
 
   atexit(default_exit);
   default_stdout_handlers();
@@ -170,18 +174,26 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
     unavail_end += interval;
   }
 
-
   MYINFO("Printing memory map");
 
   for (const auto &i : memory_map())
     INFO2("* %s",i.second.to_string().c_str());
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp2("OS::start IRQ manager init");
+#endif
   // Set up interrupt and exception handlers
   IRQ_manager::init();
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp3("OS::start ACPI init");
+#endif
   // read ACPI tables
   hw::ACPI::init();
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp4("OS::start APIC init");
+#endif
   // setup APIC, APIC timer, SMP etc.
   hw::APIC::init();
 
@@ -189,9 +201,15 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
   INFO("BSP", "Enabling interrupts");
   IRQ_manager::enable_interrupts();
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp5("OS::start PIT init");
+#endif
   // Initialize the Interval Timer
   hw::PIT::init();
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp6("OS::start PCI manager init");
+#endif
   // Initialize PCI devices
   PCI_manager::init();
 
@@ -205,12 +223,18 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
         (hw::PIT::frequency() / _cpu_sampling_freq_divider_).count());
   INFO2("|");
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp7("OS::start CPU frequency");
+#endif
   // TODO: Debug why actual measurments sometimes causes problems. Issue #246.
   if (OS::cpu_mhz_.count() < 0) {
     OS::cpu_mhz_ = MHz(hw::PIT::estimate_CPU_frequency(16));
   }
   INFO2("+--> %f MHz", cpu_freq().count());
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp8("OS::start Timers init");
+#endif
   // cpu_mhz must be known before we can start timer system
   /// initialize timers hooked up to APIC timer
   Timers::init(
@@ -232,6 +256,9 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
     Timers::ready();
   });
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp9("OS::start RTC init");
+#endif
   // Realtime/monotonic clock
   RTC::init();
   booted_at_ = RTC::now();
@@ -242,6 +269,9 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
   os_cycles_total = &Statman::get().create(
       Stat::UINT64, std::string("cpu0.cycles_total")).get_uint64();
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp10("OS::start Plugins init");
+#endif
   // Trying custom initialization functions
   MYINFO("Initializing plugins");
   for (auto plugin : plugins_) {
@@ -258,6 +288,9 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
   MYINFO("Starting %s", Service::name().c_str());
   FILLINE('=');
 
+#ifdef ENABLE_PROFILERS
+  ScopedProfiler sp11("OS::start RNG init");
+#endif
   // initialize random seed based on cycles since start
   if (CPUID::has_feature(CPUID::Feature::RDRAND)) {
     uint32_t rdrand_output[32];
@@ -287,8 +320,6 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
 
   // do CPU frequency measurements again with more samples
   //OS::cpu_mhz_ = MHz(hw::PIT::estimate_CPU_frequency(18));
-
-  event_loop();
 }
 
 void OS::register_plugin(Plugin delg, const char* name){

--- a/src/net/tcp/tcp.cpp
+++ b/src/net/tcp/tcp.cpp
@@ -115,12 +115,6 @@ void TCP::insert_connection(Connection_ptr conn)
       std::piecewise_construct,
       std::forward_as_tuple(conn->local_port(), conn->remote()),
       std::forward_as_tuple(conn));
-  // add to writeq if it has any jobs
-  if (conn->has_doable_job()) {
-    writeq.push_back(conn);
-    // try to flush
-    this->kick();
-  }
 }
 
 

--- a/src/net/tcp/tcp.cpp
+++ b/src/net/tcp/tcp.cpp
@@ -117,7 +117,9 @@ void TCP::insert_connection(Connection_ptr conn)
       std::forward_as_tuple(conn));
   // add to writeq if it has any jobs
   if (conn->has_doable_job()) {
-      writeq.push_back(conn);
+    writeq.push_back(conn);
+    // try to flush
+    this->kick();
   }
 }
 


### PR DESCRIPTION
Also move the initial call to OS::event_loop from OS::start to kernel_start to allow running scoped profilers in OS::start