### PR TITLE
HTTP Client improvements, DNS Client rework, RFC 6335

### DIFF
--- a/api/net/dns/client.hpp
+++ b/api/net/dns/client.hpp
@@ -56,9 +56,7 @@ namespace net
     }
 
   private:
-    struct Request;
     UDPSocket& socket_;
-    std::unordered_map<DNS::Request::id_t, Request> requests_;
     std::map<std::string, IP4::addr> cache;
     std::map<IP4::addr, std::string> rev_cache;
 
@@ -85,6 +83,8 @@ namespace net
       { timer.start(timeout); }
 
     }; // < struct Request
+
+    std::unordered_map<DNS::Request::id_t, Request> requests_;
   };
 }
 

--- a/api/net/dns/dns.hpp
+++ b/api/net/dns/dns.hpp
@@ -151,18 +151,21 @@ namespace net
     public:
       int  create(char* buffer, const std::string& hostname);
       bool parseResponse(const char* buffer);
-      void print(char* buffer);
+      void print(const char* buffer) const;
 
       const std::string& getHostname() const
       {
         return this->hostname;
       }
+
       IP4::addr getFirstIP4() const
       {
-        if (answers.size())
-          return answers[0].getIP4();
+        auto it = answers.begin();
 
-        return IP4::ADDR_ANY;
+        while(it != answers.end() and !it->is_answer_type(DNS_TYPE_A))
+          ++it;
+
+        return (it != answers.end()) ? it->getIP4() : IP4::ADDR_ANY;
       }
 
     private:
@@ -175,7 +178,10 @@ namespace net
         rr_data resource;
 
         IP4::addr getIP4() const;
-        void      print();
+        void      print()  const;
+
+        bool is_answer_type(int type) const
+        { return ntohs(resource.type) == type; }
 
       private:
         // decompress names in 3www6google3com format

--- a/api/net/dns/dns.hpp
+++ b/api/net/dns/dns.hpp
@@ -162,10 +162,14 @@ namespace net
       {
         auto it = answers.begin();
 
-        while(it != answers.end() and !it->is_answer_type(DNS_TYPE_A))
+        while(it != answers.end())
+        {
+          if(it->is_type(DNS_TYPE_A))
+            return it->getIP4();
           ++it;
+        }
 
-        return (it != answers.end()) ? it->getIP4() : IP4::ADDR_ANY;
+        return IP4::ADDR_ANY;
       }
 
     private:
@@ -180,7 +184,7 @@ namespace net
         IP4::addr getIP4() const;
         void      print()  const;
 
-        bool is_answer_type(int type) const
+        bool is_type(int type) const
         { return ntohs(resource.type) == type; }
 
       private:

--- a/api/net/dns/dns.hpp
+++ b/api/net/dns/dns.hpp
@@ -161,13 +161,10 @@ namespace net
 
       IP4::addr getFirstIP4() const
       {
-        auto it = answers.begin();
-
-        while(it != answers.end())
+        for(auto&& ans : answers)
         {
-          if(it->is_type(DNS_TYPE_A))
-            return it->getIP4();
-          ++it;
+          if(ans.is_type(DNS_TYPE_A))
+            return ans.getIP4();
         }
 
         return IP4::ADDR_ANY;

--- a/api/net/dns/dns.hpp
+++ b/api/net/dns/dns.hpp
@@ -149,6 +149,7 @@ namespace net
     class Request
     {
     public:
+      using id_t = unsigned short;
       int  create(char* buffer, const std::string& hostname);
       bool parseResponse(const char* buffer);
       void print(const char* buffer) const;
@@ -171,6 +172,9 @@ namespace net
 
         return IP4::ADDR_ANY;
       }
+
+      id_t get_id() const
+      { return id; }
 
     private:
       struct rr_t // resource record

--- a/api/net/http/common.hpp
+++ b/api/net/http/common.hpp
@@ -38,7 +38,7 @@ class Response;
 using Response_ptr = std::unique_ptr<Response>;
 
 class Error;
-using Response_handler = delegate<void(Error, Response_ptr)>;
+using Response_handler = delegate<void(Error, Response_ptr), spec::dynamic>;
 
 } //< namespace http
 

--- a/api/net/inet_common.hpp
+++ b/api/net/inet_common.hpp
@@ -57,6 +57,20 @@ namespace net {
       return std::unique_ptr<Derived>(d);
   }
 
+  /* RFC 6335 - IANA */
+  namespace port_ranges
+  {
+    static constexpr uint16_t SYSTEM_START  {0};
+    static constexpr uint16_t SYSTEM_END    {1023};
+    static constexpr uint16_t USER_START    {1024};
+    static constexpr uint16_t USER_END      {49151};
+    static constexpr uint16_t DYNAMIC_START {49152};
+    static constexpr uint16_t DYNAMIC_END   {65534}; // 65535 never assigned
+  }
+
+  inline uint16_t new_ephemeral_port() noexcept
+  { return port_ranges::DYNAMIC_START + rand() % (port_ranges::DYNAMIC_END - port_ranges::DYNAMIC_START); }
+
 } //< namespace net
 
 #endif //< NET_INET_COMMON_HPP

--- a/api/net/ip4/udp.hpp
+++ b/api/net/ip4/udp.hpp
@@ -159,7 +159,7 @@ namespace net {
     downstream  network_layer_out_;
     Stack&      stack_;
     std::map<port_t, UDPSocket> ports_;
-    port_t      current_port_ {1024};
+    port_t      current_port_;
 
     // the async send queue
     std::deque<WriteBuffer> sendq;

--- a/api/net/ip4/udp_socket.hpp
+++ b/api/net/ip4/udp_socket.hpp
@@ -52,7 +52,9 @@ namespace net
     void bcast(addr_t srcIP, port_t port,
                const void* buffer, size_t length,
                sendto_handler cb = [] {});
-    void close();
+
+    void close()
+    { udp_.close(l_port); }
 
     void join(multicast_group_addr);
     void leave(multicast_group_addr);

--- a/api/net/super_stack.hpp
+++ b/api/net/super_stack.hpp
@@ -22,8 +22,15 @@
 #include <net/ip4/ip4.hpp>
 #include "inet.hpp"
 #include <vector>
+#include <stdexcept>
 
 namespace net {
+
+class Stack_not_found : public std::runtime_error
+{
+  using base = std::runtime_error;
+  using base::base;
+};
 
 class Super_stack {
 public:

--- a/lib/mana/include/mana/server.hpp
+++ b/lib/mana/include/mana/server.hpp
@@ -18,7 +18,7 @@
 #ifndef MANA_SERVER_HPP
 #define MANA_SERVER_HPP
 
-#include <net/inet4>
+#include <net/inet>
 #include <net/dhcp/dh4client.hpp>
 #include <rtc>
 
@@ -48,7 +48,7 @@ private:
   // Internal class type aliases
   //-------------------------------
   using Port      = const unsigned;
-  using IP_stack  = net::Inet4;
+  using IP_stack  = net::Inet<net::IP4>;
   using Path      = std::string;
   struct MappedCallback {
     Path path;

--- a/src/net/dns/client.cpp
+++ b/src/net/dns/client.cpp
@@ -17,35 +17,49 @@
 
 #include <net/dns/client.hpp>
 
-#include <net/ip4/udp.hpp>
-#include <net/dns/dns.hpp>
-
 namespace net
 {
+  Timer::duration_t DNSClient::DEFAULT_RESOLVE_TIMEOUT{std::chrono::seconds(5)};
+
   void DNSClient::resolve(IP4::addr dns_server, const std::string& hostname, Stack::resolve_func<IP4> func)
   {
-    auto& sock = stack.udp().bind();
-
     // create DNS request
     DNS::Request request;
     auto*  data = new char[256];
     size_t len  = request.create(data, hostname);
 
+    // store the request for later match
+    requests_.emplace(std::piecewise_construct,
+      std::forward_as_tuple(request.get_id()),
+      std::forward_as_tuple(std::move(request), std::move(func)));
+
     // send request to DNS server
-    sock.sendto(dns_server, DNS::DNS_SERVICE_PORT, data, len);
+    socket_.sendto(dns_server, DNS::DNS_SERVICE_PORT, data, len);
     delete[] data;
+  }
 
-    // wait for response
-    // FIXME: WE DO NOT CHECK TRANSACTION IDS HERE (yet), GOD HELP US ALL
-    sock.on_read(net::UDPSocket::recvfrom_handler::make_packed(
-    [this, hostname, request, func]
-    (IP4::addr, UDP::port_t, const char* data, size_t) mutable
+  void DNSClient::receive_response(IP4::addr, UDP::port_t, const char* data, size_t)
+  {
+    const auto& reply = *(DNS::header*) data;
+    // match the transactions id on the reply with the ones in our map
+    auto it = requests_.find(ntohs(reply.id));
+    // if this is match
+    if(it != requests_.end())
     {
-      // original request ID = this->id;
-      request.parseResponse(data);
+      // TODO: do some necessary validation ... (truncate etc?)
 
+      // parse request
+      it->second.request.parseResponse(data);
       // fire onResolve event
-      func(request.getFirstIP4());
-    }));
+      it->second.finish();
+
+      // the request is finished, removed it from our map
+      requests_.erase(it);
+    }
+    else
+    {
+      debug("<DNSClient::receive_response> Cannot find matching DNS Request with transid=%u\n", ntohs(reply.id));
+    }
+
   }
 }

--- a/src/net/dns/client.cpp
+++ b/src/net/dns/client.cpp
@@ -25,8 +25,8 @@ namespace net
   {
     // create DNS request
     DNS::Request request;
-    auto*  data = new char[256];
-    size_t len  = request.create(data, hostname);
+    std::array<char, 256> buf{};
+    size_t len  = request.create(buf.data(), hostname);
 
     // store the request for later match
     requests_.emplace(std::piecewise_construct,
@@ -34,8 +34,7 @@ namespace net
       std::forward_as_tuple(std::move(request), std::move(func)));
 
     // send request to DNS server
-    socket_.sendto(dns_server, DNS::DNS_SERVICE_PORT, data, len);
-    delete[] data;
+    socket_.sendto(dns_server, DNS::DNS_SERVICE_PORT, buf.data(), len);
   }
 
   void DNSClient::receive_response(IP4::addr, UDP::port_t, const char* data, size_t)

--- a/src/net/dns/dns.cpp
+++ b/src/net/dns/dns.cpp
@@ -204,7 +204,7 @@ namespace net
     return true;
   }
 
-  void DNS::Request::print(char* buffer)
+  void DNS::Request::print(const char* buffer) const
   {
     header* dns = (header*) buffer;
 
@@ -287,7 +287,8 @@ namespace net
       return IP4::ADDR_ANY;
     }
   }
-  void DNS::Request::rr_t::print()
+
+  void DNS::Request::rr_t::print() const
   {
     printf("Name: %s ", name.c_str());
     switch (ntohs(resource.type))

--- a/src/net/http/client.cpp
+++ b/src/net/http/client.cpp
@@ -40,6 +40,7 @@ namespace http {
 
   void Client::send(Request_ptr req, Host host, Response_handler cb, Options options)
   {
+    Expects(cb != nullptr);
     using namespace std;
     auto& conn = get_connection(host);
 
@@ -55,11 +56,12 @@ namespace http {
 
   void Client::request(Method method, URI url, Header_set hfields, Response_handler cb, Options options)
   {
+    Expects(cb != nullptr);
     using namespace std;
-    const auto host = url.host().to_string();
-    resolve(host,
-    [ this, method, url{std::move(url)}, hfields{move(hfields)}, cb{move(cb)}, opt{move(options)}] (auto ip)
+    tcp_.stack().resolve(url.host().to_string(),
+    [ this, method, url{move(url)}, hfields{move(hfields)}, cb{move(cb)}, opt{move(options)}] (auto ip)
     {
+      Expects(cb != nullptr);
       // Host resolved
       if(ip != 0)
       {
@@ -98,8 +100,7 @@ namespace http {
   void Client::request(Method method, URI url, Header_set hfields, std::string data, Response_handler cb, Options options)
   {
     using namespace std;
-    const auto host = url.host().to_string();
-    resolve(host,
+    tcp_.stack().resolve(url.host().to_string(),
     [ this, method, url{move(url)}, hfields{move(hfields)}, data{move(data)}, cb{move(cb)}, opt{move(options)} ] (auto ip)
     {
       // Host resolved

--- a/src/net/http/connection.cpp
+++ b/src/net/http/connection.cpp
@@ -44,9 +44,10 @@ namespace http {
   void Connection::send(Request_ptr req, Response_handler on_res, const size_t bufsize, timeout_duration timeout)
   {
     Expects(available());
-
     req_ = std::move(req);
+    Expects(on_res != nullptr);
     on_response_ = std::move(on_res);
+    Expects(on_response_ != nullptr);
     timeout_dur_ = timeout;
 
     if(timeout_dur_ > timeout_duration::zero())

--- a/src/net/super_stack.cpp
+++ b/src/net/super_stack.cpp
@@ -21,12 +21,23 @@
 // Specialization for IP4
 template <>
 net::Inet<net::IP4>& net::Super_stack::get<net::IP4>(int N) {
-  return *inet().ip4_stacks_.at(N);
+  try
+  {
+    return *inet().ip4_stacks_.at(N);
+  }
+  catch(std::out_of_range&)
+  {
+    throw Stack_not_found{"No IP4 stack found for [" + std::to_string(N) + "] (missing driver?)"};
+  }
 }
 
 net::Super_stack::Super_stack()
 {
-  INFO("Super stack", "Constructing");
+  INFO("Super stack", "Constructing stacks");
+
+  if(hw::Devices::devices<hw::Nic>().empty())
+    INFO2("No registered Nic devices found (nothing to construct)");
+
   for(auto& nic : hw::Devices::devices<hw::Nic>())
   {
     INFO("Super stack", "Creating stack for Nic %s", nic->device_name().c_str());
@@ -40,4 +51,5 @@ net::Super_stack::Super_stack()
 
     }
   }
+
 }


### PR DESCRIPTION
For some reason the the callback delegate the HTTP Client sometimes ended up as nullptr. Maybe due to new delegate implementation. Seems to be fixed by using `spec::dynamic`. If anyone can explain why, please do :D

TCP and UDP are now using dynamic (ephemeral) ports in the range described by IANA in [RFC 6335](https://tools.ietf.org/html/rfc6335). In other words, the outgoing ports are now in range of `49152 - 65534`.

Improved the DNS Client by adding timeout on resolve requests (5s default). It now also reuses one UDP socket. Also added transaction ID matching on incoming responses.

Also a fix for #1073 sneaked in before I noticed #1074 - please merge that one first (when sorted).