### PR TITLE
Updated URI move and copy

### DIFF
--- a/api/net/http/client.hpp
+++ b/api/net/http/client.hpp
@@ -158,7 +158,7 @@ namespace http {
 
     bool keep_alive_ = false;
 
-    void resolve(const URI&, ResolveCallback);
+    void resolve(const std::string& host, ResolveCallback);
 
     void set_connection_header(Request& req) const
     {

--- a/api/net/http/connection.hpp
+++ b/api/net/http/connection.hpp
@@ -71,6 +71,7 @@ namespace http {
     Response_handler  on_response_;
     Timer             timer_;
 
+    timeout_duration  timeout_dur_;
     bool keep_alive_;
 
     void send_request(const size_t bufsize);

--- a/api/util/uri.hpp
+++ b/api/util/uri.hpp
@@ -50,14 +50,14 @@ class URI {
   explicit URI() = default;
 
   ///
-  /// Default copy constructor
+  /// Copy constructor
   ///
-  URI(const URI&) = default;
+  URI(const URI&);
 
   ///
-  /// Default move constructor
+  /// Move constructor
   ///
-  URI(URI&&) = default;
+  URI(URI&&);
 
   ///
   /// Default destructor
@@ -65,14 +65,14 @@ class URI {
   ~URI() = default;
 
   ///
-  /// Default assignment operator
+  /// Default copy assignment operator
   ///
-  URI& operator=(const URI&) = default;
+  URI& operator=(const URI&);
 
   ///
   /// Default move assignment operator
   ///
-  URI& operator=(URI&&) = default;
+  URI& operator=(URI&&);
 
   ///
   /// Construct using a view of a string representing a uri

--- a/src/net/http/client.cpp
+++ b/src/net/http/client.cpp
@@ -48,14 +48,17 @@ namespace http {
     if(! header.has_field(header::Host))
       header.set_field(header::Host, host.to_string());
 
+    debug("<http::Client> Sending Request:\n%s\n", req->to_string().c_str());
+
     conn.send(move(req), move(cb), options.bufsize, options.timeout);
   }
 
   void Client::request(Method method, URI url, Header_set hfields, Response_handler cb, Options options)
   {
     using namespace std;
-    resolve(url,
-    [ this, method, url{move(url)}, hfields{move(hfields)}, cb{move(cb)}, opt{move(options)}] (auto ip)
+    const auto host = url.host().to_string();
+    resolve(host,
+    [ this, method, url{std::move(url)}, hfields{move(hfields)}, cb{move(cb)}, opt{move(options)}] (auto ip)
     {
       // Host resolved
       if(ip != 0)
@@ -86,8 +89,8 @@ namespace http {
     auto req = create_request(method);
     *req << hfields;
 
-    //set uri
-    req->set_uri(URI{move(path)});
+    //set uri (default "/")
+    req->set_uri((!path.empty()) ? URI{move(path)} : URI{"/"});
 
     send(move(req), move(host), move(cb), move(options));
   }
@@ -95,8 +98,9 @@ namespace http {
   void Client::request(Method method, URI url, Header_set hfields, std::string data, Response_handler cb, Options options)
   {
     using namespace std;
-    resolve(url,
-    [ this, method, url, hfields{move(hfields)}, data{move(data)}, cb{move(cb)}, opt{move(options)} ] (auto ip)
+    const auto host = url.host().to_string();
+    resolve(host,
+    [ this, method, url{move(url)}, hfields{move(hfields)}, data{move(data)}, cb{move(cb)}, opt{move(options)} ] (auto ip)
     {
       // Host resolved
       if(ip != 0)
@@ -130,8 +134,8 @@ namespace http {
     auto req = create_request(method);
     *req << hfields;
 
-    // set uri
-    req->set_uri(URI{move(path)});
+    // set uri (default "/")
+    req->set_uri((!path.empty()) ? URI{move(path)} : URI{"/"});
 
     // Add data and content length
     add_data(*req, data);
@@ -154,21 +158,21 @@ namespace http {
 
   void Client::populate_from_url(Request& req, const URI& url)
   {
-    // Set uri path
-    req.set_uri( URI{url.path().to_string()} );
+    // Set uri path (default "/")
+    req.set_uri((!url.path().empty()) ? URI{url.path()} : URI{"/"});
 
     // Set Host: host(:port)
     const auto port = url.port();
     req.header().set_field(header::Host,
-      (port != 0xFFFF or port != 80) ?
+      (port != 0xFFFF and port != 80) ?
       url.host().to_string() + ":" + std::to_string(port)
       : url.host().to_string()); // to_string madness
   }
 
-  void Client::resolve(const URI& url, ResolveCallback cb)
+  void Client::resolve(const std::string& host, ResolveCallback cb)
   {
     static auto&& stack = tcp_.stack();
-    stack.resolve(url.host().to_string(),
+    stack.resolve(host,
       [ cb{std::move(cb)} ](auto ip)
     {
       cb(ip);
@@ -194,7 +198,7 @@ namespace http {
 
   void Client::close(Connection& c)
   {
-    debug("Closing %u:%s %p\n", c.local_port(), c.peer().to_string().c_str(), &c);
+    debug("<http::Client> Closing %u:%s %p\n", c.local_port(), c.peer().to_string().c_str(), &c);
     auto& cset = conns_.at(c.peer());
 
     cset.erase(std::remove_if(cset.begin(), cset.end(),

--- a/src/util/uri.cpp
+++ b/src/util/uri.cpp
@@ -51,11 +51,97 @@ inline static uint16_t bind_port(const std::experimental::string_view scheme,
   return (it not_eq port_table.cend()) ? it->second : 0xFFFFU;
 }
 
+// copy helper
+inline static std::experimental::string_view updated_copy(
+  const std::string& to_copy,
+  const std::experimental::string_view& view,
+  const std::string& from_copy)
+{
+  const auto offs = view.data() - from_copy.data();
+  return {to_copy.data() + offs, view.size()};
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
 URI::URI(const std::experimental::string_view uri, const bool parse)
   : uri_str_{decode(uri)}
 {
   if (parse) this->parse();
+}
+
+URI::URI(const URI& u)
+  : uri_str_{u.uri_str_},
+    port_{u.port_},
+    scheme_{updated_copy(uri_str_, u.scheme_, u.uri_str_)},
+    userinfo_{updated_copy(uri_str_, u.userinfo_, u.uri_str_)},
+    host_{updated_copy(uri_str_, u.host_, u.uri_str_)},
+    port_str_{updated_copy(uri_str_, u.port_str_, u.uri_str_)},
+    path_{updated_copy(uri_str_, u.path_, u.uri_str_)},
+    query_{updated_copy(uri_str_, u.query_, u.uri_str_)},
+    fragment_{updated_copy(uri_str_, u.fragment_, u.uri_str_)},
+    query_map_{}
+{
+  for(const auto& ent : u.query_map_)
+  {
+    query_map_.emplace(
+      updated_copy(uri_str_, ent.first, u.uri_str_),
+      updated_copy(uri_str_, ent.second, u.uri_str_)
+    );
+  }
+}
+
+URI::URI(URI&& u)
+  : uri_str_(std::move(u.uri_str_)),
+    port_(u.port_),
+    scheme_(u.scheme_),
+    userinfo_(u.userinfo_),
+    host_(u.host_),
+    port_str_(u.port_str_),
+    path_(u.path_),
+    query_(u.query_),
+    fragment_(u.fragment_),
+    query_map_(std::move(u.query_map_))
+{
+}
+
+URI& URI::operator=(const URI& u)
+{
+  uri_str_  = u.uri_str_;
+  port_     = u.port_;
+  scheme_   = updated_copy(uri_str_, u.scheme_, u.uri_str_);
+  userinfo_ = updated_copy(uri_str_, u.userinfo_, u.uri_str_);
+  host_     = updated_copy(uri_str_, u.host_, u.uri_str_);
+  port_str_ = updated_copy(uri_str_, u.port_str_, u.uri_str_);
+  path_     = updated_copy(uri_str_, u.path_, u.uri_str_);
+  query_    = updated_copy(uri_str_, u.query_, u.uri_str_);
+  fragment_ = updated_copy(uri_str_, u.fragment_, u.uri_str_);
+
+  query_map_.clear();
+
+  for(const auto& ent : u.query_map_)
+  {
+    query_map_.emplace(
+      updated_copy(uri_str_, ent.first, u.uri_str_),
+      updated_copy(uri_str_, ent.second, u.uri_str_)
+    );
+  }
+
+  return *this;
+}
+
+URI& URI::operator=(URI&& u)
+{
+  uri_str_  = std::move(u.uri_str_);
+  port_     = u.port_;
+  scheme_   = u.scheme_;
+  userinfo_ = u.userinfo_;
+  host_     = u.host_;
+  port_str_ = u.port_str_;
+  path_     = u.path_;
+  query_    = u.query_;
+  fragment_ = u.fragment_;
+  query_map_ = std::move(u.query_map_);
+  return *this;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It caused some weird stuff in the HTTP client where values where lost when URI got moved, making the Request invalid with corrupt path and empty `Host: `.