### PR TITLE
Readme: Added integration test coverage to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ IncludeOS is free software, with "no warranties or restrictions of any kind".
 
 ## Build status
 
-|        | Build from bundle                                                                                                                                             |
-|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Master | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_master_bundle)](https://jenkins.includeos.org/job/shield_master_bundle/) |
-| Dev    | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_dev_bundle)](https://jenkins.includeos.org/job/shield_dev_bundle/)      |
+|        | Build from bundle | Integration tests |
+|--------|-------------------|-------------------|
+| Master | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_master_bundle)](https://jenkins.includeos.org/job/shield_master_bundle/) |  Coming soon |
+| Dev    | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_dev_bundle)](https://jenkins.includeos.org/job/shield_dev_bundle/)      | [![Jenkins tests](https://img.shields.io/jenkins/t/https/jenkins.includeos.org/shield_dev_integration_tests.svg)](https://jenkins.includeos.org/job/shield_dev_integration_tests/) |
 
 ### Key features
 


### PR DESCRIPTION
- Due to shields.io having some load issues the shield might not be visible at the moment. They are in the process of getting additional servers up.
- The junit generation part of testrunner.py has not been merged into master yet, so I can't generate the test coverage shield for it yet. I will add this as soon as it is merged. 