### PR TITLE
util: Fix bug in URI::host_is_ip4

### DIFF
--- a/src/util/uri.cpp
+++ b/src/util/uri.cpp
@@ -181,7 +181,7 @@ std::experimental::string_view URI::host() const noexcept {
 
 ///////////////////////////////////////////////////////////////////////////////
 bool URI::host_is_ip4() const noexcept {
-  return std::isdigit(host_.back());
+  return host_.empty() ? false : std::isdigit(host_.back());
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Calling `back` on a `string_view` where the condition `empty() == true` results in undefined behavior...