### PR TITLE
Improve Arch Linux compatibility

### DIFF
--- a/etc/boot
+++ b/etc/boot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -43,7 +43,7 @@ case $SYSTEM in
                 exit 0;
                 ;;
             "arch")
-                DEPENDENCIES="curl make clang nasm bridge-utils qemu jq python-jsonschema python-psutil cmake"
+                DEPENDENCIES="curl make clang nasm bridge-utils qemu jq python-jsonschema python-psutil cmake python2 python2-jsonschema python2-psutil"
                 echo ">>> Installing dependencies (requires sudo):"
                 echo "    Packages: $DEPENDENCIES"
                 sudo pacman -Syyu

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -17,8 +17,8 @@ INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
 INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
 
 # Try to find suitable compiler
-cc_list="clang-3.8 clang-3.7 clang-3.6 clang"
-cxx_list="clang++-3.8 clang++-3.7 clang++-3.6 clang++"
+cc_list="clang-3.9 clang-3.8 clang-3.7 clang-3.6 clang"
+cxx_list="clang++-3.9 clang++-3.8 clang++-3.7 clang++-3.6 clang++"
 
 compiler=""
 guess_compiler() {


### PR DESCRIPTION
* Use `env python2` instead of `env python` in the `boot` script
* Install required `python2 python2-jsonschema python2-psutil` packages
* Explicitly add `clang-3.9` support 