### PR TITLE
kprint: add va_end

### DIFF
--- a/src/include/kprint
+++ b/src/include/kprint
@@ -32,6 +32,7 @@ inline void kprintf(const char* format, ...) {
   va_start(aptr, format);
   vsnprintf(buf, bufsize, format, aptr);
   hw::Serial::print1(buf);
+  va_end(aptr);
 }
 
 #define kprint(cstr) hw::Serial::print1(cstr)


### PR DESCRIPTION
> Before a function that has initialized a va_list object with va_start returns, the va_end macro shall be invoked.

[va_list](http://www.cplusplus.com/reference/cstdarg/va_list/)

If this is true, we should probably do it. If this is *not* true in IncludeOS, we should probably add a comment.