### PR TITLE
Fixed wrong vmrunner imports

### DIFF
--- a/test/plugin/integration/unik/test.py
+++ b/test/plugin/integration/unik/test.py
@@ -5,7 +5,7 @@ import os
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
-sys.path.insert(0,includeos_src + "/test")
+sys.path.insert(0,includeos_src)
 
 from vmrunner import vmrunner
 

--- a/test/util/integration/tar/test.py
+++ b/test/util/integration/tar/test.py
@@ -6,7 +6,7 @@ import os
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 print 'includeos_src: {0}'.format(includeos_src)
-sys.path.insert(0,includeos_src + "/test")
+sys.path.insert(0,includeos_src)
 
 from vmrunner import vmrunner
 vm = vmrunner.vms[0]

--- a/test/util/integration/tar_gz/test.py
+++ b/test/util/integration/tar_gz/test.py
@@ -6,7 +6,7 @@ import os
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 print 'includeos_src: {0}'.format(includeos_src)
-sys.path.insert(0,includeos_src + "/test")
+sys.path.insert(0,includeos_src)
 
 from vmrunner import vmrunner
 vm = vmrunner.vms[0]


### PR DESCRIPTION
The way the import is done is still not the proper way to do it. This is still not a python module, for that it will require a setup.py as well. I'll see to this later. 