### PR TITLE
Fix python version in boot for mac default installation

### DIFF
--- a/etc/boot
+++ b/etc/boot
@@ -1,4 +1,7 @@
-#!/usr/bin/env python2
+#!/bin/sh
+''''which python2 >/dev/null 2>&1 && exec python2 "$0" "$@" # '''
+''''which python  >/dev/null 2>&1 && exec python  "$0" "$@" # '''
+''''exec echo "Error: I can't find python anywhere"         # '''
 
 import os
 import sys


### PR DESCRIPTION
#837 and #1129 Broke the default mac installation as `python2` is not a valid command. This fixes that issue as it gives you a backup if `python2` does not exist. 