### PR TITLE
Better support for Arch Linux

### DIFF
--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -47,7 +47,7 @@ case $SYSTEM in
                 echo ">>> Installing dependencies (requires sudo):"
                 echo "    Packages: $DEPENDENCIES"
                 sudo pacman -Syyu
-                sudo pacman -S $DEPENDENCIES
+                sudo pacman -S --needed $DEPENDENCIES
                 exit 0;
                 ;;
         esac

--- a/etc/scripts/create_bridge.sh
+++ b/etc/scripts/create_bridge.sh
@@ -48,7 +48,7 @@ else
   fi
 
   # Check if bridge already is created
-  if $BRSHOW $BRIDGE 2>&1 | grep -q "No such device"; then
+  if $BRSHOW $BRIDGE 2>&1 | grep -qE "No such device|bridge $BRIDGE does not exist"; then
     echo ">>> Creating network bridge (requires sudo):"
     sudo brctl addbr $BRIDGE || exit 1
   else


### PR DESCRIPTION
1. Only install the "needed" packages (e.g. the ones that are not currently installed) on Arch Linux
2. brctl show differs in output on Arch Linux when the bridge does not exist