### PR TITLE
net - Update old debug print variables

### DIFF
--- a/api/net/tcp/packet.hpp
+++ b/api/net/tcp/packet.hpp
@@ -63,8 +63,8 @@ public:
     // set TCP payload location (!?)
     set_payload(buffer() + tcp_full_header_length());
 
-    debug2("<TCP::Packet::init> size()=%u ip_header_size()=%u full_header_size()=%u\n",
-      size(), ip_header_size(), tcp_full_header_length());
+    debug2("<TCP::Packet::init> size()=%u ip_header_length()=%u full_header_length()=%u\n",
+      size(), ip_header_length(), tcp_full_header_length());
   }
 
   // GETTERS

--- a/src/net/dhcp/dh4client.cpp
+++ b/src/net/dhcp/dh4client.cpp
@@ -265,8 +265,7 @@ namespace net
       if (port == DHCP_DEST_PORT)
       {
         // we have got a DHCP Offer
-        debug("Received possible DHCP OFFER from %s:%d\n",
-              addr.str().c_str(), DHCP_DEST_PORT);
+        debug("Received possible DHCP OFFER on port:%d\n", DHCP_DEST_PORT);
         this->offer(socket, data, len);
       }
     });
@@ -453,8 +452,7 @@ namespace net
       if (port == DHCP_DEST_PORT)
       {
         // we have hopefully got a DHCP Ack
-        debug("\tReceived DHCP ACK from %s:%d\n",
-              addr.str().c_str(), DHCP_DEST_PORT);
+        debug("\tReceived DHCP ACK on port:%d\n", DHCP_DEST_PORT);
         this->acknowledge(data, len);
       }
     });


### PR DESCRIPTION
Updated old debug print variables such that the code compiles in debug again. (This time without introducing an unused variable warning in release mode :)