### PR TITLE
Avoid pruning/moving elf-symbols twice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,16 +89,22 @@ set(CMAKE_C_FLAGS "-target i686 -MMD ${CAPABS} ${WARNS} -nostdlib -nostdlibinc -
 option(from_bundle "Download and use pre-compiled libraries for cross-comilation" ON)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cross_compiled_libraries.txt)
 
+#
+# Subprojects
+#
 add_subdirectory(mod)
-
 add_subdirectory(src)
 
+#
+# External projects
+#
 option(vmbuild "Build and install vmbuild and elf_syms" ON)
 if(vmbuild)
   # Install vmbuilder as an external project
   ExternalProject_Add(vmbuild
     PREFIX vmbuild # Build where
     SOURCE_DIR ${INCLUDEOS_ROOT}/vmbuild # Where is project located
+    BINARY_DIR ${INCLUDEOS_ROOT}/vmbuild/build
     INSTALL_DIR ${BIN} # Where to install
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> # Pass installation folder
     )
@@ -145,6 +151,10 @@ if(rapidjson)
   install(DIRECTORY mod/rapidjson/include/rapidjson DESTINATION includeos/include)
 endif(rapidjson)
 
+
+#
+# Installation
+#
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/etc/service.cmake DESTINATION includeos)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/etc/library.cmake DESTINATION includeos)
 install(DIRECTORY vmrunner DESTINATION includeos/)

--- a/etc/service.cmake
+++ b/etc/service.cmake
@@ -306,7 +306,6 @@ add_custom_target(
   COMMAND $ENV{INCLUDEOS_PREFIX}/includeos/bin/elf_syms ${BINARY}
   COMMAND ${CMAKE_OBJCOPY} --update-section .elf_symbols=_elf_symbols.bin ${BINARY} ${BINARY}
   COMMAND ${STRIP_LV}
-  COMMAND rm _elf_symbols.bin
   DEPENDS service
 )
 

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -4,7 +4,7 @@ project (vmbuilder)
 
 # TODO: make sure that CXX is exported before this script is called
 set(SOURCES vmbuild.cpp elf_binary.cpp)
-set(ELF_SYMS_SOURCES elf_syms.cpp)
+set(ELF_SYMS_SOURCES elf_syms.cpp elf_binary.cpp)
 
 set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O3")
 


### PR DESCRIPTION
This fixes issue #1040 for me. Ideally I guess we should also check that the binary doesn't contain any normal symbols. However, with the current build system you'll always get an empty `.elf_symbols` section from the linker script whenever a new binary is produced. If that's the case pruning will go ahead as before.