### PR TITLE
test: updated logger_test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,9 +36,9 @@ set(TEST_SOURCES
   ${TEST}/util/unit/fixed_vector.cpp
   ${TEST}/util/unit/logger_test.cpp
   ${TEST}/util/unit/membitmap.cpp
+  ${TEST}/util/unit/path_to_regex_no_options.cpp
   ${TEST}/util/unit/path_to_regex_parse.cpp
   ${TEST}/util/unit/path_to_regex_options.cpp
-  ${TEST}/util/unit/path_to_regex_no_options.cpp
   ${TEST}/util/unit/ringbuffer.cpp
   ${TEST}/util/unit/statman.cpp
   ${TEST}/util/unit/uri_test.cpp
@@ -62,15 +62,15 @@ set(OS_SOURCES
   ${SRC}/kernel/cpuid.cpp
   ${SRC}/kernel/main_call.cpp
   ${SRC}/kernel/memmap.cpp
+  ${SRC}/net/http/cookie.cpp
   ${SRC}/net/util.cpp
   ${SRC}/posix/fd.cpp
   ${SRC}/util/crc32.cpp
   ${SRC}/util/logger.cpp
+  ${SRC}/util/path_to_regex.cpp
+  ${SRC}/util/percent_encoding.cpp
   ${SRC}/util/statman.cpp
   ${SRC}/util/uri.cpp
-  ${SRC}/util/percent_encoding.cpp
-  ${SRC}/util/path_to_regex.cpp
-  ${SRC}/net/http/cookie.cpp
 )
 
 add_executable(unittests ${OS_SOURCES} ${TEST_SOURCES} )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,12 +34,12 @@ set(TEST_SOURCES
   ${TEST}/util/unit/fixed_vector.cpp
   ${TEST}/util/unit/logger_test.cpp
   ${TEST}/util/unit/membitmap.cpp
-  ${TEST}/util/unit/ringbuffer.cpp
-  #${TEST}/util/unit/statman.cpp
-  ${TEST}/util/unit/uri_test.cpp
   ${TEST}/util/unit/path_to_regex_parse.cpp
   ${TEST}/util/unit/path_to_regex_options.cpp
   ${TEST}/util/unit/path_to_regex_no_options.cpp
+  ${TEST}/util/unit/ringbuffer.cpp
+  ${TEST}/util/unit/statman.cpp
+  ${TEST}/util/unit/uri_test.cpp
 )
 
 set(OS_SOURCES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TEST_SOURCES
   ${TEST}/fs/unit/path_test.cpp
   ${TEST}/fs/unit/vfs_test.cpp
   ${TEST}/hw/unit/mac_addr_test.cpp
-  #${TEST}/kernel/unit/memmap_test.cpp
+  ${TEST}/kernel/unit/memmap_test.cpp
   ${TEST}/net/unit/ip4_addr.cpp
   ${TEST}/net/unit/tcp_packet_test.cpp
   ${TEST}/net/unit/tcp_socket.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,9 +32,10 @@ set(TEST_SOURCES
   ${TEST}/util/unit/delegate.cpp
   ${TEST}/util/unit/fixed_queue.cpp
   ${TEST}/util/unit/fixed_vector.cpp
+  ${TEST}/util/unit/logger_test.cpp
+  ${TEST}/util/unit/membitmap.cpp
   ${TEST}/util/unit/ringbuffer.cpp
   #${TEST}/util/unit/statman.cpp
-  ${TEST}/util/unit/membitmap.cpp
   ${TEST}/util/unit/uri_test.cpp
   ${TEST}/util/unit/path_to_regex_parse.cpp
   ${TEST}/util/unit/path_to_regex_options.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_SOURCES
   ${TEST}/net/unit/tcp_write_buffer.cpp
   ${TEST}/net/unit/tcp_write_queue.cpp
   ${TEST}/posix/unit/fd_map_test.cpp
+  ${TEST}/posix/unit/inet_test.cpp
   ${TEST}/util/unit/crc32.cpp
   ${TEST}/util/unit/delegate.cpp
   ${TEST}/util/unit/fixed_queue.cpp

--- a/test/kernel/unit/memmap_test.cpp
+++ b/test/kernel/unit/memmap_test.cpp
@@ -250,7 +250,3 @@ CASE ("Using the kernel memory map") {
         }
     }
 }
-
-// We can't link against the 32-bit version of IncludeOS (os.a)
-// TODOD: This is a terrible hack - we need Linux-build of os.a
-#include <kernel/memmap.cpp>

--- a/test/util/unit/logger_test.cpp
+++ b/test/util/unit/logger_test.cpp
@@ -17,7 +17,6 @@
 
 #include <common.cxx>
 #include <util/logger.hpp>
-#include <util/logger.cpp>
 
 CASE("Creating a Logger")
 {
@@ -63,7 +62,7 @@ CASE("Adding one entry")
       {
         auto entries = logger.entries();
 
-        EXPECT( entries.size() == 1 );
+        EXPECT( entries.size() == 1u );
         EXPECT( entries[0] == entry );
 
         WHEN("The logger is flushed")
@@ -115,7 +114,7 @@ CASE("Adding several entries")
       {
         auto entries = logger.entries();
 
-        EXPECT( entries.size() == 3 );
+        EXPECT( entries.size() == 3u );
 
         EXPECT( entries[0] == entry1 );
         EXPECT( entries[1] == entry2 );
@@ -127,7 +126,7 @@ CASE("Adding several entries")
 
           THEN("Only the last (latest) entry is returned")
           {
-            EXPECT( entries.size() == 1 );
+            EXPECT( entries.size() == 1u );
             EXPECT( entries[0] == entry3 );
           }
         }
@@ -159,7 +158,7 @@ CASE("Adding entries that wraps around")
       {
         auto entries = logger.entries();
 
-        EXPECT( entries.size() == 2 );
+        EXPECT( entries.size() == 2u );
         EXPECT( entries[0] == entry2 );
         EXPECT( entries[1] == entry3 );
       }
@@ -173,7 +172,7 @@ CASE("Adding entries that wraps around")
       {
         auto entries = logger.entries();
 
-        EXPECT( entries.size() == 1 );
+        EXPECT( entries.size() == 1u );
         EXPECT( entries[0] == entry3 );
       }
     }
@@ -189,7 +188,7 @@ CASE("Adding entries that wraps around")
 
         auto entries = logger.entries();
 
-        EXPECT( entries.size() == 1 );
+        EXPECT( entries.size() == 1u );
         EXPECT( entries[0] == substr );
       }
     }
@@ -201,7 +200,7 @@ CASE("Adding entries that wraps around")
       {
         auto entries = logger.entries();
 
-        EXPECT( entries.size() == 2 );
+        EXPECT( entries.size() == 2u );
       }
     }
   }
@@ -222,7 +221,7 @@ CASE("Adding a horde of log entries")
       const auto max_entries = logger.size() / sz;
       const unsigned rotations = 3;
 
-      for(int i; i < max_entries * rotations; ++i)
+      for(unsigned int i = 0; i < max_entries * rotations; ++i)
         logger.log(entry);
 
       THEN("There isnt more than maximum possible entries and they are all correct")

--- a/test/util/unit/statman.cpp
+++ b/test/util/unit/statman.cpp
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdlib.h>
+#include <util/statman.hpp>
 
 // IncludeOS
 #include <common.cxx>


### PR DESCRIPTION
For some reason, logger_test was not present in the unit test CMakeList. Added it and fixed warnings. Also re-enabled statman & memmap unit tests.
