### PR TITLE
Support for test-coverage shields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.d
 *.pyc
 *.ropeproject
+*.xml
 nbproject
 
 !Dockerfile

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -438,7 +438,7 @@ def create_junit_output(tests):
 
         # If test is skipped add skipped info
         if test.skip_:
-            junit_object.add_skipped_info(output = test.skip_reason_)
+            junit_object.add_skipped_info(message = test.skip_reason_, output = test.skip_reason_)
         elif test.proc_.returncode is not 0:
             junit_object.add_failure_info(output = test.output_[0])
         else:

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -436,7 +436,7 @@ def create_junit_output(tests):
 
     # Integration tests
     for test in tests:
-        junit_object = jx.TestCase(test.name_, classname="IncludeOS.{}".format(test.category_))
+        junit_object = jx.TestCase(test.name_, classname="IncludeOS.{}.{}".format(test.type_, test.category_))
 
         # If test is skipped add skipped info
         if test.skip_:

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -267,7 +267,9 @@ def integration_tests(tests):
     Returns:
         integer: Number of tests that failed
     """
-    tests = [x for x in tests if x.type_ == "integration"]  # Only integration
+    if len(tests) == 0:
+        return 0
+
     time_sensitive_tests = [ x for x in tests if x.time_sensitive_ ]
     tests = [ x for x in tests if x not in time_sensitive_tests ]
 
@@ -471,7 +473,7 @@ def main():
     filtered_tests, skipped_tests = filter_tests(all_tests, args)
 
     # Run the tests
-    integration_result = integration_tests(filtered_tests)
+    integration_result = integration_tests([x for x in filtered_tests if x.type_ == "integration"])
     stress_result = stress_test([x for x in filtered_tests if x.type_ == "stress"])
     misc_result = misc_working([x for x in filtered_tests if x.type_ == "misc"])
 


### PR DESCRIPTION
In order to obtain proper shields with test coverage we needed a junit implementation within our testrunner.py script. To generate `output.xml` file used by jenkins (and shields.io) use the `-j` option. 

[Example](https://jenkins.includeos.org/view/All/job/shield_mnordsletten/)

![shield-here](https://img.shields.io/jenkins/t/https/jenkins.includeos.org/shield_mnordsletten.svg)

This can enable:
- A clearer split between build status, and test status in the readme.
- All pull requests can report how many tests actually failed. 

Required some small rewrites of the testrunner.py. It simplifies the way tests are run, by adding both stress test and the misc tests to be discovered at an earlier stage. 