### PR TITLE
test: unittest workarounds for OS X/macOS

### DIFF
--- a/api/kernel/syscalls.hpp
+++ b/api/kernel/syscalls.hpp
@@ -20,12 +20,6 @@
 
 #include <sys/unistd.h>
 #include <sys/types.h>
-#if defined(__MACH__)
-typedef int clockid_t;
-#if !defined(CLOCK_REALTIME)
-#define CLOCK_REALTIME 0
-#endif
-#endif
 
 extern "C" {
   int  kill(pid_t pid, int sig);

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -183,21 +183,21 @@ void panic(const char* why) {
   // heap and backtrace info
   uintptr_t heap_total = OS::heap_max() - heap_begin;
   double total = (heap_end - heap_begin) / (double) heap_total;
-  
+
   fprintf(stderr, "\tHeap is at: %#x / %#x  (diff=%#x)\n",
          heap_end, OS::heap_max(), OS::heap_max() - heap_end);
   fprintf(stderr, "\tHeap usage: %u / %u Kb (%.2f%%)\n",
-         (uintptr_t) (heap_end - heap_begin) / 1024, 
+         (uintptr_t) (heap_end - heap_begin) / 1024,
          heap_total / 1024,
          total * 100.0);
   print_backtrace();
 
   // Signal End-Of-Transmission
   fprintf(stderr, "\x04"); fflush(stderr);
-  
+
   // call on_panic handler
   panic_handler();
-  
+
   // .. if we return from the panic handler, go to permanent sleep
   while (1) asm("cli; hlt");
   __builtin_unreachable();
@@ -215,6 +215,14 @@ void abort_ex(const char* why) {
   __builtin_unreachable();
 }
 
+#if defined(__MACH__)
+#if !defined(__MAC_10_12)
+typedef int clockid_t;
+#endif
+#if !defined(CLOCK_REALTIME)
+#define CLOCK_REALTIME 0
+#endif
+#endif
 // Basic second-resolution implementation - using CMOS directly for now.
 int clock_gettime(clockid_t clk_id, struct timespec* tp) {
   if (clk_id == CLOCK_REALTIME) {

--- a/test/net/unit/cookie_test.cpp
+++ b/test/net/unit/cookie_test.cpp
@@ -327,6 +327,7 @@ using namespace http;
     EXPECT_THROWS( (Cookie{"name", "value", {"Expires", "abc"}}) );
     EXPECT_THROWS( (Cookie{"name", "value", {"Expires", "saT, Apr 16 00:09:44 GMT"}}) );
     EXPECT_THROWS( (Cookie{"name", "value", {"Expires", "Sun Nov 6 08:49:37"}}) );
+    EXPECT_THROWS( (Cookie{"name", "value", {"Expires", ""}}) );
   }
 
   // Option: Max-Age (int)
@@ -431,3 +432,27 @@ using namespace http;
     EXPECT_NOT( c5.is_http_only() );
   }
 
+CASE("Cookies can be streamed")
+{
+  Cookie c{"name", "value"};
+  std::stringstream ss;
+  ss << c;
+  EXPECT(ss.str().size() > 13);
+}
+
+CASE("CookieException::what() returns string describing exception")
+{
+  try {
+    Cookie c {"name", "value", {"Path", "/;invalidpath"}};
+  }
+  catch (const CookieException& ce) {
+    const auto msg_len = strlen(ce.what());
+    EXPECT(msg_len > 20);
+  }
+}
+
+CASE("Cookie::set_value throws if attempting to set invalid value")
+{
+  Cookie c {"name", "value"};
+  EXPECT_THROWS(c.set_value("v:a[]l{ue____"));
+}

--- a/test/net/unit/http_response_test.cpp
+++ b/test/net/unit/http_response_test.cpp
@@ -18,6 +18,8 @@
 #include <common.cxx>
 #include <net/http/response.hpp>
 
+using namespace std::string_literals;
+
 CASE("HTTP response can be created from a string")
 {
   http::Response r("HTTP/1.1 200 OK\r\nServer: IncludeOS/Acorn\r\nConnection: keep-alive\r\nContent-Type: application/json\r\nContent-Length: 194\r\n\r\n{\"version\":\"v0.9.3-1868-gd008d1a-dirty\",\"service\":\"Acorn Web Appliance\",\"heap_usage\":438272,\"cpu_freq\":2600.381981722683,\"boot_time\":\"2016-12-20T12:29:28Z\",\"current_time\":\"2017-01-10T16:03:53Z\"}");
@@ -77,4 +79,19 @@ CASE("responses can be streamed")
   std::stringstream ss;
   ss << r;
   EXPECT(ss.str().size() > 20);
+}
+
+CASE("status_line() returns the status line portion of the response")
+{
+  http::Response r("HTTP/1.0 200 OK\r\nServer: IncludeOS/Acorn\r\nConnection: keep-alive\r\nContent-Type: application/json\r\nContent-Length: 194\r\n\r\n{\"version\":\"v0.9.3-1868-gd008d1a-dirty\",\"service\":\"Acorn Web Appliance\",\"heap_usage\":438272,\"cpu_freq\":2600.381981722683,\"boot_time\":\"2016-12-20T12:29:28Z\",\"current_time\":\"2017-01-10T16:03:53Z\"}");
+  EXPECT(r.status_line() == "HTTP/1.0 200 OK");
+}
+
+CASE("operator std::string returns string representation of response")
+{
+  http::Response r;
+  r.set_version(http::Version(1, 0));
+  r.set_status_code(http::Not_Found);
+  std::string s = (std::string)r;
+  EXPECT(s == "HTTP/1.0 404 Not Found\r\n");
 }

--- a/test/util/unit/base64.cpp
+++ b/test/util/unit/base64.cpp
@@ -80,3 +80,8 @@ CASE("Decode 'Zm9vYmE='") {
 CASE("Decode 'Zm9vYmFy'") {
   EXPECT("foobar" == base64::decode<std::string>("Zm9vYmFy"s));
 }
+
+CASE("Decode 'Zm8' (without padding) throws exception") {
+  EXPECT_THROWS(base64::decode<std::string>("Zm8"s));
+  EXPECT_THROWS_AS(base64::decode<std::string>("Zm8"s),  base64::Decode_error);
+}


### PR DESCRIPTION
Support for clockid_t/CLOCK_REALTIME differs between OS X/macOS versions. Now builds on both Mac OS X El Capitan and macOS Sierra.