### PR TITLE
RTC - Support boot_timestamp & time_since_boot

### DIFF
--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -63,11 +63,11 @@ public:
 
   /** Timestamp for when OS was booted */
   static RTC::timestamp_t boot_timestamp()
-  { return booted_at_; }
+  { return RTC::boot_timestamp(); }
 
   /** Uptime in whole seconds. */
   static RTC::timestamp_t uptime() {
-    return RTC::now() - booted_at_;
+    return RTC::time_since_boot();
   }
 
   static MHz cpu_freq() noexcept
@@ -215,7 +215,6 @@ private:
 
   static MHz cpu_mhz_;
 
-  static RTC::timestamp_t booted_at_;
   static std::string version_field;
 
   struct Plugin_struct {

--- a/api/kernel/rtc.hpp
+++ b/api/kernel/rtc.hpp
@@ -32,6 +32,18 @@ public:
 
   /// start an auto-calibration process
   static void init();
+
+  /// returns a 64-bit unix timestamp for when the OS was booted
+  static timestamp_t boot_timestamp()
+  { return booted_at_; }
+
+  /// returns a 64-bit unix timestamp of the elapsed time since boot
+  static timestamp_t time_since_boot()
+  { return now() - booted_at_; }
+
+private:
+  static timestamp_t booted_at_;
+
 };
 
 #endif

--- a/api/net/ip4/arp.hpp
+++ b/api/net/ip4/arp.hpp
@@ -19,7 +19,7 @@
 #ifndef NET_IP4_ARP_HPP
 #define NET_IP4_ARP_HPP
 
-#include <os>
+#include <rtc>
 #include <map>
 
 #include <delegate>
@@ -46,12 +46,12 @@ namespace net {
       cache_entry() noexcept = default;
 
       cache_entry(Ethernet::addr mac) noexcept
-      : mac_(mac), timestamp_(OS::uptime()) {}
+      : mac_(mac), timestamp_(RTC::time_since_boot()) {}
 
       cache_entry(const cache_entry& cpy) noexcept
       : mac_(cpy.mac_), timestamp_(cpy.timestamp_) {}
 
-      void update() noexcept { timestamp_ = OS::uptime(); }
+      void update() noexcept { timestamp_ = RTC::time_since_boot(); }
     }; //< struct cache_entry
 
     using Cache       = std::map<IP4::addr, cache_entry>;

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -58,7 +58,6 @@ extern uintptr_t _MAX_MEM_MIB_;
 
 bool  OS::power_   = true;
 MHz   OS::cpu_mhz_ {-1};
-RTC::timestamp_t OS::booted_at_ {0};
 uintptr_t OS::low_memory_size_  {0};
 uintptr_t OS::high_memory_size_ {0};
 uintptr_t OS::memory_end_ {0};
@@ -241,7 +240,6 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr) {
 #endif
   // Realtime/monotonic clock
   RTC::init();
-  booted_at_ = RTC::now();
 
 #ifdef ENABLE_PROFILERS
   ScopedProfiler sp10("OS::start Plugins init");

--- a/src/kernel/rtc.cpp
+++ b/src/kernel/rtc.cpp
@@ -10,6 +10,7 @@
 
 static int64_t  current_time  = 0;
 static uint64_t current_ticks = 0;
+RTC::timestamp_t RTC::booted_at_ = 0;
 
 using namespace std::chrono;
 
@@ -18,6 +19,9 @@ void RTC::init()
   // Initialize CMOS
   cmos::init();
 
+  // set boot timestamp
+  booted_at_ = cmos::now().to_epoch();
+  
   // set current timestamp and ticks
   current_time  = cmos::now().to_epoch();
   current_ticks = hw::CPU::rdtsc();

--- a/src/net/dhcp/dh4client.cpp
+++ b/src/net/dhcp/dh4client.cpp
@@ -21,7 +21,7 @@
 
 #include <net/dhcp/dh4client.hpp>
 #include <net/dhcp/dhcp4.hpp>
-#include <kernel/os.hpp> // OS::cycles_since_boot()
+#include <rtc>  // RTC::time_since_boot()
 #include <debug>
 
 // BOOTP (rfc951) message types
@@ -196,7 +196,7 @@ namespace net
     });
 
     // create a random session ID
-    this->xid = OS::cycles_since_boot() & 0xFFFFFFFF;
+    this->xid = RTC::time_since_boot() & 0xFFFFFFFF;
     if (console_spam)
       MYINFO("Negotiating IP-address (xid=%u)", xid);
 

--- a/src/net/inet4.cpp
+++ b/src/net/inet4.cpp
@@ -1,6 +1,5 @@
 //-*- C++ -*-
 #define DEBUG
-#include <os>
 #include <net/inet4.hpp>
 #include <net/dhcp/dh4client.hpp>
 

--- a/src/net/inet_common.cpp
+++ b/src/net/inet_common.cpp
@@ -17,7 +17,6 @@
 
 #include <stdlib.h>
 
-#include <os>
 #include <net/util.hpp>
 #include <net/inet_common.hpp>
 

--- a/src/net/ip4/arp.cpp
+++ b/src/net/ip4/arp.cpp
@@ -20,7 +20,6 @@
 
 #include <vector>
 
-#include <os>
 #include <net/inet4.hpp>
 #include <net/ip4/arp.hpp>
 #include <net/ip4/packet_arp.hpp>
@@ -129,11 +128,11 @@ namespace net {
       debug("<Arp> Cached entry, mac: %s time: %llu Expiry: %llu\n",
             entry->second.mac_.str().c_str(),
             entry->second.timestamp_, entry->second.timestamp_ + cache_exp_t_);
-      debug2("<Arp> Time now: %llu\n", static_cast<uint64_t>(OS::uptime()));
+      debug2("<Arp> Time now: %llu\n", static_cast<uint64_t>(RTC::time_since_boot()));
     }
 
     return entry != cache_.end()
-      and (entry->second.timestamp_ + cache_exp_t_ > static_cast<uint64_t>(OS::uptime()));
+      and (entry->second.timestamp_ + cache_exp_t_ > static_cast<uint64_t>(RTC::time_since_boot()));
   }
 
   extern "C" {

--- a/src/net/tcp/rttm.cpp
+++ b/src/net/tcp/rttm.cpp
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <os> // uptime
+#include <rtc> // time_since_boot()
 #include <net/tcp/rttm.hpp>
 
 using namespace net::tcp;
@@ -23,7 +23,7 @@ using namespace net::tcp;
 const RTTM::duration_t RTTM::CLOCK_G;
 
 void RTTM::start() {
-  t = OS::uptime();
+  t = RTC::time_since_boot();
   active = true;
 }
 
@@ -31,7 +31,7 @@ void RTTM::stop(bool first) {
   assert(active);
   active = false;
   // round trip time (RTT)
-  auto rtt = OS::uptime() - t;
+  auto rtt = RTC::time_since_boot() - t;
   debug2("<RTTM::stop> RTT: %ums\n",
     (uint32_t)(rtt * 1000));
   if(!first)

--- a/src/posix/sys/select.cpp
+++ b/src/posix/sys/select.cpp
@@ -4,6 +4,7 @@
 #include <fd_map.hpp>
 #include <tcp_fd.hpp>
 #include <list>
+#include <kernel/os.hpp> // OS::block()
 
 static struct {
   typedef std::pair<int, TCP_FD&> listpair;

--- a/src/posix/udp_fd.cpp
+++ b/src/posix/udp_fd.cpp
@@ -17,6 +17,7 @@
 
 #include <udp_fd.hpp>
 #include <kernel/irq_manager.hpp>
+#include <kernel/os.hpp> // OS::block
 
 // return the "currently selected" networking stack
 static net::Inet<net::IP4>& net_stack() {

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -40,9 +40,10 @@ Statman& Statman::get() {
   return statman_;
 }
 
-#include <os>
-#include <kernel/timers.hpp>
 
+
+#include <rtc>
+RTC::timestamp_t RTC::booted_at_ = 0;
 RTC::timestamp_t RTC::now() {
   return 0;
 }
@@ -51,6 +52,7 @@ void RTC::init() {
   return;
 }
 
+#include <kernel/timers.hpp>
 void Timers::timers_handler() {
   return;
 }
@@ -71,6 +73,7 @@ Timers::id_t Timers::periodic(duration_t, duration_t, handler_t) {
   return 0;
 }
 
+#include <os>
 void OS::resume_softreset(intptr_t) {
   return;
 }


### PR DESCRIPTION
This PR adds boot_timestamp() & time_since_boot() to RTC, enabling us to remove the dependency on #include <OS> from the network stack classes.

OS:: & the network stack classes have been updated to call the new RTC:: functions.

Additionally, two posix classes have been updated to directly #include <kernel/os.hpp>. Several already did, but these two were previously indirectly including it via the <net> classes.