### PR TITLE
dh4client - Add missing variable name to fix debug prints

### DIFF
--- a/src/net/dhcp/dh4client.cpp
+++ b/src/net/dhcp/dh4client.cpp
@@ -259,7 +259,7 @@ namespace net
     socket.bcast(IP4::ADDR_ANY, DHCP_DEST_PORT, packet, packetlen);
 
     socket.on_read(
-    [this, &socket] (IP4::addr, UDP::port_t port,
+    [this, &socket] (IP4::addr addr, UDP::port_t port,
                      const char* data, size_t len)
     {
       if (port == DHCP_DEST_PORT)
@@ -447,7 +447,7 @@ namespace net
 
     // set our onRead function to point to a hopeful DHCP ACK!
     sock.on_read(
-    [this] (IP4::addr, UDP::port_t port,
+    [this] (IP4::addr addr, UDP::port_t port,
             const char* data, size_t len)
     {
       if (port == DHCP_DEST_PORT)


### PR DESCRIPTION
The two socket.on_read lambdas are missing a variable name for
IP4::addr such that dh4client.cpp won’t compile if debug is defined.
Adds the expected variable name of ‘addr’