### PR TITLE
tcp - Update debug prints to reference the newer functions

### DIFF
--- a/api/net/tcp/packet.hpp
+++ b/api/net/tcp/packet.hpp
@@ -63,8 +63,8 @@ public:
     // set TCP payload location (!?)
     set_payload(buffer() + tcp_full_header_length());
 
-    debug2("<TCP::Packet::init> size()=%u ip_header_size()=%u full_header_size()=%u\n",
-      size(), ip_header_size(), tcp_full_header_length());
+    debug2("<TCP::Packet::init> size()=%u ip_header_length()=%u full_header_length()=%u\n",
+      size(), ip_header_length(), tcp_full_header_length());
   }
 
   // GETTERS


### PR DESCRIPTION
Packet.hpp & connection.cpp referenced old variables in a couple of debug prints.
ip_header_size() -> ip_header_length()
buf.* -> writeq.* in a couple cases
timewait_timer.id is a private variable, so removed the attempt to print it.