### PR TITLE
tcp: Delayed ACK, Window Scaling, Timestamps etc

### DIFF
--- a/api/net/tcp/common.hpp
+++ b/api/net/tcp/common.hpp
@@ -32,6 +32,8 @@ namespace net {
     // window scaling + window size
     static constexpr uint8_t  default_window_scaling {5};
     static constexpr uint32_t default_ws_window_size {8192 << default_window_scaling};
+    // use of timestamps option
+    static constexpr bool     default_timestamps {true};
     // maximum size of a TCP segment - later set based on MTU or peer
     static constexpr uint16_t default_mss {536};
     // the maximum amount of half-open connections per port (listener)

--- a/api/net/tcp/common.hpp
+++ b/api/net/tcp/common.hpp
@@ -21,6 +21,7 @@
 
 #include <net/ip4/addr.hpp>
 #include <net/packet.hpp>
+#include <chrono>
 
 namespace net {
   namespace tcp {

--- a/api/net/tcp/common.hpp
+++ b/api/net/tcp/common.hpp
@@ -27,11 +27,17 @@ namespace net {
 
     // Constants
     // default size of TCP window - how much data can be "in flight" (unacknowledged)
-    static constexpr uint16_t default_window_size = 0xffff;
+    static constexpr uint16_t default_window_size {0xffff};
+    // window scaling + window size
+    static constexpr uint8_t  default_window_scaling {5};
+    static constexpr uint32_t default_ws_window_size {8192 << default_window_scaling};
     // maximum size of a TCP segment - later set based on MTU or peer
-    static constexpr uint16_t default_mss = 536;
+    static constexpr uint16_t default_mss {536};
     // the maximum amount of half-open connections per port (listener)
-    static constexpr size_t max_syn_backlog = 64;
+    static constexpr size_t   default_max_syn_backlog {64};
+
+    static const std::chrono::seconds       default_msl {30};
+    static const std::chrono::milliseconds  default_dack_timeout {40};
 
     using Address = ip4::Addr;
 

--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -542,7 +542,7 @@ private:
   seq_t prev_highest_ack_ = 0;
 
   /** Delayed ACK - number of seg received without ACKing */
-  bool  dack_{0};
+  uint8_t  dack_{0};
 
   /// --- CALLBACKS --- ///
 

--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -192,8 +192,10 @@ public:
 
   /*
     Represent the Connection as a string (STATUS).
+    Local:Port Remote:Port (STATE)
   */
-  std::string to_string() const;
+  std::string to_string() const
+  { return {local().to_string() + " " + remote_.to_string() + " (" + state_->to_string() + ")"}; }
 
   /*
     Returns the current state of the connection.
@@ -234,7 +236,8 @@ public:
   /*
     Is the usable window large enough, and is there data to send.
   */
-  bool can_send();
+  constexpr bool can_send() const
+  { return (usable_window() >= SMSS()) and writeq.has_remaining_requests(); }
 
   /*
     Return the id (TUPLE) of the connection.
@@ -407,7 +410,8 @@ public:
 
       uint16_t MSS; // Maximum segment size for outgoing segments.
 
-      uint8_t  wind_shift;
+      uint8_t  wind_shift; // WS factor
+      bool     TS_OK;  // Use timestamp option
     } SND; // <<
     seq_t ISS;      // initial send sequence number
 
@@ -419,13 +423,15 @@ public:
 
       uint16_t rwnd; // receivers advertised window [RFC 5681]
 
-      uint8_t  wind_shift;
+      uint8_t  wind_shift; // WS factor
     } RCV; // <<
     seq_t IRS;      // initial receive sequence number
 
     uint32_t ssthresh; // slow start threshold [RFC 5681]
     uint32_t cwnd;     // Congestion window [RFC 5681]
     seq_t recover;     // New Reno [RFC 6582]
+
+    uint32_t TS_recent; // Recent timestamp received from user [RFC 7323]
 
     TCB(const uint32_t recvwin);
     TCB();
@@ -538,6 +544,7 @@ private:
 
   /** Delayed ACK - number of seg received without ACKing */
   uint8_t  dack_{0};
+  seq_t    last_ack_sent_;
 
   /// --- CALLBACKS --- ///
 
@@ -552,16 +559,7 @@ private:
   CleanupCallback         _on_cleanup_;
   inline Connection&      _on_cleanup(CleanupCallback cb);
 
-  void default_on_connect(Connection_ptr);
   void default_on_disconnect(Connection_ptr, Disconnect);
-  void default_on_error(TCPException);
-  void default_on_packet_dropped(const Packet&, const std::string&);
-  void default_on_rtx_timeout(size_t, double);
-  void default_on_close();
-  void default_on_cleanup(Connection_ptr);
-  void default_on_write(size_t);
-
-
 
   /// --- READING --- ///
 
@@ -701,20 +699,25 @@ private:
     SND.UNA + WINDOW - SND.NXT
   */
   uint32_t usable_window() const {
-    auto x = (int64_t)send_window() - (int64_t)flight_size();
+    const auto x = (int64_t)send_window() - (int64_t)flight_size();
     return (uint32_t) std::max(0ll, x);
   }
 
   uint32_t send_window() const {
-    return std::min((cb.SND.WND << cb.SND.wind_shift), cb.cwnd);
+    return std::min(cb.SND.WND, cb.cwnd);
   }
 
   int32_t congestion_window() const {
-    auto win = (uint64_t)cb.SND.UNA + std::min((uint64_t)cb.cwnd, (uint64_t)send_window());
+    const auto win = (uint64_t)cb.SND.UNA + (uint64_t)send_window();
     return (int32_t)win;
   }
 
+  uint32_t flight_size() const
+  { return (uint64_t)cb.SND.NXT - (uint64_t)cb.SND.UNA; }
+
   bool uses_window_scaling() const;
+
+  bool uses_timestamps() const;
 
   /// --- INCOMING / TRANSMISSION --- ///
   /*
@@ -736,22 +739,19 @@ private:
   /*
     Is it possible to send ONE segment.
   */
-  bool can_send_one();
+  constexpr bool can_send_one() const
+  { return send_window() >= SMSS() and writeq.has_remaining_requests(); }
 
   /*
     Send as much as possible from write queue.
   */
-  void send_much();
+  void send_much()
+  { writeq_push(); }
 
   /*
     Fill a packet with data and give it a SEQ number.
   */
-  size_t fill_packet(Packet&, const uint8_t*, size_t, seq_t);
-
-  /*
-    Transmit the send buffer.
-  */
-  void transmit();
+  size_t fill_packet(Packet&, const uint8_t*, size_t);
 
   /*
     Transmit the packet and hooks up retransmission.
@@ -775,28 +775,33 @@ private:
 
   /// --- Congestion Control [RFC 5681] --- ///
 
-  void setup_congestion_control();
+  void setup_congestion_control()
+  { reno_init(); }
 
   uint16_t SMSS() const;
 
   uint16_t RMSS() const
   { return cb.SND.MSS; }
 
-  uint32_t flight_size() const
-  { return (uint64_t)cb.SND.NXT - (uint64_t)cb.SND.UNA; }
-
   // Reno specifics //
 
-  void reno_init();
+  void reno_init()
+  {
+    reno_init_cwnd(3);
+    reno_init_sshtresh();
+  }
 
-  void reno_init_cwnd(size_t segments);
+  void reno_init_cwnd(const size_t segments)
+  { cb.cwnd = segments*SMSS(); }
 
   void reno_init_sshtresh()
   { cb.ssthresh = cb.SND.WND; }
 
-  void reno_increase_cwnd(uint16_t n);
+  void reno_increase_cwnd(const uint16_t n)
+  { cb.cwnd += std::min(n, SMSS()); }
 
-  void reno_deflate_cwnd(uint16_t n);
+  void reno_deflate_cwnd(const uint16_t n)
+  { cb.cwnd -= (n >= SMSS()) ? n-SMSS() : n; }
 
   void reduce_ssthresh();
 
@@ -869,7 +874,8 @@ private:
   void timewait_restart();
 
   /** When timewait timer times out */
-  void timewait_timeout();
+  void timewait_timeout()
+  { signal_close(); }
 
   /** Wether to use Delayed ACK or not */
   bool use_dack() const;

--- a/api/net/tcp/listener.hpp
+++ b/api/net/tcp/listener.hpp
@@ -41,7 +41,7 @@ public:
 
 public:
 
-  Listener(TCP& host, port_t port);
+  Listener(TCP& host, port_t port, ConnectCallback cb = nullptr);
 
   Listener& on_accept(AcceptCallback cb)
   {
@@ -55,8 +55,7 @@ public:
     return *this;
   }
 
-  bool syn_queue_full() const
-  { return syn_queue_.size() >= max_syn_backlog; }
+  bool syn_queue_full() const;
 
   /**
    * @brief Returns the local socket identified with this Listener
@@ -66,7 +65,7 @@ public:
    */
   Socket local() const;
 
-  port_t port() const
+  constexpr port_t port() const
   { return port_; }
 
   auto syn_queue_size() const
@@ -102,8 +101,6 @@ private:
   CloseCallback _on_close_;
 
   bool default_on_accept(Socket);
-
-  void default_on_connect(Connection_ptr);
 
   void segment_arrived(Packet_ptr);
 

--- a/api/net/tcp/options.hpp
+++ b/api/net/tcp/options.hpp
@@ -36,6 +36,7 @@ struct Option {
     END = 0x00, // End of option list
     NOP = 0x01, // No-Opeartion
     MSS = 0x02, // Maximum Segment Size [RFC 793] Rev: [879, 6691]
+    WS  = 0x03, // Window Scaling [RFC 7323] p. 8
   };
 
   static std::string kind_string(Kind kind) {
@@ -43,19 +44,36 @@ struct Option {
     case MSS:
       return {"MSS"};
 
+    case WS:
+      return {"WS"};
+
     default:
       return {"Unknown Option"};
     }
   }
 
   struct opt_mss {
-    uint8_t kind;
-    uint8_t length;
+    uint8_t kind    {MSS};
+    uint8_t length  {4};
     uint16_t mss;
 
     opt_mss(uint16_t mss)
-      : kind(MSS), length(4), mss(htons(mss)) {}
-  };
+      : mss(htons(mss)) {}
+
+  } __attribute__((packed));
+
+  /**
+   * @brief      Window Scaling option [RFC 7323] p. 8
+   */
+  struct opt_ws {
+    uint8_t kind    {WS};
+    uint8_t length  {3};
+    uint8_t shift_cnt;
+
+    opt_ws(uint8_t shift)
+      : shift_cnt{shift} {}
+
+  } __attribute__((packed));
 
   struct opt_timestamp {
     uint8_t kind;

--- a/api/net/tcp/options.hpp
+++ b/api/net/tcp/options.hpp
@@ -28,16 +28,18 @@ namespace tcp {
   TCP Header Option
 */
 struct Option {
-  uint8_t kind;
-  uint8_t length;
-  uint8_t data[0];
 
   enum Kind {
     END = 0x00, // End of option list
     NOP = 0x01, // No-Opeartion
     MSS = 0x02, // Maximum Segment Size [RFC 793] Rev: [879, 6691]
     WS  = 0x03, // Window Scaling [RFC 7323] p. 8
+    TS  = 0x08, // Timestamp [RFC 7323] p. 11
   };
+
+  const uint8_t kind    {END};
+  const uint8_t length  {0};
+  uint8_t               data[0];
 
   static std::string kind_string(Kind kind) {
     switch(kind) {
@@ -45,7 +47,10 @@ struct Option {
       return {"MSS"};
 
     case WS:
-      return {"WS"};
+      return {"Window Scaling"};
+
+    case TS:
+      return {"Timestamp"};
 
     default:
       return {"Unknown Option"};
@@ -53,11 +58,11 @@ struct Option {
   }
 
   struct opt_mss {
-    uint8_t kind    {MSS};
-    uint8_t length  {4};
-    uint16_t mss;
+    const uint8_t   kind    {MSS};
+    const uint8_t   length  {4};
+    const uint16_t  mss;
 
-    opt_mss(uint16_t mss)
+    opt_mss(const uint16_t mss)
       : mss(htons(mss)) {}
 
   } __attribute__((packed));
@@ -66,21 +71,27 @@ struct Option {
    * @brief      Window Scaling option [RFC 7323] p. 8
    */
   struct opt_ws {
-    uint8_t kind    {WS};
-    uint8_t length  {3};
-    uint8_t shift_cnt;
+    const uint8_t kind    {WS};
+    const uint8_t length  {3};
+    const uint8_t shift_cnt;
 
-    opt_ws(uint8_t shift)
+    opt_ws(const uint8_t shift)
       : shift_cnt{shift} {}
 
   } __attribute__((packed));
 
-  struct opt_timestamp {
-    uint8_t kind;
-    uint8_t length;
-    uint32_t ts_val;
-    uint32_t ts_ecr;
-  };
+  struct opt_ts {
+    const uint8_t   kind    {TS};
+    const uint8_t   length  {10};
+    const uint32_t  val;
+    const uint32_t  ecr;
+
+    opt_ts(const uint32_t val, const uint32_t echo)
+      : val{htonl(val)},
+        ecr{htonl(echo)}
+    {}
+
+  } __attribute__((packed));
 
 }; // < struct Option
 

--- a/api/net/tcp/packet.hpp
+++ b/api/net/tcp/packet.hpp
@@ -201,9 +201,21 @@ public:
     assert(!has_tcp_data());
     // option address
     auto* addr = tcp_options()+tcp_options_length();
-    new (addr) T(args...);
+    // emplace the option
+    const auto& opt = *(new (addr) T(args...));
+
+    // find number of NOP to pad with
+    const auto nops = opt.length % 4;
+    if(nops) {
+      struct NOP {
+        uint8_t kind{0x01};
+      };
+      new (addr + opt.length) NOP[nops];
+    }
+
     // update offset
-    set_offset(offset() + round_up( ((T*)addr)->length, 4 ));
+    set_offset(offset() + round_up(opt.length, 4));
+
     set_length(); // update
   }
 

--- a/api/net/tcp/tcp.hpp
+++ b/api/net/tcp/tcp.hpp
@@ -126,16 +126,32 @@ namespace net {
     { return connections_.size(); }
 
     /*
-      Maximum Segment Lifetime
-    */
-    auto MSL() const
-    { return MAX_SEG_LIFETIME; }
-
-    /*
       Set Maximum Segment Lifetime
     */
     void set_MSL(const std::chrono::milliseconds msl)
-    { MAX_SEG_LIFETIME = msl; }
+    { max_seg_lifetime_ = msl; }
+
+    /*
+      Maximum Segment Lifetime
+    */
+    auto MSL() const
+    { return max_seg_lifetime_; }
+
+    /**
+     * @brief      Sets the dack. [RFC 1122] (p.96)
+     *
+     * @param[in]  dack_timeout  The dack timeout
+     */
+    void set_DACK(const std::chrono::milliseconds dack_timeout)
+    { delayed_ack_timeout_ = dack_timeout; }
+
+    /**
+     * @brief      Returns the delayed ACK timeout (ms)
+     *
+     * @return     time to wait before sending an ACK
+     */
+    auto DACK_timeout() const
+    { return delayed_ack_timeout_; }
 
     /*
       Maximum Segment Size
@@ -188,7 +204,10 @@ namespace net {
     */
     tcp::port_t current_ephemeral_;
 
-    std::chrono::milliseconds MAX_SEG_LIFETIME;
+    // Maximum segment lifetime (this affects TIME-WAIT period - a connection will be closed after 2*MSL)
+    std::chrono::milliseconds max_seg_lifetime_;
+    // Delayed ACK timeout - how long should we wait with sending an ACK
+    std::chrono::milliseconds delayed_ack_timeout_;
 
     /*
       Transmit packet to network layer (IP).

--- a/api/net/tcp/tcp.hpp
+++ b/api/net/tcp/tcp.hpp
@@ -19,7 +19,6 @@
 #ifndef NET_TCP_HPP
 #define NET_TCP_HPP
 
-#include <chrono> // timer duration
 #include <map>
 #include <net/inet.hpp>
 #include <net/util.hpp> // net::Packet_ptr

--- a/api/net/tcp/tcp.hpp
+++ b/api/net/tcp/tcp.hpp
@@ -196,6 +196,11 @@ namespace net {
     constexpr bool uses_wscale() const
     { return wscale_ > 0; }
 
+    void set_timestamps(bool active)
+    { timestamps_ = active; }
+
+    constexpr bool uses_timestamps() const
+    { return timestamps_; }
 
     /**
      * @brief      Sets the dack. [RFC 1122] (p.96)
@@ -265,6 +270,8 @@ namespace net {
     uint32_t                  win_size_;
     /** Window scale factor [RFC 7323] p. 8 */
     uint8_t                   wscale_;
+    /** Timestamp option active [RFC 7323] p. 11 */
+    bool                      timestamps_;
     /** Delayed ACK timeout - how long should we wait with sending an ACK */
     std::chrono::milliseconds dack_timeout_;
     /** Maximum SYN queue backlog */
@@ -299,6 +306,8 @@ namespace net {
       Check if the port is in use either among "listeners" or "connections"
     */
     bool port_in_use(const tcp::port_t) const;
+
+    uint32_t get_ts_value() const;
 
     /*
       Packet is dropped.

--- a/examples/demo_service/service.cpp
+++ b/examples/demo_service/service.cpp
@@ -104,13 +104,13 @@ void Service::start(const std::string&)
 
   // Add a TCP connection handler - here a hardcoded HTTP-service
   server.on_connect(
-  [] (auto conn) {
+  [] (net::tcp::Connection_ptr conn) {
     printf("<Service> @on_connect: Connection %s successfully established.\n",
       conn->remote().to_string().c_str());
     // read async with a buffer size of 1024 bytes
     // define what to do when data is read
     conn->on_read(1024,
-    [conn] (auto buf, size_t n)
+    [conn] (net::tcp::buffer_t buf, size_t n)
     {
       printf("<Service> @on_read: %u bytes received.\n", n);
       try

--- a/src/net/tcp/tcp.cpp
+++ b/src/net/tcp/tcp.cpp
@@ -41,7 +41,8 @@ TCP::TCP(IPStack& inet) :
   connections_(),
   writeq(),
   current_ephemeral_{new_ephemeral_port()}, // TODO: RFC 6056
-  MAX_SEG_LIFETIME(30s)
+  max_seg_lifetime_{30s},
+  delayed_ack_timeout_{40ms}
 {
   inet.on_transmit_queue_available({this, &TCP::process_writeq});
   // TODO: RFC 6056
@@ -158,7 +159,7 @@ uint16_t TCP::checksum(const tcp::Packet& packet)
 {
   short length = packet.tcp_length();
   // Compute sum of pseudo-header
-  uint32_t sum = 
+  uint32_t sum =
         (packet.src().whole >> 16)
       + (packet.src().whole & 0xffff)
       + (packet.dst().whole >> 16)

--- a/src/net/tcp/tcp.cpp
+++ b/src/net/tcp/tcp.cpp
@@ -22,6 +22,7 @@
 #include <net/tcp/packet.hpp>
 #include <net/inet_common.hpp>
 #include <statman>
+#include <os>
 
 using namespace std;
 using namespace net;
@@ -36,6 +37,7 @@ TCP::TCP(IPStack& inet) :
   max_seg_lifetime_{default_msl},       // 30s
   win_size_{default_ws_window_size},    // 8096*1024
   wscale_{default_window_scaling},      // 5
+  timestamps_{default_timestamps},      // true
   dack_timeout_{default_dack_timeout},  // 40ms
   max_syn_backlog_{default_max_syn_backlog}, // 64
   bytes_rx_{Statman::get().create(Stat::UINT64, inet.ifname() + ".tcp.bytes_rx").get_uint64()},
@@ -144,6 +146,11 @@ bool TCP::port_in_use(const port_t port) const {
       return true;
   }
   return false;
+}
+
+uint32_t TCP::get_ts_value() const
+{
+  return static_cast<uint32_t>(OS::micros_since_boot());
 }
 
 uint16_t TCP::checksum(const tcp::Packet& packet)

--- a/src/net/tcp/tcp.cpp
+++ b/src/net/tcp/tcp.cpp
@@ -28,6 +28,16 @@ using namespace net;
 using namespace net::tcp;
 
 TCP::TCP(IPStack& inet) :
+  inet_{inet},
+  listeners_(),
+  connections_(),
+  writeq(),
+  current_ephemeral_{new_ephemeral_port()}, // TODO: Verify RFC 6056
+  max_seg_lifetime_{default_msl},       // 30s
+  win_size_{default_ws_window_size},    // 8096*1024
+  wscale_{default_window_scaling},      // 5
+  dack_timeout_{default_dack_timeout},  // 40ms
+  max_syn_backlog_{default_max_syn_backlog}, // 64
   bytes_rx_{Statman::get().create(Stat::UINT64, inet.ifname() + ".tcp.bytes_rx").get_uint64()},
   bytes_tx_{Statman::get().create(Stat::UINT64, inet.ifname() + ".tcp.bytes_tx").get_uint64()},
   packets_rx_{Statman::get().create(Stat::UINT64, inet.ifname() + ".tcp.packets_rx").get_uint64()},
@@ -35,17 +45,12 @@ TCP::TCP(IPStack& inet) :
   incoming_connections_{Statman::get().create(Stat::UINT64, inet.ifname() + ".tcp.incoming_connections").get_uint64()},
   outgoing_connections_{Statman::get().create(Stat::UINT64, inet.ifname() + ".tcp.outgoing_connections").get_uint64()},
   connection_attempts_{Statman::get().create(Stat::UINT64, inet.ifname() + ".tcp.connection_attempts").get_uint64()},
-  packets_dropped_{Statman::get().create(Stat::UINT32, inet.ifname() + ".tcp.packets_dropped").get_uint32()},
-  inet_(inet),
-  listeners_(),
-  connections_(),
-  writeq(),
-  current_ephemeral_{new_ephemeral_port()}, // TODO: RFC 6056
-  max_seg_lifetime_{30s},
-  delayed_ack_timeout_{40ms}
+  packets_dropped_{Statman::get().create(Stat::UINT32, inet.ifname() + ".tcp.packets_dropped").get_uint32()}
 {
+  Expects(wscale_ <= 14 && "WScale factor cannot exceed 14");
+  Expects(win_size_ <= 0x40000000 && "Invalid size");
+
   inet.on_transmit_queue_available({this, &TCP::process_writeq});
-  // TODO: RFC 6056
 }
 
 /*
@@ -59,25 +64,18 @@ TCP::TCP(IPStack& inet) :
   Current solution:
   Simple.
 */
-Listener& TCP::bind(const port_t port) {
-  // Already a listening socket.
+Listener& TCP::bind(const port_t port, ConnectCallback cb)
+{
   Listeners::const_iterator it = listeners_.find(port);
+  // Already a listening socket.
   if(it != listeners_.cend()) {
     throw TCPException{"Port is already taken."};
   }
   auto& listener = listeners_.emplace(port,
-    std::make_unique<tcp::Listener>(*this, port)
+    std::make_unique<tcp::Listener>(*this, port, std::move(cb))
     ).first->second;
   debug("<TCP::bind> Bound to port %i \n", port);
   return *listener;
-
-  /*auto& listener = (listeners_.emplace(std::piecewise_construct,
-    std::forward_as_tuple(port),
-    std::forward_as_tuple(*this, port))
-    ).first->second;
-  debug("<TCP::bind> Bound to port %i \n", port);
-
-  return listener;*/
 }
 
 bool TCP::unbind(const port_t port) {
@@ -91,12 +89,6 @@ bool TCP::unbind(const port_t port) {
   return false;
 }
 
-/*
-  Active open a new connection to the given remote.
-
-  @WARNING: Callback is added when returned (TCP::connect(...).onSuccess(...)),
-  and open() is called before callback is added.
-*/
 Connection_ptr TCP::connect(Socket remote) {
   auto port = next_free_port();
   auto connection = add_connection(port, remote);
@@ -104,13 +96,10 @@ Connection_ptr TCP::connect(Socket remote) {
   return connection;
 }
 
-/*
-  Active open a new connection to the given remote.
-*/
-void TCP::connect(Socket remote, Connection::ConnectCallback callback) {
+void TCP::connect(Socket remote, ConnectCallback callback) {
   auto port = next_free_port();
-  auto connection = add_connection(port, remote);
-  connection->on_connect(callback).open(true);
+  auto connection = add_connection(port, remote, std::move(callback));
+  connection->open(true);
 }
 
 void TCP::insert_connection(Connection_ptr conn)
@@ -132,7 +121,9 @@ seq_t TCP::generate_iss() {
 */
 port_t TCP::next_free_port() {
 
-  current_ephemeral_ = (current_ephemeral_ == port_ranges::DYNAMIC_END) ? port_ranges::DYNAMIC_START : current_ephemeral_ + 1;
+  current_ephemeral_ = (current_ephemeral_ == port_ranges::DYNAMIC_END)
+    ? port_ranges::DYNAMIC_START
+    : current_ephemeral_ + 1;
 
   // Avoid giving a port that is bound to a service.
   while(listeners_.find(current_ephemeral_) != listeners_.end())
@@ -279,13 +270,15 @@ string TCP::to_string() const {
   return ss.str();
 }
 
-Connection_ptr TCP::add_connection(port_t local_port, Socket remote) {
+Connection_ptr TCP::add_connection(port_t local_port, Socket remote, ConnectCallback cb)
+{
   // Stat increment number of outgoing connections
   outgoing_connections_++;
 
   auto& conn = (connections_.emplace(
       Connection::Tuple{ local_port, remote },
-      std::make_shared<Connection>(*this, local_port, remote))
+      std::make_shared<Connection>(*this, local_port, remote, std::move(cb))
+      )
     ).first->second;
   conn->_on_cleanup({this, &TCP::close_connection});
   return conn;

--- a/src/net/tcp/write_queue.cpp
+++ b/src/net/tcp/write_queue.cpp
@@ -84,6 +84,9 @@ void Write_queue::acknowledge(size_t bytes)
 
 void Write_queue::reset()
 {
+  if(offset_ > 0 and on_write_ != nullptr)
+    on_write_(offset_);
+
   q.clear();
   current_ = 0;
   debug("<WriteQueue::reset> Reset\n");

--- a/test/net/integration/tcp/service.cpp
+++ b/test/net/integration/tcp/service.cpp
@@ -109,7 +109,7 @@ void OUTGOING_TEST(tcp::Socket outgoing) {
 
     conn->write(small);
 
-    conn->on_disconnect([](auto conn, tcp::Connection::Disconnect) {
+    conn->on_disconnect([](tcp::Connection_ptr conn, tcp::Connection::Disconnect) {
       CHECK(true, "Connection closed by server");
       CHECKSERT(conn->is_state({"CLOSE-WAIT"}), "State: CLOSE-WAIT");
       conn->close();
@@ -182,7 +182,7 @@ void Service::start(const std::string&)
   CHECK(tcp.open_ports() == 0, "No (0) open ports (listening connections)");
   CHECK(tcp.active_connections() == 0, "No (0) active connections");
 
-  tcp.bind(TEST1).on_connect([](auto conn) {
+  tcp.bind(TEST1).on_connect([](tcp::Connection_ptr conn) {
       INFO("Test 1", "SMALL string (%u)", small.size());
       conn->on_read(small.size(), [conn](tcp::buffer_t buffer, size_t n) {
           CHECKSERT(std::string((char*)buffer.get(), n) == small, "Received SMALL");
@@ -200,7 +200,7 @@ void Service::start(const std::string&)
   /*
     TEST: Send and receive big string.
   */
-  tcp.bind(TEST2).on_connect([](auto conn) {
+  tcp.bind(TEST2).on_connect([](tcp::Connection_ptr conn) {
       INFO("Test 2", "BIG string (%u)", big.size());
       auto response = std::make_shared<std::string>();
       conn->on_read(big.size(),
@@ -219,7 +219,7 @@ void Service::start(const std::string&)
   /*
     TEST: Send and receive huge string.
   */
-  tcp.bind(TEST3).on_connect([](auto conn) {
+  tcp.bind(TEST3).on_connect([](tcp::Connection_ptr conn) {
       INFO("Test 3", "HUGE string (%u)", huge.size());
       auto temp = std::make_shared<Buffer>(huge.size());
       conn->on_read(16384, [temp, conn](tcp::buffer_t buffer, size_t n) {
@@ -249,7 +249,7 @@ void Service::start(const std::string&)
   /*
     TEST: Connection (Status etc.) and Active Close
   */
-  tcp.bind(TEST4).on_connect([](auto conn) {
+  tcp.bind(TEST4).on_connect([](tcp::Connection_ptr conn) {
       INFO("Test 4","Connection/TCP state");
       // There should be at least one connection.
       CHECKSERT(Inet4::stack<0>().tcp().active_connections() > 0, "There is (>0) open connection(s)");

--- a/test/net/unit/tcp_write_queue.cpp
+++ b/test/net/unit/tcp_write_queue.cpp
@@ -200,7 +200,7 @@ CASE("Creating a WriteQueue and operate it")
                 {
                   wq.reset();
 
-                  THEN("The queue is empty and on write has returned correct values on the fully completed ones [1000, 1000]")
+                  THEN("The queue is empty and on write has returned correct values on the fully/half completed ones [1000, 1000, 500]")
                   {
                     EXPECT( wq.empty() );
                     EXPECT( wq.size() == 0u );
@@ -212,7 +212,7 @@ CASE("Creating a WriteQueue and operate it")
 
                     EXPECT( written[0] == 1000u );
                     EXPECT( written[1] == 1000u );
-                    EXPECT( written[2] == 0u );
+                    EXPECT( written[2] == 500u );
                     EXPECT( written[3] == 0u );
                     EXPECT( written[4] == 0u );
 

--- a/test/stress/service.cpp
+++ b/test/stress/service.cpp
@@ -109,7 +109,7 @@ void Service::start(const std::string&)
     printf("Recv: %llu Sent: %llu\n", TCP_BYTES_RECV, TCP_BYTES_SENT);
   });
 */
-  server_mem.on_connect([] (auto conn) {
+  server_mem.on_connect([] (net::tcp::Connection_ptr conn) {
       conn->on_read(1024, [conn](net::tcp::buffer_t buf, size_t n) {
           TCP_BYTES_RECV += n;
           // create string from buffer
@@ -122,7 +122,7 @@ void Service::start(const std::string&)
           });
           conn->write(reply);
 
-          conn->on_disconnect([](auto c, auto){
+          conn->on_disconnect([](net::tcp::Connection_ptr c, auto){
               c->close();
             });
         });
@@ -131,7 +131,7 @@ void Service::start(const std::string&)
 
 
   // Add a TCP connection handler - here a hardcoded HTTP-service
-  server.on_connect([] (auto conn) {
+  server.on_connect([] (net::tcp::Connection_ptr conn) {
         // read async with a buffer size of 1024 bytes
         // define what to do when data is read
         conn->on_read(1024, [conn](net::tcp::buffer_t buf, size_t n) {


### PR DESCRIPTION
**DACK**  (RFC 1122 p96):
More or less reduces outgoing packets with 50% when only receiving data. Tho not much of a performance gain since stopping and creating timers seems to cost just as much.
Default timeout set to `40ms` (maybe this is too low). Can be changed in application: `tcp().set_DACK(100ms);` A value of `0` will turn delayed ACK off.

**Window Scaling** (RFC 7323):
Receive and send window can now exceed 64KB, which means more data can be in flight. (Up to 1GB). Default is set to **256 KB** for trying it out. Gives a lot of performance when sending, not any when receiving (less depending on the window set..). 

**TCP Configure**:
The TCP instance that spawn new connections are now more configurable (still using default values set in `tcp/common.hpp`):
```
tcp.set_window_size(8192, 5); // 8192 bytes * 2^5 == 256 KB
// or to be used separatly
tcp.set_window_size(262144); // 256 KB, caps at 65535 without WS
tcp.set_wscale(5); // use scale 5
tcp.set_wscale(0); // don't use window scaling
tcp.set_syn_backlog(64); // allow maximum 64 outstanding connection attempts
```

**Timestamps** (RFC 7323):
Now negotiates timestamp option on handshake. Need to do some heavy refactoring to make it fully complete. Can be turned off with `tcp.set_timestamps(false);`.