### PR TITLE
icmpv4: Remove <os> include & fix broken include path

### DIFF
--- a/src/net/ip4/icmpv4.cpp
+++ b/src/net/ip4/icmpv4.cpp
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../../api/net/ip4/icmpv4.hpp"
-
-#include <os>
+#include <net/ip4/icmpv4.hpp>
 #include <net/inet_common.hpp>
 #include <net/ip4/packet_ip4.hpp>
 #include <net/util.hpp>


### PR DESCRIPTION
#include <os> is extraneous here, we don’t need to take on the
dependency. The icmpv4.hpp is short a ../ in its relative pathing, but
regardless should use <net/ip4/icmpv4.hpp> directly instead. This
mirrors the styling in other ip cpp files.