### PR TITLE
Some HTTP Refactoring + fixes to build issues on Mac

### DIFF
--- a/api/net/http/client.hpp
+++ b/api/net/http/client.hpp
@@ -1,6 +1,6 @@
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
-// Copyright 2016 Oslo and Akershus University College of Applied Sciences
+// Copyright 2016-2017 Oslo and Akershus University College of Applied Sciences
 // and Alfred Bratterud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,12 +19,10 @@
 #ifndef HTTP_CLIENT_HPP
 #define HTTP_CLIENT_HPP
 
-#include "common.hpp"
-#include "request.hpp"
-#include "response.hpp"
+// http
+#include "client_connection.hpp"
+
 #include <net/tcp/tcp.hpp>
-#include "connection.hpp"
-#include "error.hpp"
 #include <vector>
 #include <map>
 
@@ -32,13 +30,13 @@ namespace http {
 
   class Client {
   public:
-    using TCP               = net::TCP;
-    using Host              = net::tcp::Socket;
+    using TCP                 = net::TCP;
+    using Host                = net::tcp::Socket;
 
-    using Connection_set     = std::vector<std::unique_ptr<Connection>>;
-    using Connection_mapset  = std::map<Host, Connection_set>;
+    using Connection_set      = std::vector<std::unique_ptr<Client_connection>>;
+    using Connection_mapset   = std::map<Host, Connection_set>;
 
-    using timeout_duration  = Connection::timeout_duration;
+    using timeout_duration    = Client_connection::timeout_duration;
 
     const static timeout_duration     DEFAULT_TIMEOUT; // client.cpp, 5s
     constexpr static size_t           DEFAULT_BUFSIZE = 2048;
@@ -153,10 +151,11 @@ namespace http {
     inline void post(Host host, std::string path, Header_set hfields, const std::string& data, Response_handler cb, Options options = {});
 
   private:
-    TCP& tcp_;
-    Connection_mapset conns_;
+    friend class Client_connection;
 
-    bool keep_alive_ = false;
+    TCP&              tcp_;
+    Connection_mapset conns_;
+    bool              keep_alive_ = false;
 
     void resolve(const std::string& host, ResolveCallback);
 
@@ -172,9 +171,9 @@ namespace http {
     /** Add data and content length */
     void add_data(Request&, const std::string& data);
 
-    Connection& get_connection(const Host host);
+    Client_connection& get_connection(const Host host);
 
-    void close(Connection&);
+    void close(Client_connection&);
 
   }; // < class Client
 

--- a/api/net/http/client_connection.hpp
+++ b/api/net/http/client_connection.hpp
@@ -1,0 +1,69 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2016-2017 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef HTTP_CLIENT_CONNECTION_HPP
+#define HTTP_CLIENT_CONNECTION_HPP
+
+// http
+#include "common.hpp"
+#include "connection.hpp"
+#include "error.hpp"
+
+#include <util/timer.hpp>
+
+namespace http {
+
+  class Client;
+
+  class Client_connection : public Connection {
+  public:
+    using timeout_duration  = std::chrono::milliseconds;
+
+  public:
+    explicit Client_connection(Client&, TCP_conn);
+
+    bool available() const
+    { return on_response_ == nullptr && keep_alive_; }
+
+    bool occupied() const
+    { return !available(); }
+
+    void send(Request_ptr, Response_handler, const size_t bufsize, timeout_duration = timeout_duration::zero());
+
+  private:
+    Client&           client_;
+    Response_handler  on_response_;
+    Timer             timer_;
+    timeout_duration  timeout_dur_;
+
+    void send_request(const size_t bufsize);
+
+    void recv_response(buffer_t buf, size_t len);
+
+    void end_response(Error err = Error::NONE);
+
+    void timeout_request()
+    { end_response(Error::TIMEOUT); }
+
+    void close();
+
+  }; // < class Client_connection
+
+} // < namespace http
+
+#endif // < HTTP_CLIENT_CONNECTION_HPP

--- a/api/net/http/connection.hpp
+++ b/api/net/http/connection.hpp
@@ -34,7 +34,7 @@ namespace http {
     using buffer_t      = net::tcp::buffer_t;
 
   public:
-    explicit Connection(TCP_conn tcpconn, bool keep_alive = true);
+    inline explicit Connection(TCP_conn tcpconn, bool keep_alive = true);
 
     template <typename TCP>
     explicit Connection(TCP&, Peer);
@@ -56,7 +56,7 @@ namespace http {
 
   }; // < class Connection
 
-  Connection::Connection(TCP_conn tcpconn, bool keep_alive)
+  inline Connection::Connection(TCP_conn tcpconn, bool keep_alive)
     : tcpconn_{std::move(tcpconn)},
       req_{nullptr},
       res_{nullptr},

--- a/diskimagebuild/CMakeLists.txt
+++ b/diskimagebuild/CMakeLists.txt
@@ -5,7 +5,6 @@ set (CMAKE_CXX_STANDARD 14)
 
 set(SOURCES main.cpp filetree.cpp writer.cpp)
 
-include_directories(../api)
 include_directories(../mod/GSL)
 add_executable(diskbuilder ${SOURCES})
 

--- a/diskimagebuild/fat_internal.hpp
+++ b/diskimagebuild/fat_internal.hpp
@@ -1,0 +1,62 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Slim copy of <api/fs/fat_internal.hpp>
+
+#pragma once
+#ifndef FS_FAT_INTERNAL_HPP
+#define FS_FAT_INTERNAL_HPP
+
+#include <cstdint>
+
+// Attribute masks
+static const uint8_t ATTR_READ_ONLY = 0x01;
+static const uint8_t ATTR_HIDDEN    = 0x02;
+static const uint8_t ATTR_SYSTEM    = 0x04;
+static const uint8_t ATTR_VOLUME_ID = 0x08;
+static const uint8_t ATTR_DIRECTORY = 0x10;
+static const uint8_t ATTR_ARCHIVE   = 0x20;
+
+// Mask for the last longname entry
+static const uint8_t LAST_LONG_ENTRY = 0x40;
+
+struct cl_dir
+{
+  uint8_t  shortname[11];
+  uint8_t  attrib;
+  uint8_t  pad1[8];
+  uint16_t cluster_hi;
+  uint32_t modified;
+  uint16_t cluster_lo;
+  uint32_t filesize;
+
+} __attribute__((packed));
+
+struct cl_long
+{
+  uint8_t  index;
+  uint16_t first[5];
+  uint8_t  attrib;
+  uint8_t  entry_type;
+  uint8_t  checksum;
+  uint16_t second[6];
+  uint16_t zero;
+  uint16_t third[2];
+
+} __attribute__((packed));
+
+#endif

--- a/diskimagebuild/writer.cpp
+++ b/diskimagebuild/writer.cpp
@@ -1,7 +1,7 @@
 #include "filetree.hpp"
 
 #include "../api/fs/mbr.hpp"
-#include "../api/fs/fat_internal.hpp"
+#include "fat_internal.hpp"
 #include <cassert>
 #include <cstring>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ set(OS_OBJECTS
   net/super_stack.cpp
   net/http/header.cpp net/http/header_fields.cpp net/http/message.cpp net/http/request.cpp
   net/http/response.cpp net/http/status_codes.cpp net/http/time.cpp net/http/version.cpp
-  net/http/mime_types.cpp net/http/client.cpp net/http/connection.cpp net/http/cookie.cpp
+  net/http/mime_types.cpp net/http/client.cpp net/http/client_connection.cpp net/http/cookie.cpp
   fs/disk.cpp fs/filesystem.cpp fs/mbr.cpp fs/path.cpp
   fs/fat.cpp fs/fat_async.cpp fs/fat_sync.cpp fs/memdisk.cpp
   posix/fd.cpp posix/tcp_fd.cpp posix/udp_fd.cpp posix/unistd.cpp posix/fcntl.cpp posix/syslog.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -119,7 +119,7 @@ set(OS_SOURCES
   ${SRC}/net/dns/dns.cpp
   ${SRC}/net/ethernet/ethernet.cpp
   ${SRC}/net/http/client.cpp
-  ${SRC}/net/http/connection.cpp
+  ${SRC}/net/http/client_connection.cpp
   ${SRC}/net/http/cookie.cpp
   ${SRC}/net/http/header.cpp
   ${SRC}/net/http/header_fields.cpp

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -9,7 +9,7 @@ set(ELF_SYMS_SOURCES elf_syms.cpp)
 set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O3")
 
 # TODO: write scripts that automatically find include directories
-include_directories(. ./../api ./../mod/GSL/)
+include_directories(. ./../mod/GSL/)
 
 add_executable(vmbuild ${SOURCES})
 add_executable(elf_syms ${ELF_SYMS_SOURCES})

--- a/vmbuild/vmbuild.cpp
+++ b/vmbuild/vmbuild.cpp
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
-#include <boot/multiboot.h>
+#include "../api/boot/multiboot.h"
 #include <gsl/gsl>
 #include "elf.h"
 #include "elf_binary.hpp"


### PR DESCRIPTION
Some WIP on HTTP for lightweight server.

Due to the new `<sys/signal.h>` our tools including IncludeOS sys no longer builds on Mac. Did some changes to avoid including our sys when building tools.