### PR TITLE
replaced use of std::function with delegate

### DIFF
--- a/api/fs/common.hpp
+++ b/api/fs/common.hpp
@@ -186,10 +186,10 @@ namespace fs {
   extern error_t no_error;
 
     /** Async function types **/
-  using on_init_func = delegate<void(error_t), spec::dynamic>;
-  using on_ls_func    = delegate<void(error_t, dirvec_t), spec::dynamic>;
-  using on_read_func  = delegate<void(error_t, buffer_t, uint64_t), spec::dynamic>;
-  using on_stat_func  = delegate<void(error_t, const Dirent&), spec::dynamic>;
+  using on_init_func  = delegate<void(error_t)>;
+  using on_ls_func    = delegate<void(error_t, dirvec_t)>;
+  using on_read_func  = delegate<void(error_t, buffer_t, uint64_t)>;
+  using on_stat_func  = delegate<void(error_t, const Dirent&)>;
 
 
   struct List {

--- a/api/fs/disk.hpp
+++ b/api/fs/disk.hpp
@@ -41,8 +41,8 @@ namespace fs {
     };
 
     struct Partition;
-    using on_parts_func = std::function<void(fs::error_t, std::vector<Partition>&)>;
-    using on_init_func = std::function<void(fs::error_t)>;
+    using on_parts_func = delegate<void(fs::error_t, std::vector<Partition>&)>;
+    using on_init_func = delegate<void(fs::error_t)>;
     using lba_t = uint32_t;
 
     enum partition_t {

--- a/api/fs/fat.hpp
+++ b/api/fs/fat.hpp
@@ -109,12 +109,12 @@ namespace fs
     // initialize filesystem by providing base sector
     void init(const void* base_sector);
     // return a list of entries from directory entries at @sector
-    typedef delegate<void(error_t, dirvec_t), spec::dynamic> on_internal_ls_func;
+    typedef delegate<void(error_t, dirvec_t)> on_internal_ls_func;
     void int_ls(uint32_t sector, dirvec_t, on_internal_ls_func);
     bool int_dirent(uint32_t sector, const void* data, dirvector&);
 
     // tree traversal
-    typedef delegate<void(error_t, dirvec_t), spec::dynamic> cluster_func;
+    typedef delegate<void(error_t, dirvec_t)> cluster_func;
     // async tree traversal
     void traverse(std::shared_ptr<Path> path, cluster_func callback, const Dirent* const = nullptr);
     // sync version

--- a/api/hw/apic.hpp
+++ b/api/hw/apic.hpp
@@ -20,39 +20,39 @@
 #define HW_APIC_HPP
 
 #include <cstdint>
-#include <functional>
+#include <delegate>
 
 namespace hw {
-  
+
   class APIC {
   public:
-    typedef std::function<void()>  smp_task_func;
-    typedef std::function<void()>  smp_done_func;
-    
+    typedef delegate<void()>  smp_task_func;
+    typedef delegate<void()>  smp_done_func;
+
     static void add_task(smp_task_func, smp_done_func);
     static void work_signal();
-    
-    typedef std::function<void()>   timer_func;
-    
+
+    typedef delegate<void()>   timer_func;
+
     static void init();
     static void setup_subs();
-    
+
     static void send_ipi(uint8_t cpu, uint8_t vector);
     static void send_bsp_intr();
     static void bcast_ipi(uint8_t vector);
-    
+
     // enable and disable legacy IRQs
     static void enable_irq(uint8_t irq);
     static void disable_irq(uint8_t irq);
-    
+
     static uint8_t get_isr();
     static uint8_t get_irr();
     static void eoi();
-    
+
   private:
     static void init_smp();
   };
-  
+
 }
 
 #endif

--- a/api/hw/block_device.hpp
+++ b/api/hw/block_device.hpp
@@ -35,7 +35,8 @@ namespace hw
     using buffer_t = std::shared_ptr<uint8_t>;
 
     // Delegate for result of reading a disk sector
-    using on_read_func = delegate<void(buffer_t), spec::dynamic>;
+    //using on_read_func = delegate<void(buffer_t)>;
+    using on_read_func = delegate<void(buffer_t)>;
 
     using Device_id = int;
 

--- a/api/hw/pit.hpp
+++ b/api/hw/pit.hpp
@@ -35,7 +35,7 @@ namespace hw {
   public:
 
     using timeout_handler = delegate<void()>;
-    using repeat_condition = std::function<bool()>;
+    using repeat_condition = delegate<bool()>;
 
     /** A timer is a handler and an expiration time (interval).
         @todo The timer also keeps a pre-computed rdtsc-value, which is currently unused.*/
@@ -142,7 +142,7 @@ namespace hw {
 
   private:
     // Default repeat-condition
-    static std::function<bool()> forever;
+    static delegate<bool()> forever;
 
     enum Mode { ONE_SHOT = 0,
                 HW_ONESHOT = 1 << 1,

--- a/api/hw/ps2.hpp
+++ b/api/hw/ps2.hpp
@@ -19,19 +19,19 @@
 #ifndef HW_PS2_HPP
 #define HW_PS2_HPP
 
-#include <functional>
+#include <delegate>
 #include <cstdint>
 
 namespace hw
 {
   class KBM {
   public:
-    typedef std::function<void(int)> on_virtualkey_func;
-    typedef std::function<void(int, int, int)> on_mouse_func;
-    
+    typedef delegate<void(int)> on_virtualkey_func;
+    typedef delegate<void(int, int, int)> on_mouse_func;
+
     enum {
       VK_UNKNOWN,
-      
+
       VK_ESCAPE,
       VK_1,
       VK_2,
@@ -43,42 +43,42 @@ namespace hw
       VK_8,
       VK_9,
       VK_0,
-      
+
       VK_BACK,
       VK_TAB,
       VK_ENTER,
       VK_SPACE,
-      
-      
+
+
       VK_UP,
       VK_DOWN,
       VK_LEFT,
       VK_RIGHT,
-      
+
       VK_COUNT
     };
-    
+
     static void init();
-    
+
     static void set_virtualkey_handler(on_virtualkey_func func) {
       get().on_virtualkey = func;
     }
-    
+
     static KBM& get() {
       static KBM kbm;
       return kbm;
     }
-    
+
   private:
     KBM();
     int  mouse_x;
     int  mouse_y;
     bool mouse_button[4];
-    
+
     int transform_ascii(int vk);
     int transform_vk(uint8_t scancode);
     void handle_mouse(uint8_t scancode);
-    
+
     on_virtualkey_func on_virtualkey;
     on_mouse_func      on_mouse;
   };

--- a/api/kernel/terminal.hpp
+++ b/api/kernel/terminal.hpp
@@ -18,7 +18,6 @@
 #ifndef KERNEL_BTERM_HPP
 #define KERNEL_BTERM_HPP
 
-#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -35,7 +34,11 @@ namespace hw
 
 struct Command
 {
-  using main_func = std::function<int(const std::vector<std::string>&)>;
+  using main_func = delegate<
+    int(const std::vector<std::string>&),
+    spec::inplace,
+    detail::default_capacity * 2
+  >;
 
   Command(const std::string& descr, main_func func)
     : desc(descr), main(func) {}
@@ -61,7 +64,7 @@ public:
       CR   = 13
     };
 
-  using on_write_func = std::function<void(const char*, size_t)>;
+  using on_write_func = delegate<void(const char*, size_t)>;
 
   Terminal(Connection_ptr);
   Terminal(hw::Serial& serial);
@@ -84,7 +87,7 @@ public:
     on_write(buffer, bytes);
   }
 
-  std::function<void()> on_exit { [] {} };
+  delegate<void()> on_exit { [] {} };
 
   ///
   void add_disk_commands(Disk_ptr disk);

--- a/api/net/dns/dns.hpp
+++ b/api/net/dns/dns.hpp
@@ -52,7 +52,6 @@
 #include <net/ip4/ip4.hpp> // IP4::addr
 #include <string>
 #include <vector>
-#include <functional>
 
 namespace net
 {
@@ -125,7 +124,7 @@ namespace net
         OP_REFUSED   = 5, // for political reasons
       };
 
-    typedef std::function<std::vector<IP4::addr>* (const std::string&)> lookup_func;
+    typedef delegate<std::vector<IP4::addr>* (const std::string&)> lookup_func;
 
     static int createResponse(header& hdr, lookup_func func);
 

--- a/api/net/http/client.hpp
+++ b/api/net/http/client.hpp
@@ -63,7 +63,7 @@ namespace http {
     };
 
   private:
-    using ResolveCallback    = delegate<void(net::ip4::Addr), spec::dynamic>;
+    using ResolveCallback    = delegate<void(net::ip4::Addr)>;
 
   public:
     explicit Client(TCP& tcp);

--- a/api/net/http/common.hpp
+++ b/api/net/http/common.hpp
@@ -38,7 +38,7 @@ class Response;
 using Response_ptr = std::unique_ptr<Response>;
 
 class Error;
-using Response_handler = delegate<void(Error, Response_ptr), spec::dynamic>;
+using Response_handler = delegate<void(Error, Response_ptr)>;
 
 } //< namespace http
 

--- a/api/net/inet.hpp
+++ b/api/net/inet.hpp
@@ -41,7 +41,7 @@ namespace net {
     using Forward_delg = delegate<void(Stack& source, typename IPV::IP_packet_ptr)>;
 
     template <typename IPv>
-    using resolve_func = delegate<void(typename IPv::addr), spec::dynamic>;
+    using resolve_func = delegate<void(typename IPv::addr)>;
 
     virtual typename IPV::addr ip_addr() = 0;
     virtual typename IPV::addr netmask() = 0;

--- a/api/net/ip6/udp6.hpp
+++ b/api/net/ip6/udp6.hpp
@@ -30,7 +30,7 @@ namespace net
   public:
     typedef uint16_t port_t;
     //typedef int (*listener_t)(std::shared_ptr<PacketUDP6>& pckt);
-    typedef std::function<int(std::shared_ptr<PacketUDP6>& pckt)> listener_t;
+    typedef delegate<int(std::shared_ptr<PacketUDP6>& pckt)> listener_t;
 
     struct header
     {

--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -101,10 +101,6 @@ public:
   using RtxTimeoutCallback      = delegate<void(size_t no_attempts, double rto)>;
   inline Connection&            on_rtx_timeout(RtxTimeoutCallback);
 
-
-  /** Supplied together with write - called when a write request is done. void(size_t) */
-  using WriteCallback           = delegate<void(size_t), spec::dynamic>;
-
   inline void write(const void* buf, size_t n);
   inline void write(const void* buf, size_t n, WriteCallback callback);
 

--- a/api/net/tcp/write_queue.hpp
+++ b/api/net/tcp/write_queue.hpp
@@ -28,6 +28,8 @@
 namespace net {
 namespace tcp {
 
+using WriteCallback = delegate<void(size_t)>;
+
 /*
   Write Queue containig WriteRequests from user.
   Stores requests until they are fully acknowledged;
@@ -39,7 +41,6 @@ public:
     Callback when a write is sent by the TCP
     - Supplied on asynchronous write
   */
-  using WriteCallback = delegate<void(size_t), spec::dynamic>;
 
   using WriteRequest = std::pair<WriteBuffer, WriteCallback>;
 

--- a/api/util/async.hpp
+++ b/api/util/async.hpp
@@ -22,7 +22,6 @@
 #include <net/inet4.hpp>
 #include <net/tcp/connection.hpp>
 #include <fs/disk.hpp>
-#include <functional>
 
 class Async
 {
@@ -33,9 +32,9 @@ public:
   using Disk = fs::Disk_ptr;
   typedef fs::Dirent Dirent;
 
-  typedef std::function<void(bool)> next_func;
-  typedef std::function<void(fs::error_t, bool)> on_after_func;
-  typedef std::function<void(fs::buffer_t, size_t, next_func)> on_write_func;
+  typedef delegate<void(bool)> next_func;
+  typedef delegate<void(fs::error_t, bool)> on_after_func;
+  typedef delegate<void(fs::buffer_t, size_t, next_func)> on_write_func;
 
   static void upload_file(
       Disk,

--- a/api/util/async_loop.hpp
+++ b/api/util/async_loop.hpp
@@ -11,9 +11,9 @@ async_loop(
 {
   // store next function on heap
   auto next = std::make_shared<next_func_t> ();
-  
+
   // loop:
-  *next = 
+  *next =
     [next] (bool done)
     {
       // check we are done, and if so,

--- a/api/util/delegate.hpp
+++ b/api/util/delegate.hpp
@@ -348,46 +348,6 @@ private:
 			"constructing delegate with move only type is invalid!");
 	}
 };
-
-// --- dynamic ---
-template<size_t size, typename R, typename... Args> class dynamic
-{
-public:
-	using storage_t = std::function<R(Args&&...)>;
-
-	explicit dynamic() noexcept :
-		storage_{}
-	{}
-
-	template<typename T> explicit dynamic(T&& closure) :
-		storage_{ std::forward<T>(closure) }
-	{}
-
-	dynamic(const dynamic&) = default;
-	dynamic(dynamic&&) = default;
-
-	dynamic& operator= (const dynamic&) = default;
-	dynamic& operator= (dynamic&&) = default;
-
-	~dynamic() = default;
-
-	R operator() (Args&&... args) const
-	{
-		return storage_(std::forward<Args>(args)...);
-	}
-
-	bool empty() const noexcept
-	{
-		return !static_cast<bool>(storage_);
-	}
-
-	template<typename T> T* target() const noexcept
-	{
-		return storage_.template target<T>();
-	}
-private:
-	mutable storage_t storage_;
-};
 } // namespace spec
 
 template<

--- a/api/util/signal.hpp
+++ b/api/util/signal.hpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,13 +19,13 @@
 #define UTIL_SIGNAL_HPP
 
 #include <vector>
-#include <functional>
+#include <delegate>
 
 template <typename F>
 class signal {
 public:
   //! \brief Callable type of the signal handlers
-  using handler = std::function<F>;
+  using handler = delegate<F>;
 
   //! \brief Default constructor
   explicit signal() = default;
@@ -43,14 +43,14 @@ public:
   void connect(handler&& fn) {
     funcs.emplace_back(std::forward<handler>(fn));
   }
-        
+
   //! \brief Emit this signal by executing all connected callable objects
   template<typename... Args>
   void emit(Args&&... args) {
     for(auto& fn : funcs)
       fn(std::forward<Args>(args)...);
   }
-        
+
 private:
   // Set of callable objects registered to be called on demand
   std::vector<handler> funcs;

--- a/lib/mana/include/mana/connection.hpp
+++ b/lib/mana/include/mana/connection.hpp
@@ -41,7 +41,7 @@ private:
   using TCPException    = net::tcp::TCPException;
   using Packet_ptr      = net::tcp::Packet_ptr;
 
-  using OnConnection = std::function<void()>;
+  using OnConnection = delegate<void()>;
 
 public:
   Connection(Server&, Connection_ptr, size_t idx);

--- a/lib/mana/include/mana/middleware.hpp
+++ b/lib/mana/include/mana/middleware.hpp
@@ -27,7 +27,7 @@ namespace mana {
 class Middleware;
 using Middleware_ptr = std::shared_ptr<Middleware>;
 
-using next_t = delegate<void(), spec::dynamic>;
+using next_t = delegate<void()>;
 using Next = std::shared_ptr<next_t>;
 using Callback = delegate<void(Request_ptr, Response_ptr, Next)>;
 

--- a/lib/mana/include/mana/request.hpp
+++ b/lib/mana/include/mana/request.hpp
@@ -53,7 +53,7 @@ private:
   using Parent = http::Request;
   using buffer_t = std::shared_ptr<uint8_t>;
 
-  using OnRecv = std::function<void(size_t)>;
+  using OnRecv = delegate<void(size_t)>;
 
 public:
   // inherit constructors

--- a/lib/mana/include/mana/response.hpp
+++ b/lib/mana/include/mana/response.hpp
@@ -49,7 +49,7 @@ class Response : public http::Response {
 private:
   using Code = http::status_t;
   using Connection_ptr = net::tcp::Connection_ptr;
-  using OnSent = std::function<void(size_t)>;
+  using OnSent = delegate<void(size_t)>;
 
 public:
 

--- a/lib/mana/src/middleware/director.cpp
+++ b/lib/mana/src/middleware/director.cpp
@@ -40,16 +40,20 @@ void Director::process(
   #endif
 
   normalize_trailing_slashes(path);
-  disk_->fs().ls(fpath, [this, req, res, next, path](auto err, auto entries) {
-    // Path not found on filesystem, go next
-    if(err) {
-      return (*next)();
-    }
-    else {
-      res->add_body(create_html(entries, path));
-      res->send();
-    }
-  });
+  disk_->fs().ls(
+    fpath,
+    fs::on_ls_func::make_packed(
+    [this, req, res, next, path](auto err, auto entries) {
+      // Path not found on filesystem, go next
+      if(err) {
+        return (*next)();
+      }
+      else {
+        res->add_body(create_html(entries, path));
+        res->send();
+      }
+    })
+  );
 }
 
 std::string Director::create_html(Entries entries, const std::string& path) {

--- a/lib/mana/src/response.cpp
+++ b/lib/mana/src/response.cpp
@@ -76,23 +76,28 @@ void Response::send_file(const File& file) {
     entry.name().c_str(), entry.size());
   #endif
 
-  Async::upload_file(file.disk, file.entry, conn,
+  Async::upload_file(
+    file.disk,
+    file.entry,
+    conn,
+    Async::on_after_func::make_packed(
     [conn, entry](fs::error_t err, bool good)
-  {
-      if(good) {
-        #ifdef VERBOSE_WEBSERVER
-        printf("<Response> Success sending %s => %s\n",
-          entry.name().c_str(), conn->remote().to_string().c_str());
-        #endif
+    {
+        if(good) {
+          #ifdef VERBOSE_WEBSERVER
+          printf("<Response> Success sending %s => %s\n",
+            entry.name().c_str(), conn->remote().to_string().c_str());
+          #endif
 
-        on_sent_(entry.size());
-      }
-      else {
-        printf("<Response> Error sending %s => %s [%s]\n",
-          entry.name().c_str(), conn->remote().to_string().c_str(),
-          conn->is_closing() ? "Connection closing" : err.to_string().c_str());
-      }
-  });
+          on_sent_(entry.size());
+        }
+        else {
+          printf("<Response> Error sending %s => %s [%s]\n",
+            entry.name().c_str(), conn->remote().to_string().c_str(),
+            conn->is_closing() ? "Connection closing" : err.to_string().c_str());
+        }
+    })
+  );
 
   end();
 }

--- a/lib/mana/src/server.cpp
+++ b/lib/mana/src/server.cpp
@@ -100,7 +100,8 @@ void Server::process(Request_ptr req, Response_ptr res) {
   auto next = std::make_shared<next_t>();
   auto weak_next = std::weak_ptr<next_t>(next);
   // setup Next callback
-  *next = [this, it_ptr, weak_next, req, res]
+  *next = next_t::make_packed(
+  [this, it_ptr, weak_next, req, res]
   {
     // derefence the pointer to the iterator
     auto& it = *it_ptr;
@@ -123,7 +124,7 @@ void Server::process(Request_ptr req, Response_ptr res) {
     else {
       process_route(req, res);
     }
-  };
+  });
   // get the party started..
   (*next)();
 }

--- a/src/fs/filesystem.cpp
+++ b/src/fs/filesystem.cpp
@@ -38,8 +38,13 @@ namespace fs
     return tok_str[token_];
   }
 
-  void File_system::read_file(const std::string& path, on_read_func on_read) {
-    stat(path, [this, on_read, path](error_t err, const Dirent& ent) {
+  void File_system::read_file(const std::string& path, on_read_func on_read)
+  {
+    stat(
+      path,
+      on_stat_func::make_packed(
+      [this, on_read, path](error_t err, const Dirent& ent)
+      {
         if(UNLIKELY(err))
           return on_read(err, nullptr, 0);
 
@@ -47,7 +52,8 @@ namespace fs
           return on_read({error_t::E_NOTFILE, path + " is not a file"}, nullptr, 0);
 
         read(ent, 0, ent.size(), on_read);
-      });
+      })
+    );
   }
 
   Buffer File_system::read_file(const std::string& path) {
@@ -61,7 +67,7 @@ namespace fs
 
       return read(ent, 0, ent.size());
   }
-  
+
   static error_t print_subtree(dirvec_t entries, int depth)
   {
     int indent = depth * 3;

--- a/src/hw/pit.cpp
+++ b/src/hw/pit.cpp
@@ -47,7 +47,7 @@ namespace hw {
   uint64_t PIT::millisec_counter = 0;
 
   // The default recurring timer condition
-  std::function<bool()> PIT::forever = []{ return true; };
+  delegate<bool()> PIT::forever = []{ return true; };
 
   // Timer ID's
   uint32_t PIT::Timer::timers_count_ = 0;
@@ -91,7 +91,7 @@ namespace hw {
     set_freq_divider(temp_freq_divider_);
 
     IRQ_manager::get().set_irq_handler(0, prev_irq_handler);
-    
+
     return freq;
   }
 

--- a/src/posix/ftw.cpp
+++ b/src/posix/ftw.cpp
@@ -57,20 +57,20 @@ public:
         // call fn on each entry
         ++level;
         auto ent = fs::VFS::stat_sync(abs_path);
-        ent.ls([abs_path, &result, &level, this](auto, auto entries) {
-          for (auto&& ent : *entries) {
-            if (ent.name() == "." or ent.name() == "..")
+        ent.ls(fs::on_ls_func::make_packed(
+          [abs_path, &result, &level, this](auto, auto entries)
+          {
+            for (auto&& ent : *entries)
             {
-              //printf("Skipping %s\n", ent.name().c_str());
-            }
-            else
-            {
-              if ((result = walk(abs_path + "/" + ent.name(), level) != 0)) {
-                break;
+              if (ent.name() == "." or ent.name() == "..")
+              {
+                //printf("Skipping %s\n", ent.name().c_str());
               }
+              else if ((result = walk(abs_path + "/" + ent.name(), level) != 0))
+                break;
             }
-          }
-        });
+          })
+        );
         if (flags_ & FTW_DEPTH) {
           result = fn_ptr_(abs_path.c_str(), &buffer, FTW_D, &ftw);
         }

--- a/src/posix/tcp_fd.cpp
+++ b/src/posix/tcp_fd.cpp
@@ -244,8 +244,12 @@ ssize_t TCP_FD_Conn::send(const void* data, size_t len, int)
   }
 
   bool written = false;
-  conn->write(data, len,
-  [&written] (bool) { written = true; });
+  conn->write(
+    data,
+    len,
+    [&written] (bool) { written = true; }
+  );
+  
   // sometimes we can just write and forget
   if (written) return len;
   while (!written) {

--- a/src/util/async.cpp
+++ b/src/util/async.cpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,14 +39,18 @@ void Async::upload_file(
           next_func    next)
   {
     // write chunk to TCP connection
-    conn->write(buffer, length,
-    [length, next] (size_t n) {
+    conn->write(
+      buffer,
+      length,
+      net::tcp::WriteCallback::make_packed(
+      [length, next] (size_t n) {
 
-      // if all data written, go to next chunk
-      debug("<Async::upload_file> %u / %u\n", n, length);
-      next(n == length);
+        // if all data written, go to next chunk
+        debug("<Async::upload_file> %u / %u\n", n, length);
+        next(n == length);
 
-    });
+      })
+    );
 
   }, callback, CHUNK_SIZE);
 }
@@ -58,11 +62,11 @@ void Async::disk_transfer(
     on_after_func callback,
     const size_t  CHUNK_SIZE)
 {
-  typedef std::function<void(size_t)> next_func_t;
+  typedef delegate<void(size_t)> next_func_t;
   auto next = std::make_shared<next_func_t> ();
   auto weak_next = std::weak_ptr<next_func_t>(next);
 
-  *next =
+  *next = next_func_t::make_packed(
   [weak_next, disk, ent, write_func, callback, CHUNK_SIZE] (size_t pos) {
 
     // number of write calls necessary
@@ -75,32 +79,41 @@ void Async::disk_transfer(
     }
     auto next = weak_next.lock();
     // read chunk from file
-    disk->fs().read(ent, pos * CHUNK_SIZE, CHUNK_SIZE,
-    [next, pos, write_func, callback, CHUNK_SIZE] (
-        fs::error_t  err,
-        fs::buffer_t buffer,
-        uint64_t     length)
-    {
-      debug("<Async> len=%llu\n",length);
-      if (err) {
-        printf("%s\n", err.to_string().c_str());
-        callback(err, false);
-        return;
-      }
+    disk->fs().read(
+      ent,
+      pos * CHUNK_SIZE,
+      CHUNK_SIZE,
+      fs::on_read_func::make_packed(
+      [next, pos, write_func, callback, CHUNK_SIZE] (
+          fs::error_t  err,
+          fs::buffer_t buffer,
+          uint64_t     length)
+      {
+        debug("<Async> len=%llu\n",length);
+        if (err) {
+          printf("%s\n", err.to_string().c_str());
+          callback(err, false);
+          return;
+        }
 
-      // call write callback with data
-      write_func(buffer, length,
-      [next, pos, callback] (bool good) {
-        // if the write succeeded, call next
-        if (likely(good))
-          (*next)(pos+1);
-        else
-          // otherwise, fail
-          callback({fs::error_t::E_IO, "Write failed"}, false);
-      });
-    });
-
-  };
+        // call write callback with data
+        write_func(
+          buffer,
+          length,
+          next_func::make_packed(
+          [next, pos, callback] (bool good)
+          {
+            // if the write succeeded, call next
+            if (likely(good))
+              (*next)(pos+1);
+            else
+              // otherwise, fail
+              callback({fs::error_t::E_IO, "Write failed"}, false);
+          })
+        );
+      })
+    );
+  });
   // start async loop
   (*next)(0);
 }

--- a/test/fs/integration/vfs/service.cpp
+++ b/test/fs/integration/vfs/service.cpp
@@ -123,12 +123,12 @@ void Service::start(const std::string&)
 
   // Store and retreive a lambda as a VFS entry
   bool lambda_called = false;
-  std::function<void()> func1 = [&lambda_called]{
+  delegate<void()> func1 = [&lambda_called]{
     lambda_called = true;
   };
 
   fs::VFS_entry func_entry{func1, "Function 1", "Sets a bool to true"};
-  func_entry.obj<std::function<void()>>()();
+  func_entry.obj<delegate<void()>>()();
 
   CHECKSERT(lambda_called, "The lambda entry was called");
 

--- a/test/fs/integration/virtio_block/service.cpp
+++ b/test/fs/integration/virtio_block/service.cpp
@@ -62,19 +62,25 @@ void Service::start(const std::string&)
 
         if (e.is_file()) {
           printf("*** Read %s\n", e.name().c_str());
-          disk->fs().read(e, 0, e.size(),
-          [e] (fs::error_t err, fs::buffer_t buffer, size_t len) {
-            if (err) {
-              printf("Failed to read %s!\n", e.name().c_str());
-              panic("read() failed");
-            }
+          disk->fs().read(
+            e,
+            0,
+            e.size(),
+            [e_name = e.name()]
+            (fs::error_t err, fs::buffer_t buffer, size_t len)
+            {
+              if (err) {
+                printf("Failed to read %s!\n", e_name.c_str());
+                panic("read() failed");
+              }
 
-            std::string contents((const char*) buffer.get(), len);
-            printf("[%s contents]:\n%s\nEOF\n\n",
-                   e.name().c_str(), contents.c_str());
-            // ---
-            INFO("Virtioblk Test", "SUCCESS");
-          });
+              std::string contents((const char*) buffer.get(), len);
+              printf("[%s contents]:\n%s\nEOF\n\n",
+                     e_name.c_str(), contents.c_str());
+              // ---
+              INFO("Virtioblk Test", "SUCCESS");
+            }
+          );
 
         } // is_file
 

--- a/test/fs/unit/memdisk_test.cpp
+++ b/test/fs/unit/memdisk_test.cpp
@@ -29,12 +29,16 @@ CASE("memdisk properties")
   EXPECT(disk->dev().device_type() == "Block device");
   EXPECT(disk->dev().driver_name() == "MemDisk");
   bool enumerated_partitions {false};
-  auto part_fn = [&enumerated_partitions, lest_env](fs::error_t err, std::vector<fs::Disk::Partition>& partitions) {
+  
+  fs::Disk::on_parts_func part_fn = [&enumerated_partitions, &lest_env]
+  (fs::error_t err, std::vector<fs::Disk::Partition>& partitions)
+  {
     if (!err) {
       enumerated_partitions = true;
       EXPECT(partitions.size() == 4u); // 4 is default number
     }
   };
+
   disk->partitions(part_fn);
   EXPECT(enumerated_partitions == true);
 }

--- a/test/net/unit/tcp_write_queue.cpp
+++ b/test/net/unit/tcp_write_queue.cpp
@@ -24,7 +24,7 @@ using namespace net::tcp;
 
 WriteQueue::WriteRequest create_write_request(
   size_t size,
-  WriteQueue::WriteCallback cb = [](size_t n) {})
+  WriteCallback cb = [](size_t n) {})
 {
   WriteBuffer wb { new_shared_buffer(size), size, true };
   return { wb, cb };


### PR DESCRIPTION
And removed `spec::inplace`
Larger closures are stored via a `std::shared_ptr` the implication is, that a copied `make_packed` delegate still shares state with it's source. 