### PR TITLE
Install: Start of new install script

### DIFF
--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -31,8 +31,8 @@ case $SYSTEM in
                 DEPENDENCIES="curl make clang-$clang_version nasm bridge-utils qemu jq python-jsonschema python-psutil cmake $DEPENDENCIES"
                 echo ">>> Installing dependencies (requires sudo):"
                 echo "    Packages: $DEPENDENCIES"
-                sudo apt-get -q update || exit 1
-                sudo apt-get -q install -y $DEPENDENCIES || exit 1
+                sudo apt-get -qq update || exit 1
+                sudo apt-get -qqy install $DEPENDENCIES > /dev/null || exit 1
                 exit 0;
                 ;;
             "fedora")

--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -31,8 +31,8 @@ case $SYSTEM in
                 DEPENDENCIES="curl make clang-$clang_version nasm bridge-utils qemu jq python-jsonschema python-psutil cmake $DEPENDENCIES"
                 echo ">>> Installing dependencies (requires sudo):"
                 echo "    Packages: $DEPENDENCIES"
-                sudo apt-get update || exit 1
-                sudo apt-get install -y $DEPENDENCIES || exit 1
+                sudo apt-get -q update || exit 1
+                sudo apt-get -q install -y $DEPENDENCIES || exit 1
                 exit 0;
                 ;;
             "fedora")

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -16,6 +16,10 @@ set -e
 INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
 INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
 
+echo SRC: $INCLUDEOS_SRC
+echo PREFIX: $INCLUDEOS_PREFIX
+
+
 # Try to find suitable compiler
 cc_list="clang-3.9 clang-3.8 clang-3.7 clang-3.6 clang"
 cxx_list="clang++-3.9 clang++-3.8 clang++-3.7 clang++-3.6 clang++"

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -33,13 +33,13 @@ guess_compiler() {
 
 if [ -z "$CC" ]
 then
-	guess_compiler $cc_list
+	guess_compiler "$cc_list"
 	export CC=$compiler
 fi
 
 if [ -z "$CXX" ]
 then
-	guess_compiler $cxx_list
+	guess_compiler "$cxx_list"
 	export CXX=$compiler
 fi
 

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -16,10 +16,6 @@ set -e
 INCLUDEOS_SRC=${INCLUDEOS_SRC-$HOME/IncludeOS}
 INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
 
-echo SRC: $INCLUDEOS_SRC
-echo PREFIX: $INCLUDEOS_PREFIX
-
-
 # Try to find suitable compiler
 cc_list="clang-3.9 clang-3.8 clang-3.7 clang-3.6 clang"
 cxx_list="clang++-3.9 clang++-3.8 clang++-3.7 clang++-3.6 clang++"
@@ -28,11 +24,8 @@ compiler=""
 guess_compiler() {
     for compiler in $1
     do
-	exists=`command -v $compiler`
-	if [ "$exists" != "" ]
-	then
-	    compiler=$exists
-	    break
+		if command -v $compiler; then
+			break
 	fi
     done
 }
@@ -40,14 +33,14 @@ guess_compiler() {
 
 if [ -z "$CC" ]
 then
-  guess_compiler $cc_list
-  export CC=$compiler
+	guess_compiler $cc_list
+	export CC=$compiler
 fi
 
 if [ -z "$CXX" ]
 then
-  guess_compiler $cxx_list
-  export CXX=$compiler
+	guess_compiler $cxx_list
+	export CXX=$compiler
 fi
 
 echo -e "\n\n>>> Best guess for compatible compilers: $CXX / $CC"

--- a/etc/scripts/create_bridge.sh
+++ b/etc/scripts/create_bridge.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-echo ">>> Creating network bridge for IncludeOS "
+echo "    Creating network bridge for IncludeOS "
 
 if [ $# -eq 0 ]
 then
-  echo ">>> Using default settings "
+  echo "    Using default settings "
   BRIDGE=bridge43
   NETMASK=255.255.0.0
   GATEWAY=10.0.0.1
@@ -21,7 +21,7 @@ else
   exit 1
 fi
 
-echo ">>> Creating bridge $BRIDGE, netmask $NETMASK, gateway $GATEWAY "
+echo "    Creating bridge $BRIDGE, netmask $NETMASK, gateway $GATEWAY "
 
 # Håreks cool hack:
 # - First two bytes is fixed to "c001" because it's cool
@@ -35,10 +35,10 @@ DHCPRANGE=10.0.0.2,10.0.0.254
 # Check if bridge is created
 if uname -s | grep Darwin > /dev/null 2>&1; then  # Check if on Mac
   if ifconfig $BRIDGE 2>&1 | grep -q "does not exist"; then
-    echo ">>> Creating network bridge (requires sudo):"
+    echo "    Creating network bridge (requires sudo):"
     sudo ifconfig $BRIDGE create || exit 1
   else
-    echo ">>> Network bridge already created"
+    echo "    Network bridge already created"
   fi
 else
   BRSHOW="brctl show"
@@ -50,29 +50,29 @@ else
 
   # Check if bridge already is created
   if $BRSHOW $BRIDGE 2>&1 | grep -qE "No such device|bridge $BRIDGE does not exist"; then
-    echo ">>> Creating network bridge (requires sudo):"
+    echo "    Creating network bridge (requires sudo):"
     sudo brctl addbr $BRIDGE || exit 1
   else
-    echo ">>> Network bridge already created"
+    echo "    Network bridge already created"
   fi
 fi
 
 # Check if bridge is configured
 #if ip -o link show $BRIDGE | grep -q "$HWADDR"; then
 if ifconfig $BRIDGE | grep -q "$HWADDR"; then
-  echo ">>> Network bridge already configured"
+  echo "    Network bridge already configured"
 
   # Make sure that the bridge is activated
   #if ip -o link show $BRIDGE | grep -q "UP"; then
   if ifconfig $BRIDGE | grep -q "UP"; then
-    echo ">>> Network bridge already activated"
+    echo "    Network bridge already activated"
   else
-    echo ">>> Activating network bridge (requires sudo):"
+    echo "    Activating network bridge (requires sudo):"
     sudo ifconfig $BRIDGE up || exit 1
   fi
 else
   # Configure and activate bridge
-  echo ">>> Configuring network bridge (requires sudo):"
+  echo "    Configuring network bridge (requires sudo):"
 
   sudo ifconfig $BRIDGE $GATEWAY netmask $NETMASK up || exit 1
   if uname -s | grep Darwin > /dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ############################################################
 # OPTIONS:
@@ -133,6 +133,12 @@ if tty -s; then
 	esac
 fi
 
+# Trap that cleans the cmake output file in case of exit
+function clean {
+	rm /tmp/cmake_output.txt
+} 
+trap clean EXIT
+
 # if the --all-source parameter was given, build it the hard way
 if [ "$1" = "--all-source" ]; then
     printf "\n\n>>> Installing everything from source"
@@ -141,8 +147,9 @@ if [ "$1" = "--all-source" ]; then
 				"Could not install from source."
 	fi
 else
-    printf "\n\n>>> Calling install_from_bundle.sh script"
-    if ! ./etc/install_from_bundle.sh; then
+	printf "\n\n>>> Running install_from_bundle.sh (expect up to 3 minutes)\n"
+    if ! ./etc/install_from_bundle.sh &> /tmp/cmake_output.txt; then
+		cat /tmp/cmake_output.txt	# Print output because it failed
         printf  "%s\n" ">>> Sorry <<<"\
 				"Could not install from bundle."
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -72,12 +72,18 @@ if ! command -v sudo > /dev/null 2>&1; then
     exit 1
 fi
 
-# now install build requirements (compiler, etc). This was moved into
-# a function of its own as it can easen the setup.
-if ! ./etc/install_build_requirements.sh $SYSTEM $RELEASE; then
-    printf "%s\n" ">>> Sorry <<<"\
-		   "Could not install build requirements."
-    exit 1
+# Install build requirements (compiler, etc) 
+if [ "Darwin" = "$SYSTEM" ]; then
+    if ! ./etc/install_osx.sh; then
+		printf "%s\n" ">>> Sorry <<<"\
+			   "Could not install osx dependencies"
+	fi
+else
+	if ! ./etc/install_build_requirements.sh $SYSTEM $RELEASE; then
+		printf "%s\n" ">>> Sorry <<<"\
+			   "Could not install build requirements."
+		exit 1
+	fi
 fi
 
 ############################################################
@@ -126,32 +132,21 @@ if tty -s; then
 	esac
 fi
 
-# if the --all-source parameter was given, build it the hard way
-if [ "$1" = "--all-source" ]; then
-    printf "\n\n>>> Installing everything from source"
-    ./etc/install_all_source.sh
+printf "\n\n>>> Calling install_from_bundle.sh script"
+if ! ./etc/install_from_bundle.sh; then
+	printf  "%s\n" ">>> Sorry <<<"\
+			"Could not install from bundle."
+	exit 1
+fi
 
-elif [ "Darwin" = "$SYSTEM" ]; then
-    # TODO: move build dependencies to the install build requirements step
-    ./etc/install_osx.sh
-
-elif [ "Linux" = "$SYSTEM" ]; then
-    printf "\n\n>>> Calling install_from_bundle.sh script"
-    if ! ./etc/install_from_bundle.sh; then
-        printf  "%s\n" ">>> Sorry <<<"\
-				"Could not install from bundle."
-        exit 1
-    fi
-
-	# Installing network bridge
+if [ "Linux" = "$SYSTEM" ]; then
+	# Install network bridge
     printf "\n\n>>> Installing network bridge\n"
     if ! ./etc/scripts/create_bridge.sh; then
         printf "%s\n" ">>> Sorry <<<"\
 			   "Could not create or configure bridge."
         exit 1
     fi
-
-
 fi
 
 ############################################################

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,19 @@
 #!/bin/sh
 
+############################################################
 # OPTIONS:
-#
-# Location of the IncludeOS repo (assumes current folder if not defined), e.g.:
-# $ export INCLUDEOS_SRC=your/github/cloned/IncludeOS
+############################################################
+
+# Location of the IncludeOS repo (assumes current folder if not defined)
 export INCLUDEOS_SRC=${INCLUDEOS_SRC-`pwd`}
+echo INCLUDEOS_SRC=$INCLUDEOS_SRC
+# Prefered install location (assumes /usr/local/ if not defined)
+export INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
+echo INCLUDEOS_PREFIX=$INCLUDEOS_PREFIX
+
+############################################################
+# SYSTEM PROPERTIES:
+############################################################
 
 SYSTEM=`uname -s`
 

--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,12 @@ fi
 # INSTALL INCLUDEOS:
 ############################################################
 
+# Perform a check of required environment variables
+export INCLUDEOS_SRC=${INCLUDEOS_SRC-`pwd`}	# IncludeOS src repo
+export INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}	# Install location
+export CC=${CC-clang-3.8}
+export CXX=${CXX-clang++-3.8}
+
 # if the --all-source parameter was given, build it the hard way
 if [ "$1" = "--all-source" ]; then
     echo ">>> Installing everything from source"

--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,8 @@
 
 # Location of the IncludeOS repo (assumes current folder if not defined)
 export INCLUDEOS_SRC=${INCLUDEOS_SRC-`pwd`}
-echo INCLUDEOS_SRC=$INCLUDEOS_SRC
 # Prefered install location (assumes /usr/local/ if not defined)
 export INCLUDEOS_PREFIX=${INCLUDEOS_PREFIX-/usr/local}
-echo INCLUDEOS_PREFIX=$INCLUDEOS_PREFIX
 
 ############################################################
 # SYSTEM PROPERTIES:
@@ -51,13 +49,6 @@ check_os_support() {
     return 1;
 }
 
-# check if sudo is available
-if ! command -v sudo > /dev/null 2>&1; then
-    echo -e ">>> Sorry <<< \n\
-The command sudo was not found. \n"
-    exit 1
-fi
-
 # check if system is supported at all
 if ! check_os_support $SYSTEM $RELEASE; then
     echo -e ">>> Sorry <<< \n\
@@ -69,6 +60,17 @@ a look at\n \
     exit 1
 fi
 
+############################################################
+# DEPENDENCIES:
+############################################################
+
+# check if sudo is available
+if ! command -v sudo > /dev/null 2>&1; then
+    echo -e ">>> Sorry <<< \n\
+The command sudo was not found. \n"
+    exit 1
+fi
+
 # now install build requirements (compiler, etc). This was moved into
 # a function of its own as it can easen the setup.
 if ! ./etc/install_build_requirements.sh $SYSTEM $RELEASE; then
@@ -76,6 +78,10 @@ if ! ./etc/install_build_requirements.sh $SYSTEM $RELEASE; then
 Could not install build requirements. \n"
     exit 1
 fi
+
+############################################################
+# INSTALL INCLUDEOS:
+############################################################
 
 # if the --all-source parameter was given, build it the hard way
 if [ "$1" = "--all-source" ]; then

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,28 @@ fi
 # INSTALL INCLUDEOS:
 ############################################################
 
-# Perform a check of required environment variables
+# Check if script has write permission to PREFIX location
+start_dir=$INCLUDEOS_PREFIX
+while [ "$start_dir" != "/" ]
+do	
+	if [ -d $start_dir ]; then	# If dir exists
+		if [ ! -w $start_dir ]; then	# If dir is not writable
+			printf "\n\n>>> IncludeOS can't be installed with the current options\n"
+			printf "    INCLUDEOS_PREFIX is set to %s\n" "$INCLUDEOS_PREFIX"
+			printf "    which is not a directory where you have write permissions.\n"
+			printf "    Either call install.sh with sudo or set INCLUDEOS_PREFIX\n"
+			exit 1
+		else
+			# Directory exists and is writable, continue install script
+			break
+		fi
+	else
+		# If directory is not yet created, check if parent dir is writeable
+		start_dir="$(dirname "$start_dir")"
+	fi
+done
+
+# Print currently set install options
 printf "\n\n>>> IncludeOS will be installed with the following options:\n\n"
 printf "%-25s %-25s %s\n"\
 	   "Env variable" "Description" "Value"\
@@ -93,6 +114,7 @@ printf "%-25s %-25s %s\n"\
 	   "INCLUDEOS_PREFIX" "Install location" "$INCLUDEOS_PREFIX"\
 	   "INCLUDEOS_ENABLE_TEST" "Enable test compilation" "$INCLUDEOS_ENABLE_TEST"
 
+# Give user option to evaluate install options
 if tty -s; then
 	read -p "Is this correct [Y|N]?" answer
 	case $answer in
@@ -132,6 +154,10 @@ elif [ "Linux" = "$SYSTEM" ]; then
 
 fi
 
+############################################################
+# INSTALL FINISHED:
+############################################################
+
 printf "\n\n>>> IncludeOS installation Done!\n" 
 printf "%s\n" "To use IncludeOS set env variables for cmake to know your compiler, e.g.:"\
 	   '    export CC="clang-3.8"'\
@@ -142,7 +168,7 @@ printf "%s\n" "To use IncludeOS set env variables for cmake to know your compile
 # Check if boot command is available
 if ! type boot > /dev/null 2>&1; then
 	printf "\nThe boot utility is not available, add IncludeOS to your path:\n"
-	printf "    export PATH=\$PATH:$INCLUDEOS_PREFIX/bin"
+	printf "    export PATH=\$PATH:$INCLUDEOS_PREFIX/bin\n"
 fi
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ############################################################
 # OPTIONS:
@@ -122,7 +122,7 @@ elif [ "Linux" = "$SYSTEM" ]; then
     fi
 
 	# Installing network bridge
-    printf "\n\n>>> Installing network bridge"
+    printf "\n\n>>> Installing network bridge\n"
     if ! ./etc/scripts/create_bridge.sh; then
         printf "%s\n" ">>> Sorry <<<"\
 			   "Could not create or configure bridge."
@@ -138,5 +138,12 @@ printf "%s\n" "To use IncludeOS set env variables for cmake to know your compile
 	   '    export CXX="clang++-3.8"'\
 	   ""\
 	   "Test your installation with ./test.sh"
+
+# Check if boot command is available
+if ! type boot > /dev/null 2>&1; then
+	printf "\nThe boot utility is not available, add IncludeOS to your path:\n"
+	printf "    export PATH=\$PATH:$INCLUDEOS_PREFIX/bin"
+fi
+
 
 exit 0

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,7 @@
 . ./etc/set_traps.sh
 
 pushd examples/demo_service
+rm -rf build
 mkdir -p build
 pushd build
 cmake ..


### PR DESCRIPTION
## Start of install script rewrite.

- Made parts of installation a lot quieter. Now only the cmake steps make noise. I'll look into suppressing output from this later.
- Fixed the function that guesses what compiler we have. It now works properly.
- When installing using terminal it now gives you a review of your install options and (y/n) prompt to continue.
- General reordering in install script and cleanup.

## When installing on a clean machine you have two options:
1. `sudo install.sh` and everything is installed in `/usr/local/includeos`
2. `install.sh` and you must set `INCLUDEOS_PREFIX`. If that is done everything is installed correctly. I created a prompt at the end urging the user to set `CC, CXX` and to add the `boot` utility to your `PATH`