### PR TITLE
Updates to HTTP Server

### DIFF
--- a/api/net/http/header.hpp
+++ b/api/net/http/header.hpp
@@ -161,6 +161,25 @@ public:
   /// empty
   ///
   void clear() noexcept;
+
+  /**
+   * @brief      Returns the Content-Length value in header as an integer
+   *
+   * @note       Return value 0 can mean its either unset or zero.
+   *
+   * @return     The content length as integer
+   */
+  size_t content_length() const;
+
+  /**
+   * @brief      Sets the Content-Length value in the header
+   *
+   * @param[in]  len   The length of the content
+   *
+   * @return     Outcome of wether the field got updated or not
+   */
+  bool set_content_length(size_t len);
+
 private:
   ///
   /// Class data members

--- a/api/net/http/message.hpp
+++ b/api/net/http/message.hpp
@@ -85,6 +85,24 @@ public:
   ///
   const Header& header() const noexcept;
 
+  /**
+   * @brief      Returns the Content-Length value in header as an integer
+   *
+   * @note       Return value 0 can mean its either unset or zero.
+   *
+   * @return     The content length as integer
+   */
+  inline size_t content_length() const;
+
+  /**
+   * @brief      Sets the Content-Length value in the header
+   *
+   * @param[in]  len   The length of the content
+   *
+   * @return     Outcome of wether the field got updated or not
+   */
+  inline bool set_content_length(size_t len);
+
   ///
   /// Add an entity to the message
   ///
@@ -177,6 +195,16 @@ private:
 Message& operator << (Message& res, const Header_set& headers);
 
 /**--^----------- Helper Functions -----------^--**/
+
+/**--v-------- Inline Implementations --------v--**/
+inline size_t Message::content_length() const {
+  return header_fields_.content_length();
+}
+
+inline bool Message::set_content_length(size_t len) {
+  return header_fields_.set_content_length(len);
+}
+/**--^-------- Inline Implementations --------^--**/
 
 } //< namespace http
 

--- a/etc/library.cmake
+++ b/etc/library.cmake
@@ -42,10 +42,9 @@ set(CMAKE_C_FLAGS "-MMD -target i686-elf ${CAPABS} ${OPTIMIZE} ${WARNS} -c -m32"
 
 # includes
 include_directories(${LOCAL_INCLUDES})
-include_directories($ENV{INCLUDEOS_PREFIX}/includeos/include/libcxx)
-include_directories($ENV{INCLUDEOS_PREFIX}/includeos/api/sys)
-include_directories($ENV{INCLUDEOS_PREFIX}/includeos/include/newlib)
 include_directories($ENV{INCLUDEOS_PREFIX}/includeos/api/posix)
+include_directories($ENV{INCLUDEOS_PREFIX}/includeos/include/libcxx)
+include_directories($ENV{INCLUDEOS_PREFIX}/includeos/include/newlib)
 include_directories($ENV{INCLUDEOS_PREFIX}/includeos/api)
 include_directories($ENV{INCLUDEOS_PREFIX}/includeos/include)
 include_directories($ENV{INCLUDEOS_PREFIX}/include)

--- a/src/net/http/header.cpp
+++ b/src/net/http/header.cpp
@@ -89,6 +89,27 @@ void Header::clear() noexcept {
   fields_.clear();
 }
 
+size_t Header::content_length() const
+{
+  try
+  {
+    const auto cl = value(header::Content_Length);
+
+    if(cl.empty()) return 0;
+
+    return std::stoul(cl.to_string());
+  }
+  catch(...)
+  {
+    return 0;
+  }
+}
+
+bool Header::set_content_length(size_t len)
+{
+  return set_field(header::Content_Length, std::to_string(len));
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 Header::Const_iterator Header::find(const std::experimental::string_view field) const noexcept {
   if (field.empty()) return fields_.cend();

--- a/src/net/http/response_writer.cpp
+++ b/src/net/http/response_writer.cpp
@@ -27,7 +27,51 @@ namespace http {
   {
   }
 
-  void Response_writer::send_header(status_t code)
+  void Response_writer::write(std::string data)
+  {
+    pre_write(data.size());
+
+    connection_->write(std::move(data));
+  }
+
+  void Response_writer::write(buffer_t buf, size_t len)
+  {
+    pre_write(len);
+
+    connection_->write(buf, len);
+  }
+
+  void Response_writer::pre_write(size_t len)
+  {
+    // send headers if not already sent
+    if(not header_sent_)
+    {
+      // lets help out with setting the content-length if none is set
+      if(not header().has_field(header::Content_Length))
+      {
+        response_->set_content_length(len);
+      }
+      // content-length is already set
+      else
+      {
+        const auto cl = response_->content_length();
+        // don't allow writing more than content-length in header allows
+        if(cl < len)
+          throw Response_writer_error{"Trying to write more than Content-Length allows: " + std::to_string(cl)};
+      }
+      // write headers
+      write_header(http::OK);
+    }
+    else
+    {
+      const auto cl = response_->content_length();
+      // don't allow writing more than content-length in header allows
+      if(cl < len)
+        throw Response_writer_error{"Trying to write more than Content-Length allows: " + std::to_string(cl)};
+    }
+  }
+
+  void Response_writer::write_header(status_t code)
   {
     if(LIKELY(not header_sent_))
     {
@@ -38,19 +82,8 @@ namespace http {
 
       connection_->write(header.str());
     }
-  }
-
-  void Response_writer::send()
-  {
-    connection_->write(response_->to_string());
-  }
-
-  void Response_writer::send_body(std::string data)
-  {
-    if(not header_sent_)
-      send_header();
-
-    connection_->write(std::move(data));
+    else
+      throw Response_writer_error{"Headers already sent."};
   }
 
 }

--- a/src/net/http/server.cpp
+++ b/src/net/http/server.cpp
@@ -37,7 +37,9 @@ namespace http {
     INFO("HTTP Server", "Listening on port %u", port);
 
     using namespace std::chrono;
-    timer_id_ = Timers::periodic(30s, 1min, {this, &Server::timeout_clients});
+
+    if(idle_timeout_ != idle_duration::zero())
+      timer_id_ = Timers::periodic(30s, 1min, {this, &Server::timeout_clients});
   }
 
   Response_ptr Server::create_response(status_t code) const
@@ -91,7 +93,7 @@ namespace http {
   {
     if(code == OK)
     {
-      on_request_(std::move(req), {create_response(code), conn.tcp()});
+      on_request_(std::move(req), std::make_unique<Response_writer>( create_response(code), conn.tcp() ));
     }
     else
     {

--- a/test/net/integration/http/service.cpp
+++ b/test/net/integration/http/service.cpp
@@ -46,15 +46,13 @@ void Service::ready()
 
   server_ = std::make_unique<Server>(inet.tcp());
 
-  server_->on_request([] (Request_ptr req, Response_writer writer)
+  server_->on_request([] (Request_ptr req, Response_writer_ptr writer)
   {
-    printf("Receiving request:\n%s\n", req->to_string().c_str());
-    auto& res = writer.res();
-    res.add_body("Hello");
-    auto& header = writer.header();
-    header.set_field(header::Content_Type, "text/plain");
-    header.set_field(header::Content_Length, std::to_string(res.body().size()));
-    writer.send();
+    printf("Received request:\n%s\n", req->to_string().c_str());
+    // set content type
+    writer->header().set_field(header::Content_Type, "text/plain");
+    // write body
+    writer->write("Hello");
   });
 
   server_->listen(8080);


### PR DESCRIPTION
Made the `Response_writer` API simpler to use. Currently only supports one write. It's possible to extract the underlying TCP Connection and do whatever you want to.
The changes can be seen in the http test.