### PR TITLE
test: re-enable uri tests, skip expected failures

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ set(TEST_SOURCES
   ${TEST}/util/unit/ringbuffer.cpp
   #${TEST}/util/unit/statman.cpp
   ${TEST}/util/unit/membitmap.cpp
-  #${TEST}/util/unit/uri_test.cpp
+  ${TEST}/util/unit/uri_test.cpp
 )
 
 set(OS_SOURCES

--- a/test/util/unit/uri_test.cpp
+++ b/test/util/unit/uri_test.cpp
@@ -40,7 +40,7 @@ using namespace std::string_literals;
       EXPECT(uri.host() == "www.vg.no"s);
     }
 
-    CASE("host() returns the URI's host (no path)") {
+    CASE("[.expectedfailure] host() returns the URI's host (no path)") {
       uri::URI uri {"http://www.vg.no"s};
       EXPECT(uri.host() == "www.vg.no"s);
     }
@@ -50,12 +50,12 @@ using namespace std::string_literals;
       EXPECT(uri.port() == 80);
     }
 
-    CASE("port() returns the URI's port (no path)") {
+    CASE("[.expectedfailure] port() returns the URI's port (no path)") {
       uri::URI uri {"http://www.vg.no:80"s};
       EXPECT(uri.port() == 80);
     }
 
-    CASE("Out-of-range ports are detected as invalid") {
+    CASE("[.expectedfailure] Out-of-range ports are detected as invalid") {
       uri::URI uri {"http://www.vg.no:65539"s};
       EXPECT(uri.is_valid() == false);
     }
@@ -85,7 +85,7 @@ using namespace std::string_literals;
       EXPECT(uri.fragment() == "#take-it-for-a-spin"s);
     }
 
-    CASE("Invalid port does not crash the parser") {
+    CASE("[.expectedfailure] Invalid port does not crash the parser") {
       uri::URI uri {"http://www.vg.no:80999999999999999999999999999"s};
       int port {0};
       EXPECT_NO_THROW(port = uri.port());


### PR DESCRIPTION
Lest tests can contain [tags] in their description. Lest skips tests that begin with `[.`, so we can tag expected failures to make Lest skip the few failing tests instead of commenting out a full test file in CMakeLists.txt