### PR TITLE
mana: Use URI string operator due to changes of to_string

### DIFF
--- a/lib/mana/src/middleware/butler.cpp
+++ b/lib/mana/src/middleware/butler.cpp
@@ -40,7 +40,7 @@ void Butler::process(mana::Request_ptr req, mana::Response_ptr res, mana::Next n
   }
 
   // get path
-  std::string path = req->uri().to_string();
+  std::string path = req->uri();
   // resolve extension
   auto ext = get_extension(path);
   // concatenate root with path, example: / => /public/

--- a/lib/mana/src/middleware/director.cpp
+++ b/lib/mana/src/middleware/director.cpp
@@ -32,7 +32,7 @@ void Director::process(
   )
 {
   // get path
-  auto path = req->uri().to_string();
+  std::string path = req->uri();
 
   auto fpath = resolve_file_path(path);
   #ifdef VERBOSE_WEBSERVER

--- a/lib/mana/src/server.cpp
+++ b/lib/mana/src/server.cpp
@@ -106,7 +106,7 @@ void Server::process(Request_ptr req, Response_ptr res) {
     auto& it = *it_ptr;
 
     // skip those who don't match
-    while(it != middleware_.end() and !path_starts_with(req->uri().to_string(), it->path))
+    while(it != middleware_.end() and !path_starts_with(req->uri(), it->path))
       it++;
 
     // while there is more to do
@@ -130,7 +130,7 @@ void Server::process(Request_ptr req, Response_ptr res) {
 
 void Server::process_route(Request_ptr req, Response_ptr res) {
   try {
-    auto parsed_route = router_.match(req->method(), req->uri().to_string());
+    auto parsed_route = router_.match(req->method(), req->uri());
     req->set_params(parsed_route.parsed_values);
     parsed_route.job(req, res);
   }


### PR DESCRIPTION
Due to `URI::to_string` now returning `string_view` (and to avoid `to_string().to_string()`) it now makes use of the overloaded `std::string` operator. 
Maybe some of the code in mana should be refactored to operate with URI's instead of strings.