### PR TITLE
kernel: Verify symbols and strings with CRC32

### DIFF
--- a/src/crt/c_abi.c
+++ b/src/crt/c_abi.c
@@ -88,10 +88,6 @@ void _init_c_runtime()
   extern void _init_elf_parser();
   _init_elf_parser();
 
-  /// call global constructors emitted by compiler
-  extern void _init();
-  _init();
-
   // sanity checks
   assert(heap_begin >= &_end);
   assert(heap_end >= heap_begin);

--- a/src/drivers/heap_debugging.cpp
+++ b/src/drivers/heap_debugging.cpp
@@ -129,7 +129,7 @@ void* operator new (std::size_t len) throw(std::bad_alloc)
 
   if (UNLIKELY(!data)) {
       print_backtrace();
-      DPRINTF("malloc(%u bytes): FAILED\n", len, data);
+      DPRINTF("malloc(%u bytes): FAILED\n", len);
       throw std::bad_alloc();
   }
 

--- a/src/kernel/kernel_start.cpp
+++ b/src/kernel/kernel_start.cpp
@@ -24,6 +24,7 @@
 extern "C" void __init_sanity_checks();
 extern "C" void _init_c_runtime();
 extern "C" void _init_syscalls();
+extern "C" void _init();
 
 // enables Streaming SIMD Extensions
 static void enableSSE(void) noexcept
@@ -47,9 +48,6 @@ void kernel_start(uintptr_t magic, uintptr_t addr)  {
   // generate checksums of read-only areas etc.
   __init_sanity_checks();
 
-  // Initialize system calls
-  _init_syscalls();
-
   // Save multiboot string before symbols overwrite area after binary
   if (magic == MULTIBOOT_BOOTLOADER_MAGIC) {
     char* cmdline = reinterpret_cast<char*>(reinterpret_cast<multiboot_info_t*>(addr)->cmdline);
@@ -59,6 +57,12 @@ void kernel_start(uintptr_t magic, uintptr_t addr)  {
 
   // Initialize stack-unwinder, call global constructors etc.
   _init_c_runtime();
+
+  // Initialize system calls
+  _init_syscalls();
+
+  // call global constructors emitted by compiler
+  _init();
 
   // Initialize OS including devices
   OS::start(magic, addr);


### PR DESCRIPTION
This will prevent symbols & strings from being used in most if not all services.. the checksums have been verified to be preserved all the way into the ELF binary, but fails only inside kernel.