### PR TITLE
test: make unittests buildable on macOS

### DIFF
--- a/api/posix/arpa/inet.h
+++ b/api/posix/arpa/inet.h
@@ -26,6 +26,25 @@ extern "C" {
 #include "../netinet/in.h"
 #include <stdint.h>
 
+#ifdef ntohs
+#undef ntohs
+#endif
+#ifdef htons
+#undef htons
+#endif
+#ifdef ntohl
+#undef ntohl
+#endif
+#ifdef htonl
+#undef htonl
+#endif
+#ifdef ntohll
+#undef ntohll
+#endif
+#ifdef htonll
+#undef htonll
+#endif
+
 inline uint16_t ntohs(const uint16_t n) {
   return __builtin_bswap16(n);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST ${INCLUDEOS_ROOT}/test)
 
 include_directories(
   ${INCLUDEOS_ROOT}/api
+  ${INCLUDEOS_ROOT}/api/posix
   ${INCLUDEOS_ROOT}/src/
   ${INCLUDEOS_ROOT}/src/include
   ${INCLUDEOS_ROOT}/mod/


### PR DESCRIPTION
There *has* to be a better way (suggestions very welcome!), but this makes it possible to build/run unittests on macOS again with native compiler, no symlinking tricks necessary.