### PR TITLE
HTTP Client, TCP improvements and update GSL

### DIFF
--- a/api/net/http/client.hpp
+++ b/api/net/http/client.hpp
@@ -1,0 +1,111 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef HTTP_CLIENT_HPP
+#define HTTP_CLIENT_HPP
+
+#include "request.hpp"
+#include "response.hpp"
+#include <net/tcp/tcp.hpp>
+
+namespace http {
+
+  class Error {
+  public:
+    enum Code {
+      NONE,
+      RESOLVE_HOST,
+      NO_REPLY
+    };
+
+    Error(Code code = NONE)
+      : code_{code}
+    {}
+
+    operator bool() const
+    { return code_ != NONE; }
+
+    Error code() const
+    { return code_; }
+
+    std::string to_string() const
+    {
+      switch(code_)
+      {
+        case NONE:
+          return "No error";
+        case RESOLVE_HOST:
+          return "Unable to resolve host";
+        case NO_REPLY:
+          return "No reply";
+        default:
+          return "General error";
+      } // < switch code_
+    }
+
+  private:
+    Code code_;
+
+  };
+
+  class Client {
+  public:
+    using URI               = uri::URI;
+    using TCP               = net::TCP;
+    using Host              = net::tcp::Socket;
+    using Request_ptr       = std::unique_ptr<Request>;
+    using Response_ptr      = std::unique_ptr<Response>;
+    using ResponseCallback  = delegate<void(Error, Response_ptr)>;
+    const static size_t bufsiz = 4096;
+
+  private:
+    using Connection_ptr    = net::tcp::Connection_ptr;
+    using ResolveCallback   = delegate<void(net::ip4::Addr)>;
+
+
+  public:
+    explicit Client(TCP& tcp);
+
+    void send(Request_ptr, Host host, ResponseCallback);
+
+    void get(URI url, Header_set hfields, ResponseCallback cb);
+
+    void post(URI url, Header_set hfields, std::string data, ResponseCallback cb);
+
+    Request_ptr create_request() const;
+
+  private:
+    TCP& tcp_;
+    Connection_ptr conn_;
+    bool keep_alive_ = false;
+
+    void resolve(const URI&, ResolveCallback);
+
+    void set_connection_header(Request& req) const
+    {
+      req.header().set_field(header::Connection,
+      (keep_alive_) ? std::string{"keep-alive"} : std::string{"close"});
+    }
+
+    void populate_from_url(Request& req, const URI& url);
+
+  }; // < class Client
+
+} // < namespace http
+
+#endif // < HTTP_CLIENT_HPP

--- a/api/net/http/client.hpp
+++ b/api/net/http/client.hpp
@@ -34,36 +34,33 @@ namespace http {
   public:
     using TCP               = net::TCP;
     using Host              = net::tcp::Socket;
-    using ResponseCallback  = delegate<void(Error, Response_ptr)>;
-    const static size_t bufsiz = 2048;
 
-    using Connection_set     = std::vector<Connection>;
+    using Connection_set     = std::vector<std::unique_ptr<Connection>>;
     using Connection_mapset  = std::map<Host, Connection_set>;
 
-  private:
-    using Connection_ptr    = net::tcp::Connection_ptr;
-    using ResolveCallback   = delegate<void(net::ip4::Addr)>;
+    const static size_t bufsiz = 2048;
 
+  private:
+    using ResolveCallback    = delegate<void(net::ip4::Addr)>;
 
   public:
     explicit Client(TCP& tcp);
 
-    void send(Request_ptr, Host host, ResponseCallback);
+    void send(Request_ptr, Host host, Response_handler);
 
-    void get(URI url, Header_set hfields, ResponseCallback cb);
-    void get(std::string url, Header_set hfields, ResponseCallback cb)
+    void get(URI url, Header_set hfields, Response_handler cb);
+    void get(std::string url, Header_set hfields, Response_handler cb)
     { get(URI{url}, std::move(hfields), std::move(cb)); }
 
-    void post(URI url, Header_set hfields, std::string data, ResponseCallback cb);
-
-    void send_file(URI url, Header_set hfields, gsl::span<uint8_t> data, ResponseCallback cb);
+    void post(URI url, Header_set hfields, std::string data, Response_handler cb);
 
     Request_ptr create_request() const;
 
   private:
     TCP& tcp_;
-    bool keep_alive_ = false;
     Connection_mapset conns_;
+
+    bool keep_alive_ = false;
 
     void resolve(const URI&, ResolveCallback);
 

--- a/api/net/http/client.hpp
+++ b/api/net/http/client.hpp
@@ -32,7 +32,6 @@ namespace http {
 
   class Client {
   public:
-    using URI               = uri::URI;
     using TCP               = net::TCP;
     using Host              = net::tcp::Socket;
     using ResponseCallback  = delegate<void(Error, Response_ptr)>;
@@ -52,6 +51,8 @@ namespace http {
     void send(Request_ptr, Host host, ResponseCallback);
 
     void get(URI url, Header_set hfields, ResponseCallback cb);
+    void get(std::string url, Header_set hfields, ResponseCallback cb)
+    { get(URI{url}, std::move(hfields), std::move(cb)); }
 
     void post(URI url, Header_set hfields, std::string data, ResponseCallback cb);
 

--- a/api/net/http/common.hpp
+++ b/api/net/http/common.hpp
@@ -29,7 +29,7 @@ namespace http {
 
 using URI = uri::URI;
 
-using Header_set = std::vector<std::pair<std::experimental::string_view, std::string>>;
+using Header_set = std::vector<std::pair<std::string, std::string>>;
 
 class Request;
 using Request_ptr = std::unique_ptr<Request>;

--- a/api/net/http/common.hpp
+++ b/api/net/http/common.hpp
@@ -23,6 +23,7 @@
 #include <uri>
 #include <utility>
 #include <vector>
+#include <delegate>
 
 namespace http {
 
@@ -35,6 +36,9 @@ using Request_ptr = std::unique_ptr<Request>;
 
 class Response;
 using Response_ptr = std::unique_ptr<Response>;
+
+class Error;
+using Response_handler  = delegate<void(Error, Response_ptr)>;
 
 } //< namespace http
 

--- a/api/net/http/connection.hpp
+++ b/api/net/http/connection.hpp
@@ -1,0 +1,83 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef HTTP_CONNECTION_HPP
+#define HTTP_CONNECTION_HPP
+
+#include "common.hpp"
+#include "request.hpp"
+#include "response.hpp"
+#include "error.hpp"
+#include <net/tcp/connection.hpp>
+#include <map>
+#include <vector>
+#include <delegate>
+
+namespace http {
+
+  class Connection {
+  public:
+    using TCP_conn_ptr  = net::tcp::Connection_ptr;
+    using Peer          = net::tcp::Socket;
+    using buffer_t      = net::tcp::buffer_t;
+    using Close_handler = delegate<void(Connection&)>;
+
+  public:
+
+    explicit Connection(TCP_conn_ptr, Close_handler);
+
+    template <typename TCP>
+    explicit Connection(TCP&, Peer, Close_handler);
+
+    bool occupied() const
+    { return res_ != nullptr; }
+
+    void send(Request_ptr, Response_handler, const size_t bufsize = 2048);
+
+    net::tcp::port_t local_port() const
+    { return (tcpconn_) ? tcpconn_->local_port() : 0; }
+
+    Peer peer() const
+    { return (tcpconn_) ? tcpconn_->remote() : Peer(); }
+    //bool operator==(const Connection& other)
+    //{ return this == &other; }
+    //{ return tcpconn_->local_port() == other.tcpconn_->local_port(); }
+
+  private:
+    TCP_conn_ptr      tcpconn_;
+    Request_ptr       req_;
+    Response_ptr      res_;
+    Close_handler     on_close_;
+    Response_handler  on_response_;
+
+    bool keep_alive_;
+
+    void send_request(const size_t bufsize);
+
+    void recv_response(buffer_t buf, size_t len);
+
+    void end_response();
+
+    void close()
+    { on_close_(*this); }
+
+  }; // < class Connection
+
+} // < namespace http
+
+#endif // < HTTP_CONNECTION_HPP

--- a/api/net/http/connection.hpp
+++ b/api/net/http/connection.hpp
@@ -45,7 +45,7 @@ namespace http {
     explicit Connection(TCP&, Peer, Close_handler);
 
     bool occupied() const
-    { return res_ != nullptr; }
+    { return on_response_ != nullptr; }
 
     void send(Request_ptr, Response_handler, const size_t bufsize = 2048);
 
@@ -71,7 +71,7 @@ namespace http {
 
     void recv_response(buffer_t buf, size_t len);
 
-    void end_response();
+    void end_response(Error err = Error::NONE);
 
     void close()
     { on_close_(*this); }

--- a/api/net/http/error.hpp
+++ b/api/net/http/error.hpp
@@ -28,7 +28,8 @@ namespace http {
     enum Code {
       NONE,
       RESOLVE_HOST,
-      NO_REPLY
+      NO_REPLY,
+      INVALID
     };
 
     Error(Code code = NONE)

--- a/api/net/http/error.hpp
+++ b/api/net/http/error.hpp
@@ -1,0 +1,66 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef HTTP_ERROR_HPP
+#define HTTP_ERROR_HPP
+
+#include <string>
+
+namespace http {
+
+  class Error {
+  public:
+    enum Code {
+      NONE,
+      RESOLVE_HOST,
+      NO_REPLY
+    };
+
+    Error(Code code = NONE)
+      : code_{code}
+    {}
+
+    operator bool() const
+    { return code_ != NONE; }
+
+    Error code() const
+    { return code_; }
+
+    std::string to_string() const
+    {
+      switch(code_)
+      {
+        case NONE:
+          return "No error";
+        case RESOLVE_HOST:
+          return "Unable to resolve host";
+        case NO_REPLY:
+          return "No reply";
+        default:
+          return "General error";
+      } // < switch code_
+    }
+
+  private:
+    Code code_;
+
+  }; // < class Error
+
+} // < namespace http
+
+#endif // < HTTP_ERROR_HPP

--- a/api/net/http/header.hpp
+++ b/api/net/http/header.hpp
@@ -93,7 +93,7 @@ public:
   /// @return true if the field was added, false
   /// otherwise
   ///
-  bool add_field(const std::experimental::string_view field, std::string value);
+  bool add_field(const std::string field, std::string value);
 
   ///
   /// Change the value of the specified field
@@ -107,7 +107,7 @@ public:
   ///
   /// @return true if successful, false otherwise
   ///
-  bool set_field(const std::experimental::string_view field, std::string value);
+  bool set_field(const std::string field, std::string value);
 
   ///
   /// Check to see if the specified field is a

--- a/api/net/http/request.hpp
+++ b/api/net/http/request.hpp
@@ -18,11 +18,22 @@
 #ifndef HTTP_REQUEST_HPP
 #define HTTP_REQUEST_HPP
 
+#include <stdexcept>
+
 #include "message.hpp"
 #include "methods.hpp"
 #include "version.hpp"
 
 namespace http {
+
+///
+/// This class is used to represent an error that occurred
+/// from within the operations of class Request
+///
+class Request_error : public std::runtime_error {
+public:
+  using runtime_error::runtime_error;
+}; //< class Request_error
 
 ///
 /// This class is used to represent
@@ -38,7 +49,7 @@ public:
   ///
   /// Constructor to construct a request
   /// message from the incoming character
-  /// stream of data which is a <std::string>
+  /// stream of data which is a {std::string}
   /// object
   ///
   /// @param request The character stream of data
@@ -46,7 +57,9 @@ public:
   /// @param limit Capacity of how many fields can
   /// be added
   ///
-  explicit Request(std::string request, const std::size_t limit = 25);
+  /// @param parse Whether to perform parsing on the the data specified in {request}
+  ///
+  explicit Request(std::string request, const std::size_t limit = 25, const bool parse = true);
 
   ///
   /// Default copy constructor
@@ -72,6 +85,13 @@ public:
   /// Default move assignment operator
   ///
   Request& operator = (Request&&) = default;
+
+  ///
+  /// Parse the information supplied to the Request object
+  ///
+  /// @return The object that invoked this method
+  ///
+  Request& parse();
 
   ///
   /// Get the method of the request message
@@ -171,11 +191,20 @@ public:
   /// into string form
   ///
   operator std::string () const;
+
+  ///
+  /// Stream a chunk of new data into the request for parsing
+  ///
+  /// @param chunk A new set of data to append to request for parsing
+  ///
+  /// @return The object that invoked this method
+  ///
+  Request& operator << (const std::string& chunk);
 private:
   ///
   /// Class data members
   ///
-  const std::string request_;
+  std::string request_;
 
   ///
   /// Request-line parts

--- a/api/net/http/response.hpp
+++ b/api/net/http/response.hpp
@@ -18,11 +18,22 @@
 #ifndef HTTP_RESPONSE_HPP
 #define HTTP_RESPONSE_HPP
 
+#include <stdexcept>
+
 #include "message.hpp"
 #include "status_codes.hpp"
 #include "version.hpp"
 
 namespace http {
+
+///
+/// This class is used to represent an error that occurred
+/// from within the operations of class Response
+///
+class Response_error : public std::runtime_error {
+public:
+  using runtime_error::runtime_error;
+}; //< class Response_error
 
 ///
 /// This class is used to represent
@@ -51,7 +62,9 @@ public:
   /// @param limit Capacity of how many fields can
   /// be added
   ///
-  explicit Response(std::string response, const std::size_t limit = 25);
+  /// @param parse Whether to perform parsing on the the data specified in {response}
+  ///
+  explicit Response(std::string response, const std::size_t limit = 25, const bool parse = true);
 
   ///
   /// Default copy constructor
@@ -77,6 +90,13 @@ public:
   /// Default move assignment operator
   ///
   Response& operator = (Response&&) = default;
+
+  ///
+  /// Parse the information supplied to the Response object
+  ///
+  /// @return The object that invoked this method
+  ///
+  Response& parse();
 
   ///
   /// Get the status code of this
@@ -136,11 +156,20 @@ public:
   /// into string form
   ///
   operator std::string () const;
+
+  ///
+  /// Stream a chunk of new data into the response for parsing
+  ///
+  /// @param chunk A new set of data to append to response for parsing
+  ///
+  /// @return The object that invoked this method
+  ///
+  Response& operator << (const std::string& chunk);
 private:
   ///
   /// Class data members
   ///
-  const std::string response_;
+  std::string response_;
 
   ///
   /// Status-line parts

--- a/api/net/tcp/connection.inc
+++ b/api/net/tcp/connection.inc
@@ -9,7 +9,8 @@ inline Connection& Connection::on_connect(ConnectCallback cb) {
 }
 
 inline Connection& Connection::on_read(size_t recv_bufsz, ReadCallback cb) {
-  read(recv_bufsz, cb);
+  read_request = {{new_shared_buffer(recv_bufsz), recv_bufsz}, cb};
+  //read(recv_bufsz, cb);
   return *this;
 }
 

--- a/api/net/tcp/tcp.hpp
+++ b/api/net/tcp/tcp.hpp
@@ -186,7 +186,7 @@ namespace net {
     /*
       Settings
     */
-    tcp::port_t current_ephemeral_ = 1024;
+    tcp::port_t current_ephemeral_;
 
     std::chrono::milliseconds MAX_SEG_LIFETIME;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ set(OS_OBJECTS
   net/super_stack.cpp
   net/http/header.cpp net/http/header_fields.cpp net/http/message.cpp net/http/request.cpp
   net/http/response.cpp net/http/status_codes.cpp net/http/time.cpp net/http/version.cpp
-  net/http/client.cpp
+  net/http/client.cpp net/http/connection.cpp
   fs/disk.cpp fs/filesystem.cpp fs/mbr.cpp fs/path.cpp
   fs/fat.cpp fs/fat_async.cpp fs/fat_sync.cpp fs/memdisk.cpp
   posix/fd.cpp posix/tcp_fd.cpp posix/udp_fd.cpp posix/unistd.cpp posix/fcntl.cpp posix/syslog.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(OS_OBJECTS
   net/super_stack.cpp
   net/http/header.cpp net/http/header_fields.cpp net/http/message.cpp net/http/request.cpp
   net/http/response.cpp net/http/status_codes.cpp net/http/time.cpp net/http/version.cpp
+  net/http/client.cpp
   fs/disk.cpp fs/filesystem.cpp fs/mbr.cpp fs/path.cpp
   fs/fat.cpp fs/fat_async.cpp fs/fat_sync.cpp fs/memdisk.cpp
   posix/fd.cpp posix/tcp_fd.cpp posix/udp_fd.cpp posix/unistd.cpp posix/fcntl.cpp posix/syslog.cpp

--- a/src/net/http/client.cpp
+++ b/src/net/http/client.cpp
@@ -35,12 +35,12 @@ namespace http {
   void Client::get(URI url, Header_set hfields, ResponseCallback cb)
   {
     resolve(url,
-    [ this, url, cb{std::move(cb)}, hfields{std::move(hfields)} ] (auto ip)
+    [ this, url{std::move(url)}, cb{std::move(cb)}, hfields{std::move(hfields)} ] (auto ip)
     {
       // Host resolved
       if(ip != 0)
       {
-        const uint16_t port = (url.port() != 0) ? url.port() : 80;
+        const uint16_t port = (url.port() != 0xFFFF) ? url.port() : 80;
 
         auto req = create_request();
 
@@ -89,7 +89,7 @@ namespace http {
   void Client::populate_from_url(Request& req, const URI& url)
   {
     // Set uri path
-    req.set_uri( URI{url.path()} );
+    req.set_uri( URI{url.path().to_string()} );
     // Set Host: url.host
     req.header().set_field(header::Host, url.host().to_string());
   }

--- a/src/net/http/client.cpp
+++ b/src/net/http/client.cpp
@@ -1,0 +1,136 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <net/http/client.hpp>
+
+namespace http {
+
+  Client::Client(TCP& tcp)
+    : tcp_(tcp), conn_(nullptr)
+  {
+  }
+
+  void Client::send(Request_ptr req, Host host, ResponseCallback cb)
+  {
+    printf("Sending Request:\n%s\n", req->to_string().c_str());
+    conn_ = tcp_.connect(host);
+
+    conn_->on_read(bufsiz,
+    [ conn = conn_, cb{std::move(cb)} ] (auto buf, auto len)
+    {
+      printf("Client@onRead:\n%.*s\n", len, (char*) buf.get());
+      if(len == 0) {
+        cb({Error::NO_REPLY}, nullptr);
+        return;
+      }
+      try {
+        auto res = make_response({(char*)buf.get(), len});
+        cb({Error::NONE}, std::move(res));
+      }
+      catch(...)
+      {
+        cb({Error::NO_REPLY}, nullptr);
+      }
+    });
+
+    conn_->write(req->to_string());
+  }
+
+  void Client::get(URI url, Header_set hfields, ResponseCallback cb)
+  {
+    resolve(url,
+    [ this, url, cb{std::move(cb)}, hfields{std::move(hfields)} ] (auto ip)
+    {
+      // Host resolved
+      if(ip != 0)
+      {
+        const uint16_t port = (url.port() != 0) ? url.port() : 80;
+
+        auto req = create_request();
+
+        populate_from_url(*req, url);
+
+        *req << hfields;
+
+        send(std::move(req), {ip, port}, std::move(cb));
+      }
+      else
+      {
+        cb({Error::RESOLVE_HOST}, nullptr);
+      }
+    });
+  }
+
+  void Client::post(URI url, Header_set hfields, std::string data, ResponseCallback cb)
+  {
+    resolve(url,
+    [ this, url, cb{std::move(cb)}, data{std::move(data)}, hfields{std::move(hfields)} ] (auto ip)
+    {
+      // Host resolved
+      if(ip != 0)
+      {
+        const uint16_t port = (url.port() != 0) ? url.port() : 80;
+
+        auto req = create_request();
+
+        req->set_method(POST);
+
+        populate_from_url(*req, url);
+
+        *req << hfields;
+
+        req->add_body(std::move(data));
+
+        send(std::move(req), {ip, port}, std::move(cb));
+      }
+      else
+      {
+        cb({Error::RESOLVE_HOST}, nullptr);
+      }
+    });
+  }
+
+  void Client::populate_from_url(Request& req, const URI& url)
+  {
+    // Set uri path
+    req.set_uri( URI{url.path()} );
+    // Set Host: url.host
+    req.header().set_field(header::Host, url.host().to_string());
+  }
+
+  void Client::resolve(const URI& url, ResolveCallback cb)
+  {
+    static auto&& stack = tcp_.stack();
+    stack.resolve(url.host().to_string(),
+      [cb](auto ip)
+    {
+      cb(ip);
+    });
+  }
+
+  Request_ptr Client::create_request() const
+  {
+    auto req = std::make_unique<Request>();
+
+    auto& header = req->header();
+    header.set_field(header::User_Agent, "IncludeOS/0.9");
+    set_connection_header(*req);
+
+    return req;
+  }
+
+}

--- a/src/net/http/connection.cpp
+++ b/src/net/http/connection.cpp
@@ -1,0 +1,87 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <net/http/connection.hpp>
+#include <gsl/gsl_assert>
+
+namespace http {
+
+  Connection::Connection(TCP_conn_ptr tcpconn, Close_handler on_close)
+    : tcpconn_{std::move(tcpconn)},
+      req_{nullptr},
+      res_{nullptr},
+      on_close_{std::move(on_close)},
+      on_response_{},
+      keep_alive_{true}
+  {
+    // setup close event
+    tcpconn_->on_close({this, &Connection::close});
+
+    //tcpconn_->on_connect([](auto self) {
+    //  printf("<http::Connection> Connected: %s\n", self->to_string().c_str());
+    //});
+  }
+  template <typename TCP>
+  Connection::Connection(TCP& tcp, Peer addr, Close_handler on_close)
+    : Connection(tcp.connect(addr), std::move(on_close))
+  {
+  }
+
+  void Connection::send(Request_ptr req, Response_handler on_res, const size_t bufsize)
+  {
+    req_ = std::move(req);
+    res_ = std::make_unique<Response>();
+    on_response_ = std::move(on_res);
+
+    send_request(bufsize);
+  }
+
+  void Connection::send_request(const size_t bufsize)
+  {
+    keep_alive_ = (req_->header().value(header::Connection) != "close");
+
+    tcpconn_->on_read(bufsize, {this, &Connection::recv_response});
+
+    tcpconn_->write(req_->to_string());
+  }
+
+  void Connection::recv_response(buffer_t buf, size_t len)
+  {
+    Expects(res_ != nullptr);
+    *res_ << std::string{(char*)buf.get(), len};
+    res_->parse();
+
+    const auto& header = res_->header();
+    // TODO: Temporary, not good enough
+    // if(res_->is_complete())
+    if(!header.is_empty() && std::stoi(header.value(header::Content_Length).to_string()) == res_->body().size())
+      end_response();
+  }
+
+  void Connection::end_response()
+  {
+    // move response to a copy in case of callback result in new request
+    auto callback{std::move(on_response_)};
+
+    callback({Error::NONE}, std::move(res_));
+
+    // user callback may override this
+    if(keep_alive_)
+      tcpconn_->close();
+  }
+
+}

--- a/src/net/http/header.cpp
+++ b/src/net/http/header.cpp
@@ -30,11 +30,11 @@ Header::Header(const std::size_t limit) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-bool Header::add_field(const std::experimental::string_view field, std::string value) {
+bool Header::add_field(const std::string field, std::string value) {
   if (field.empty()) return false;
   //-----------------------------------
   if (size() < fields_.capacity()) {
-    fields_.emplace_back(field, std::move(value));
+    fields_.emplace_back(std::move(field), std::move(value));
     return true;
   }
   //-----------------------------------
@@ -42,7 +42,7 @@ bool Header::add_field(const std::experimental::string_view field, std::string v
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-bool Header::set_field(const std::experimental::string_view field, std::string value) {
+bool Header::set_field(const std::string field, std::string value) {
   if (field.empty() || value.empty()) return false;
   //-----------------------------------
   const auto target = find(field);
@@ -52,7 +52,7 @@ bool Header::set_field(const std::experimental::string_view field, std::string v
     return true;
   }
   //-----------------------------------
-  else return add_field(field, std::move(value));
+  else return add_field(std::move(field), std::move(value));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/net/http/message.cpp
+++ b/src/net/http/message.cpp
@@ -40,7 +40,7 @@ Message& Message::add_body(const Message_body& message_body) {
   //-----------------------------------
   message_body_ = message_body;
   //-----------------------------------
-  header().add_field(header::Content_Length, std::to_string(message_body_.size()));
+  //header().add_field(header::Content_Length, std::to_string(message_body_.size()));
   return *this;
 }
 
@@ -50,7 +50,7 @@ Message& Message::add_chunk(const std::string& chunk) {
   //-----------------------------------
   message_body_.append(chunk);
   //-----------------------------------
-  header().set_field(header::Content_Length, std::to_string(message_body_.size()));
+  //header().set_field(header::Content_Length, std::to_string(message_body_.size()));
   return *this;
 }
 
@@ -67,7 +67,7 @@ std::experimental::string_view Message::body() const noexcept {
 ///////////////////////////////////////////////////////////////////////////////
 Message& Message::clear_body() noexcept {
   message_body_.clear();
-  header().erase(header::Content_Length);
+  //header().erase(header::Content_Length);
   return *this;
 }
 

--- a/src/net/http/request.cpp
+++ b/src/net/http/request.cpp
@@ -129,7 +129,7 @@ static void configure_settings(http_parser_settings& settings_) noexcept {
 
   settings_.on_header_value = [](http_parser* parser, const char* at, size_t length) {
     auto req = reinterpret_cast<Request*>(parser->data);
-    req->header().add_field(req->private_field(), {at, length});
+    req->header().set_field(req->private_field().to_string(), {at, length});
     return 0;
   };
 

--- a/src/net/http/response.cpp
+++ b/src/net/http/response.cpp
@@ -108,13 +108,13 @@ static void configure_settings(http_parser_settings& settings_) noexcept {
 
   settings_.on_header_value = [](http_parser* parser, const char* at, size_t length) {
     auto res = reinterpret_cast<Response*>(parser->data);
-    res->header().add_field(res->private_field(), {at, length});
+    res->header().set_field(res->private_field(), {at, length});
     return 0;
   };
 
   settings_.on_body = [](http_parser* parser, const char* at, size_t length) {
     auto res = reinterpret_cast<Response*>(parser->data);
-    res->add_chunk({at, length});
+    res->add_body({at, length});
     return 0;
   };
 

--- a/src/net/http/response.cpp
+++ b/src/net/http/response.cpp
@@ -108,7 +108,7 @@ static void configure_settings(http_parser_settings& settings_) noexcept {
 
   settings_.on_header_value = [](http_parser* parser, const char* at, size_t length) {
     auto res = reinterpret_cast<Response*>(parser->data);
-    res->header().set_field(res->private_field(), {at, length});
+    res->header().set_field(res->private_field().to_string(), {at, length});
     return 0;
   };
 

--- a/src/net/http/response.cpp
+++ b/src/net/http/response.cpp
@@ -22,7 +22,7 @@ namespace http {
 
 static void configure_settings(http_parser_settings&) noexcept;
 
-static void execute_parser(Response*, http_parser&, http_parser_settings&, const std::string&) noexcept;
+static size_t execute_parser(Response*, http_parser&, http_parser_settings&, const std::string&) noexcept;
 
 ///////////////////////////////////////////////////////////////////////////////
 Response::Response(const Version version, const Code code) noexcept
@@ -31,15 +31,25 @@ Response::Response(const Version version, const Code code) noexcept
 {}
 
 ///////////////////////////////////////////////////////////////////////////////
-Response::Response(std::string response, const std::size_t limit)
+Response::Response(std::string response, const std::size_t limit, const bool parse)
   : Message{limit}
   , response_{std::move(response)}
 {
+  if (parse) this->parse();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+Response& Response::parse() {
   http_parser          parser;
   http_parser_settings settings;
 
   configure_settings(settings);
-  execute_parser(this, parser, settings, response_);
+
+  if (execute_parser(this, parser, settings, response_) not_eq response_.length()) {
+    throw Response_error{"Invalid response: " + response_};
+  }
+
+  return *this;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -117,11 +127,17 @@ static void configure_settings(http_parser_settings& settings_) noexcept {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-static void execute_parser(Response* res, http_parser& parser, http_parser_settings& settings,
+static size_t execute_parser(Response* res, http_parser& parser, http_parser_settings& settings,
                            const std::string& data) noexcept {
   http_parser_init(&parser, HTTP_RESPONSE);
   parser.data = res;
-  http_parser_execute(&parser, &settings, data.data(), data.size());
+  return http_parser_execute(&parser, &settings, data.data(), data.size());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+Response& Response::operator << (const std::string& chunk) {
+  response_.append(chunk);
+  return *this;
 }
 
 } //< namespace http

--- a/src/net/tcp/connection.cpp
+++ b/src/net/tcp/connection.cpp
@@ -427,6 +427,7 @@ void Connection::send_much() {
 }
 
 bool Connection::handle_ack(const Packet& in) {
+  debug2("<Connection::handle_ack> IN: %s\n", in.to_string().c_str());
   // dup ack
   /*
     1. Same ACK as latest received
@@ -683,7 +684,7 @@ void Connection::retransmit() {
   if(packet->should_rtx() and !rtx_timer.is_running()) {
     rtx_start();
   }
-
+  debug2("<Connection::retransmit> RTX: %s\n", packet->to_string().c_str());
   host_.transmit(std::move(packet));
 }
 

--- a/src/net/tcp/connection_states.cpp
+++ b/src/net/tcp/connection_states.cpp
@@ -922,10 +922,9 @@ State::Result Connection::SynSent::handle(Connection& tcp, Packet_ptr in) {
         packet->set_seq(tcb.SND.NXT).set_ack(tcb.RCV.NXT).set_flag(ACK);
         tcp.transmit(std::move(packet));
       }
-      // State is now ESTABLISHED.
-      // Experimental, also makes unessecary process.
-      //in->clear_flag(SYN);
-      //tcp.state().handle(tcp, in);
+
+      if(tcp.has_doable_job())
+        tcp.writeq_push();
 
       // 7. process segment text
       if(in->has_tcp_data()) {

--- a/src/net/tcp/tcp.cpp
+++ b/src/net/tcp/tcp.cpp
@@ -42,6 +42,8 @@ TCP::TCP(IPStack& inet) :
   MAX_SEG_LIFETIME(30s)
 {
   inet.on_transmit_queue_available({this, &TCP::process_writeq});
+  // TODO: RFC 6056
+  current_ephemeral_ = 1024 + rand() % (UINT_MAX-1024);
 }
 
 /*

--- a/test/misc/binary_check/test.sh
+++ b/test/misc/binary_check/test.sh
@@ -29,8 +29,9 @@ binary_detected=0
 # Loop over files and check for binary blobs
 for single_file in $files_changed; do
 	filetype=`file -i $INCLUDEOS_SRC/$single_file`
-    echo $filetype | grep -q charset=binary
+    echo $filetype | grep -q charset=binary | grep -v directory
     if [ $? -eq 0 ]; then
+		# Skips file if it has an extension
         if [[ $single_file == *.* ]]; then
 			continue
 		fi

--- a/test/net/integration/http/CMakeLists.txt
+++ b/test/net/integration/http/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+# IncludeOS install location
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
+endif()
+
+set(CMAKE_TOOLCHAIN_FILE $ENV{INCLUDEOS_PREFIX}/includeos/i686-elf-toolchain.cmake)
+
+project (test_http)
+
+# Human-readable name of your service
+set(SERVICE_NAME "HTTP Test Service")
+
+# Name of your service binary
+set(BINARY       "test_http")
+
+# Maximum memory can be hard-coded into the binary
+set(MAX_MEM 128)
+
+
+# Source files to be linked with OS library parts to form bootable image
+set(SOURCES
+  service.cpp # ...add more here
+  )
+
+# DRIVERS / PLUGINS:
+
+set(DRIVERS
+  virtionet   # Virtio networking
+  # virtioblock # Virtio block device
+  # ... Others from IncludeOS/src/drivers
+  )
+
+# include service build script
+include($ENV{INCLUDEOS_PREFIX}/includeos/service.cmake)

--- a/test/net/integration/http/README.md
+++ b/test/net/integration/http/README.md
@@ -1,0 +1,6 @@
+# HTTP Test
+
+## Client
+Test the HTTP Client on local server.
+
+Outgoing test requires correct network configuration.

--- a/test/net/integration/http/run.sh
+++ b/test/net/integration/http/run.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+set -
+INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
+sudo $INCLUDEOS_PREFIX/includeos/scripts/create_bridge.sh
+
+FILE=$1
+shift
+source $INCLUDEOS_PREFIX/includeos/scripts/run.sh $FILE ${*}

--- a/test/net/integration/http/service.cpp
+++ b/test/net/integration/http/service.cpp
@@ -1,0 +1,53 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <service>
+#include <net/http/client.hpp>
+#include <net/inet4>
+#include <info>
+
+std::unique_ptr<http::Client> client_;
+
+void Service::start(const std::string&)
+{
+
+}
+
+void Service::ready()
+{
+  auto& inet = net::Inet4::stack<0>(); // Inet4<VirtioNet>::stack<0>();
+  inet.network_config(
+    {  10,  0,  0, 44 },  // IP
+    {  255,255,255, 0 },  // Netmask
+    {  10,  0,  0,  1 },  // Gateway
+    {   8,  8,  8,  8 }   // DNS
+  );
+
+  client_ = std::make_unique<http::Client>(inet.tcp());
+
+  INFO("Client", "Testing HTTP Client");
+  auto req = client_->create_request();
+
+  req->set_uri(uri::URI{"/testing"});
+
+  client_->send(std::move(req), {inet.gateway(), 9000},
+  [] (auto err, auto res)
+  {
+    assert(!err);
+    printf("Response:\n%s\n", res->to_string().c_str());
+  });
+}

--- a/test/net/integration/http/service.cpp
+++ b/test/net/integration/http/service.cpp
@@ -47,7 +47,9 @@ void Service::ready()
   client_->send(std::move(req), {inet.gateway(), 9000},
   [] (auto err, auto res)
   {
-    assert(!err);
+    CHECKSERT(!err, "No error");
+    CHECKSERT(res->body() == "/testing", "Received body: \"/testing\"");
     printf("Response:\n%s\n", res->to_string().c_str());
+    printf("SUCCESS\n");
   });
 }

--- a/test/net/integration/http/test.py
+++ b/test/net/integration/http/test.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+
+import sys
+import os
+
+includeos_src = os.environ.get('INCLUDEOS_SRC',
+                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
+sys.path.insert(0,includeos_src + "/test")
+
+import vmrunner
+
+HOST = ''
+PORT = 9000
+
+import BaseHTTPServer
+
+DO_SERVE = True
+class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    def do_GET(s):
+        s.send_response(200)
+        s.send_header("Content-type", "text/plain")
+        s.end_headers()
+        s.wfile.write("%s" % s.path)
+
+
+def Client_test(trigger_line):
+    server_class = BaseHTTPServer.HTTPServer
+    httpd = server_class((HOST, PORT), RequestHandler)
+    global DO_SERVE
+    while(DO_SERVE):
+        httpd.handle_request()
+        DO_SERVE = False
+
+# Get an auto-created VM from the vmrunner
+vm = vmrunner.vms[0]
+
+# Add custom event-handler
+vm.on_output("Testing HTTP Client", Client_test)
+
+# Boot the VM, taking a timeout as parameter
+vm.cmake().boot(20).clean()

--- a/test/net/integration/http/test.py
+++ b/test/net/integration/http/test.py
@@ -36,7 +36,7 @@ def Client_test(trigger_line):
 vm = vmrunner.vms[0]
 
 # Add custom event-handler
-vm.on_output("Testing HTTP Client", Client_test)
+vm.on_output("Testing against local server", Client_test)
 
 # Boot the VM, taking a timeout as parameter
 vm.cmake().boot(20).clean()

--- a/test/net/integration/http/test.py
+++ b/test/net/integration/http/test.py
@@ -30,6 +30,7 @@ def Client_test(trigger_line):
     while(DO_SERVE):
         httpd.handle_request()
         DO_SERVE = False
+    httpd.server_close()
 
 # Get an auto-created VM from the vmrunner
 vm = vmrunner.vms[0]

--- a/test/net/integration/http/vm.json
+++ b/test/net/integration/http/vm.json
@@ -1,0 +1,6 @@
+{
+  "image" : "test_http.img",
+  "net" : [{"device" : "virtio", "mac" : "c0:01:0a:00:00:2a"}],
+  "cpu"   : "host",
+  "mem"   : 256
+}


### PR DESCRIPTION
* Simple randomization of ports (got really tired of all resets because of the same outgoing port being used when service got restarted a lot)
* Some minor changes to TCP, makes it possible to correctly write (queue) and hook up on read before connection has been established.
* HTTP Client (WIP)
* Update GSL to latest version