### PR TITLE
Solved Mac OS & URI issues

### DIFF
--- a/cmake/i686-elf-toolchain.cmake
+++ b/cmake/i686-elf-toolchain.cmake
@@ -38,4 +38,7 @@ set(CMAKE_FIND_ROOT_PATH ${INCLUDEOS_BIN})
 #
 # This can be done with /etc/install_binutils.sh
 #set(_CMAKE_TOOLCHAIN_PREFIX ${target}-)
+
+# Set nasm compiler to the one symlinked in includeos/bin (to avoid running Mac one)
+set(CMAKE_ASM_NASM_COMPILER ${INCLUDEOS_BIN}/nasm)
 endif()

--- a/etc/install_osx.sh
+++ b/etc/install_osx.sh
@@ -129,6 +129,10 @@ then
   ln -sf $SRC_BINUTILS/i686-elf-* $INCLUDEOS_BIN/
   echo -e ">> $SRC_BINUTILS/i686-elf-* > $INCLUDEOS_BIN/"
 
+  SRC_NASM="/usr/local/bin/nasm"
+  ln -sf $SRC_NASM $INCLUDEOS_BIN/nasm
+  echo -e ">> $SRC_NASM > $INCLUDEOS_BIN/nasm"
+
   echo -e "\n>>> Done symlinking dependencies to $INCLUDEOS_BIN"
 fi
 

--- a/src/util/uri.cpp
+++ b/src/util/uri.cpp
@@ -36,35 +36,37 @@ static inline bool icase_equal(const std::experimental::string_view lhs, const s
 static inline uint16_t bind_port(const std::experimental::string_view scheme,
                                  const uint16_t port_from_uri) noexcept
 {
-  static auto comparator = [](const std::experimental::string_view lhs, const std::experimental::string_view rhs) {
-    return icase_equal(lhs, rhs);
-  };
-
   static const std::initializer_list<std::pair<const std::experimental::string_view, uint16_t>> scheme_port_mapping
   {
-    {"ftp",    21U},
-    {"http",   80U},
-    {"https",  443U},
-    {"irc",    6667U},
-    {"ldap",   389U},
-    {"nntp",   119U},
-    {"rtsp",   554U},
-    {"sip",    5060U},
-    {"sips",   5061U},
-    {"smtp",   25U},
-    {"ssh",    22U},
-    {"telnet", 23U},
-    {"ws",     80U},
-    {"xmpp",   5222U}
+    {"ftp",    21U},  {"FTP",    21U},
+    {"http",   80U},  {"HTTP",   80U},
+    {"https",  443U}, {"HTTPS",  443U},
+    {"irc",    6667U},{"IRC",    6667U},
+    {"ldap",   389U}, {"LDAP",   389U},
+    {"nntp",   119U}, {"NNTP",   119U},
+    {"rtsp",   554U}, {"RTSP",   554U},
+    {"sip",    5060U},{"SIP",    5060U},
+    {"sips",   5061U},{"SIPS",   5061U},
+    {"smtp",   25U},  {"SMTP",   25U},
+    {"ssh",    22U},  {"SSH",    22U},
+    {"telnet", 23U},  {"TELNET", 23U},
+    {"ws",     80U},  {"WS",     80U},
+    {"xmpp",   5222U},{"XMPP",   5222U}
   };
-
-  static const std::map<std::experimental::string_view, uint16_t, decltype(comparator)> port_table
-  {scheme_port_mapping, comparator};
+  static const std::map<std::experimental::string_view, uint16_t> port_table
+  {scheme_port_mapping};
 
   if (port_from_uri not_eq 0) return port_from_uri;
 
   const auto it = port_table.find(scheme);
-
+  // Slow case insensitive compare
+  /*
+  const auto it = std::find_if(port_table.begin(), port_table.end(),
+    [scheme] (const std::pair<std::experimental::string_view, uint16_t>& pair)
+    {
+      return icase_equal(pair.first, scheme);
+    });
+  */
   return (it not_eq port_table.cend()) ? it->second : 0xFFFFU;
 }
 

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -103,6 +103,10 @@ extern "C" {
     return;
   }
 
+  void _init() {
+    return;
+  }
+
   void modern_interrupt_handler() {
     return;
   }
@@ -136,6 +140,15 @@ extern "C" {
   }
 
   void reboot_os() {
+    return;
+  }
+
+  struct mallinfo { int x; };
+  struct mallinfo mallinfo() {
+    return {0};
+  }
+
+  void malloc_trim() {
     return;
   }
 }

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -103,9 +103,11 @@ extern "C" {
     return;
   }
 
+#ifdef __MACH__
   void _init() {
     return;
   }
+#endif
 
   void modern_interrupt_handler() {
     return;

--- a/test/util/unit/uri_test.cpp
+++ b/test/util/unit/uri_test.cpp
@@ -52,6 +52,23 @@ CASE("port() returns the URI's port (no path)") {
   EXPECT(uri.port() == 80);
 }
 
+CASE("port() defaults according to the correct protocol") {
+  uri::URI http {"http://www.vg.no"};
+  EXPECT(http.port() == 80);
+
+  uri::URI ftp {"ftp://silkroad.com"};
+  EXPECT(ftp.port() == 21);
+
+  uri::URI irc {"irc://irc.includeos.org"};
+  EXPECT(irc.port() == 6667);
+
+  uri::URI random {"lul://does.not.work"};
+  EXPECT(random.port() == 65535);
+
+  uri::URI port_provided {"http://some.random.site.uk:8080"};
+  EXPECT(port_provided.port() == 8080);
+}
+
 CASE("out-of-range ports throws exception") {
   EXPECT_THROWS(uri::URI uri {"https://www.vg.no:65539"});
 }


### PR DESCRIPTION
Brew installed nasm should now be used on newer mac OS #1155.

URI was using wrong comparator when adding default ports - removed it all together and added tests that confirm it should be working #1161. (No longer case insensitive, but added cases for all UPPER).

Unittests now builds on Mac.

