### PR TITLE
Cache-aligned SMP per-cpu structures using std::array

### DIFF
--- a/api/kernel/irq_manager.hpp
+++ b/api/kernel/irq_manager.hpp
@@ -58,7 +58,7 @@ struct idt_loc {
 class alignas(SMP_ALIGN) IRQ_manager {
 public:
   typedef void (*intr_func) ();
-  typedef void (*exception_func) (uint32_t, uint32_t);
+  typedef void (*exception_func) (void**, uint32_t);
   using irq_delegate = delegate<void()>;
 
   static constexpr size_t  IRQ_LINES = 128;

--- a/api/kernel/irq_manager.hpp
+++ b/api/kernel/irq_manager.hpp
@@ -21,6 +21,7 @@
 #include <arch>
 #include <delegate>
 #include <membitmap>
+#include <smp>
 
 // From osdev
 struct IDTDescr {
@@ -35,10 +36,6 @@ struct idt_loc {
   uint16_t limit;
   uint32_t base;
 }__attribute__((packed));
-
-extern "C" {
-  void irq_default_handler();
-}
 
 #define IRQ_BASE          32
 
@@ -58,7 +55,7 @@ extern "C" {
 
     @TODO: Remove all dependencies on old SanOS code. In particular, eoi is now in global scope
 */
-class IRQ_manager {
+class alignas(SMP_ALIGN) IRQ_manager {
 public:
   typedef void (*intr_func) ();
   typedef void (*exception_func) (uint32_t, uint32_t);
@@ -132,8 +129,8 @@ public:
   /** Initialize for a local APIC */
   static void init(int cpuid);
 
-private:
   IRQ_manager() = default;
+private:
   IRQ_manager(IRQ_manager&) = delete;
   IRQ_manager(IRQ_manager&&) = delete;
   IRQ_manager& operator=(IRQ_manager&&) = delete;

--- a/api/net/link_layer.hpp
+++ b/api/net/link_layer.hpp
@@ -43,7 +43,7 @@ private:
 
 template <class Protocol>
 Link_layer<Protocol>::Link_layer(Protocol&& protocol, uint32_t bufstore_packets, uint16_t bufsz)
-  : hw::Nic(bufstore_packets, bufsz + Protocol::header_size()),
+  : hw::Nic(bufstore_packets, bufsz),
     link_{std::forward<Protocol>(protocol)}
 {
 }

--- a/api/smp
+++ b/api/smp
@@ -31,6 +31,8 @@
 #define SMP_MAX_CORES   16
 #endif
 
+#define SMP_ALIGN       64
+
 /// x86-related locking stuff ///
 #ifdef ARCH_X86
 // Intel 3a  8.10.6.7: 128-byte boundary

--- a/src/arch/x86/apic_boot.asm
+++ b/src/arch/x86/apic_boot.asm
@@ -1,8 +1,24 @@
+; This file is a part of the IncludeOS unikernel - www.includeos.org
+;
+; Copyright 2015 Oslo and Akershus University College of Applied Sciences
+; and Alfred Bratterud
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
 ;
 ; Thanks to Maghsoud for paving the way to SMP!
 ; We are still calling them Revenants
 ;
-org 0x80000
+org 0x10000
 BITS 16
 ; 2-bytes of jmp instruction, but aligned to 4-bytes (!)
   JMP boot_code
@@ -13,7 +29,6 @@ ALIGN 4
 revenant_main  dd  0x0
 stack_base     dd  0x0
 stack_size     dd  0
-IDT_array      equ  0x80480
 
 ALIGN 4
 boot_code:
@@ -37,37 +52,33 @@ boot_code:
 
 ;; Global descriptor table
 gdtr:
-	dw gdt32_end - gdt32 - 1
-	dq gdt32 ;; + (0x0800 << 4)
+  dw gdt32_end - gdt32 - 1
+  dq gdt32
 gdt32:
-	;; Entry 0x0: Null desriptor
-	dq 0x0 
-	;; Entry 0x8: Code segment
-	dw 0xffff		       ;Limit
-  dw 0x0000		       ;Base 15:00
-	db 0x00			       ;Base 23:16
-	dw 0xcf9a		       ;Flags
-	db 0x00			       ;Base 32:24
-	;; Entry 0x10: Data segment
-	dw 0xffff		       ;Limit
-	dw 0x0000		       ;Base 15:00
-	db 0x00			       ;Base 23:16
-	dw 0xcf92		       ;Flags
-	db 0x00			       ;Base 32:24	
+  ;; Entry 0x0: Null desriptor
+  dq 0x0 
+  ;; Entry 0x8: Code segment
+  dw 0xffff          ;Limit
+  dw 0x0000          ;Base 15:00
+  db 0x00            ;Base 23:16
+  dw 0xcf9a          ;Flags
+  db 0x00            ;Base 32:24
+  ;; Entry 0x10: Data segment
+  dw 0xffff          ;Limit
+  dw 0x0000          ;Base 15:00
+  db 0x00            ;Base 23:16
+  dw 0xcf92          ;Flags
+  db 0x00            ;Base 32:24  
 gdt32_end:
-	db `32`
-;;
 
 BITS 32
 protected_mode:
   cld
   
-  ; set all segments to data segment (0x10)
+  ; set most segments to data (0x10)
   mov   ax, 0x10
   mov   ds, ax
   mov   es, ax
-  mov   fs, ax
-  mov   gs, ax
   mov   ss, ax
   
   ; retrieve CPU id

--- a/src/arch/x86/apic_revenant.cpp
+++ b/src/arch/x86/apic_revenant.cpp
@@ -1,5 +1,6 @@
 #include "apic_revenant.hpp"
 
+#include "apic.hpp"
 #include "apic_timer.hpp"
 #include "gdt.hpp"
 #include <kernel/irq_manager.hpp>

--- a/src/arch/x86/apic_revenant.hpp
+++ b/src/arch/x86/apic_revenant.hpp
@@ -19,7 +19,6 @@
 #ifndef X86_APIC_REVENANT_HPP
 #define X86_APIC_REVENANT_HPP
 
-#include "apic.hpp"
 #include "smp.hpp"
 #include <cstdint>
 #include <deque>

--- a/src/arch/x86/apic_timer.cpp
+++ b/src/arch/x86/apic_timer.cpp
@@ -40,14 +40,14 @@ namespace x86
   // calculated once on BSP
   static uint32_t ticks_per_micro = 0;
   
-  struct timer_data
+  struct alignas(SMP_ALIGN) timer_data
   {
     bool intr_enabled = false;
     
-  } __attribute__((aligned(128)));
-  static timer_data timerdata[SMP_MAX_CORES];
+  };
+  static std::array<timer_data, SMP_MAX_CORES> timerdata;
   
-  #define GET_TIMER() timerdata[SMP::cpu_id()]
+  #define GET_TIMER() PER_CPU(timerdata)
   
   void APIC_Timer::init()
   {

--- a/src/arch/x86/arch.cpp
+++ b/src/arch/x86/arch.cpp
@@ -109,7 +109,7 @@ void __arch_reboot()
 
 namespace x86
 {
-  struct alignas(64) cpu_shared
+  struct alignas(SMP_ALIGN) cpu_shared
   {
     int cpduid;
   };
@@ -122,7 +122,7 @@ namespace x86
     }
   }
 
-  struct alignas(64) segtable
+  struct alignas(SMP_ALIGN) segtable
   {
     struct GDT gdt;
   };

--- a/src/arch/x86/gdt.cpp
+++ b/src/arch/x86/gdt.cpp
@@ -51,7 +51,7 @@ void GDT::initialize() noexcept
 int GDT::create_data(void* ptr, uint16_t pages) noexcept
 {
   uintptr_t base = (uintptr_t) ptr;
-  assert((base & 0x7f) == 0); // at least 128-byte aligned
+  assert((base & 0x3f) == 0); // at least 64-byte aligned
   this->create_data(base, pages);
   return this->count-1;
 }

--- a/src/drivers/virtionet.cpp
+++ b/src/drivers/virtionet.cpp
@@ -20,18 +20,14 @@
 //#define DEBUG2
 
 #include "virtionet.hpp"
-#include <net/packet.hpp>
 #include <kernel/irq_manager.hpp>
-#include <kernel/syscalls.hpp>
-#include <hw/pci.hpp>
-#include <cstdlib>
 #include <malloc.h>
-#include <string.h>
+#include <cstring>
 
 //#define NO_DEFERRED_KICK
 #ifndef NO_DEFERRED_KICK
 #include <smp>
-struct smp_deferred_kick
+struct alignas(SMP_ALIGN) smp_deferred_kick
 {
   std::vector<VirtioNet*> devs;
   uint8_t irq;
@@ -40,6 +36,8 @@ static std::array<smp_deferred_kick, SMP_MAX_CORES> deferred_devs;
 #endif
 
 using namespace net;
+// make packets cache-aligned on the IP-layer
+static const int VIRTIO_HDR_OFFSET = 64 - sizeof(Packet) - sizeof(ethernet::Header);
 
 void VirtioNet::get_config() {
   Virtio::get_config(&_conf, _config_length);
@@ -53,6 +51,8 @@ VirtioNet::VirtioNet(hw::PCI_Device& d)
     packets_tx_{Statman::get().create(Stat::UINT64, device_name() + ".packets_tx").get_uint64()}
 {
   INFO("VirtioNet", "Driver initializing");
+  static_assert(VIRTIO_HDR_OFFSET >= sizeof(virtio_net_hdr),
+                "Must be at least larger than the driver header itself");
 
   uint32_t needed_features = 0
     | (1 << VIRTIO_NET_F_MAC)
@@ -250,7 +250,7 @@ void VirtioNet::add_receive_buffer(uint8_t* pkt)
   auto* vnet = pkt + sizeof(Packet);
 
   Token token1 {{vnet, sizeof(virtio_net_hdr)}, Token::IN };
-  Token token2 {{vnet + sizeof(virtio_net_hdr), packet_len()}, Token::IN };
+  Token token2 {{vnet + VIRTIO_HDR_OFFSET, packet_len()}, Token::IN };
 
   std::array<Token, 2> tokens {{ token1, token2 }};
   rx_q.enqueue(tokens);
@@ -264,14 +264,14 @@ VirtioNet::recv_packet(uint8_t* data, uint16_t size)
   assert(bufstore().is_from_pool((uint8_t*) ptr));
   assert(bufstore().is_buffer((uint8_t*) ptr));
 #endif
-  new (ptr) net::Packet(packet_len(), size - sizeof(virtio_net_hdr), sizeof(virtio_net_hdr), &bufstore());
+  new (ptr) net::Packet(packet_len(), size - sizeof(virtio_net_hdr), VIRTIO_HDR_OFFSET, &bufstore());
   return net::Packet_ptr(ptr);
 }
 net::Packet_ptr
 VirtioNet::create_packet(uint16_t size)
 {
   auto* ptr = (net::Packet*) bufstore().get_buffer();
-  new (ptr) net::Packet(packet_len(), size, sizeof(virtio_net_hdr), &bufstore());
+  new (ptr) net::Packet(packet_len(), size, VIRTIO_HDR_OFFSET, &bufstore());
   return net::Packet_ptr(ptr);
 }
 
@@ -338,7 +338,7 @@ void VirtioNet::transmit(net::Packet_ptr pckt) {
 
 void VirtioNet::enqueue(net::Packet* pckt)
 {
-  auto* hdr = pckt->buffer() - sizeof(virtio_net_hdr);
+  auto* hdr = pckt->buffer() - VIRTIO_HDR_OFFSET;
   
   Token token1 {{ hdr, sizeof(virtio_net_hdr)}, Token::OUT };
   Token token2 {{ pckt->buffer(), pckt->size()}, Token::OUT };

--- a/src/drivers/virtionet.cpp
+++ b/src/drivers/virtionet.cpp
@@ -36,8 +36,6 @@ static std::array<smp_deferred_kick, SMP_MAX_CORES> deferred_devs;
 #endif
 
 using namespace net;
-// make packets cache-aligned on the IP-layer
-static const int VIRTIO_HDR_OFFSET = 64 - sizeof(Packet) - sizeof(ethernet::Header);
 
 void VirtioNet::get_config() {
   Virtio::get_config(&_conf, _config_length);

--- a/src/drivers/virtionet.cpp
+++ b/src/drivers/virtionet.cpp
@@ -387,7 +387,7 @@ void VirtioNet::deactivate()
 
 void VirtioNet::move_to_this_cpu()
 {
-  printf("VirtioNet: Moving to CPU %d\n", SMP::cpu_id());
+  INFO("VirtioNet", "Moving to CPU %d", SMP::cpu_id());
   this->Virtio::move_to_this_cpu();
   // reset the IRQ handlers
   auto& irqs = this->Virtio::get_irqs();

--- a/src/drivers/virtionet.hpp
+++ b/src/drivers/virtionet.hpp
@@ -183,15 +183,8 @@ private:
     uint16_t num_buffers;
   }__attribute__((packed));
 
-  struct virtio_net_rxhdr {
-    uint8_t   flags;
-    uint8_t   gso_type;
-    uint16_t  hdr_len;
-    uint16_t  gso_size;
-    uint16_t  csum_start;
-    uint16_t  csum_offset;
-    uint16_t  bufs;
-  }__attribute__((packed));
+  // make packets cache-aligned on the IP-layer
+  static const int VIRTIO_HDR_OFFSET = sizeof(virtio_net_hdr);
 
   Virtio::Queue rx_q;
   Virtio::Queue tx_q;

--- a/src/kernel/irq_manager.cpp
+++ b/src/kernel/irq_manager.cpp
@@ -25,6 +25,7 @@
 #include <kprint>
 #include <smp>
 
+//#define DEBUG_SMP
 #define LAPIC_IRQ_BASE   120
 #define RING0_CODE_SEG   0x8
 
@@ -50,6 +51,7 @@ void IRQ_manager::register_irq(uint8_t irq)
 }
 
 extern "C" {
+  extern void* get_cpu_esp();
   extern void unused_interrupt_handler();
   extern void modern_interrupt_handler();
   void register_modern_interrupt()
@@ -76,12 +78,17 @@ print_error_code(uint32_t){}
 
 
 template <int NR>
-void cpu_exception(uint32_t eip, uint32_t error)
+void cpu_exception(void** eip, uint32_t error)
 {
-  kprint("\n\n>>>> !!! CPU EXCEPTION !!! <<<<\n");
-  kprintf("CPU Exception no. %i while EIP @ 0x%x (value 0x%x). ", NR, eip, *(uint32_t*)eip);
+  SMP::global_lock();
+  kprintf("\n>>>> !!! CPU %u EXCEPTION !!! <<<<\n", SMP::cpu_id());
+  kprintf("Exception %i   EIP  %p\n", NR, eip);
   print_error_code<NR>(error);
-  panic("CPU exception");
+  SMP::global_unlock();
+  // call panic, which will decide what to do next
+  char buffer[64];
+  snprintf(buffer, sizeof(buffer), "CPU exception %d", NR);
+  panic(buffer);
 }
 
 
@@ -223,6 +230,12 @@ void IRQ_manager::subscribe(uint8_t irq, irq_delegate del, bool create_stat)
 
   // Add callback to subscriber list (for now overwriting any previous)
   irq_delegates_[irq] = del;
+#ifdef DEBUG_SMP
+  SMP::global_lock();
+  printf("Subscribed to intr=%u irq=%u on cpu %d\n",
+        IRQ_BASE + irq, irq, SMP::cpu_id());
+  SMP::global_unlock();
+#endif
 }
 void IRQ_manager::unsubscribe(uint8_t irq)
 {
@@ -244,6 +257,12 @@ void IRQ_manager::process_interrupts()
       // reset pending before running handler
       irq_pend.atomic_reset(intr);
       // sub and call handler
+#ifdef DEBUG_SMP
+      SMP::global_lock();
+      printf("[%p] Calling handler for intr=%u irq=%u cpu %d\n",
+             get_cpu_esp(), IRQ_BASE + intr, intr, SMP::cpu_id());
+      SMP::global_unlock();
+#endif
       irq_delegates_[intr]();
 
       // increase stat counter, if it exists

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -174,7 +174,8 @@ OS::on_panic_func panic_handler = default_panic_handler;
 void panic(const char* why)
 {
   SMP::global_lock();
-  fprintf(stderr, "\n\t**** PANIC: ****\n %s\n", why);
+  fprintf(stderr, "\n\t**** CPU %u PANIC: ****\n %s\n", 
+          SMP::cpu_id(), why);
   // the crash context buffer can help determine cause of crash
   int len = strnlen(get_crash_context_buffer(), CONTEXT_BUFFER_LENGTH);
   if (len > 0) {

--- a/src/kernel/timers.cpp
+++ b/src/kernel/timers.cpp
@@ -66,10 +66,11 @@ struct timer_system
   uint32_t* periodic_started;
   uint32_t* periodic_stopped;
 } __attribute__((aligned(128)));
-static timer_system systems[SMP_MAX_CORES];
+
+static std::array<timer_system, SMP_MAX_CORES> systems;
 
 static inline timer_system& get() {
-  return systems[SMP::cpu_id()];
+  return PER_CPU(systems);
 }
 
 void Timers::init(const start_func_t& start, const stop_func_t& stop)

--- a/src/net/inet4.cpp
+++ b/src/net/inet4.cpp
@@ -1,7 +1,7 @@
 //-*- C++ -*-
-#define DEBUG
 #include <net/inet4.hpp>
 #include <net/dhcp/dh4client.hpp>
+#include <smp>
 
 using namespace net;
 
@@ -65,6 +65,14 @@ Inet4::Inet4(hw::Nic& nic)
   // Arp -> Link
   assert(link_top);
   arp_.set_linklayer_out(link_top);
+
+#ifndef INCLUDEOS_SINGLE_THREADED
+  // move this nework stack automatically
+  // to the current CPU if its not 0
+  if (SMP::cpu_id() != 0) {
+    this->move_to_this_cpu();
+  }
+#endif
 }
 
 void Inet4::negotiate_dhcp(double timeout, dhcp_timeout_func handler) {

--- a/test/kernel/integration/smp/service.cpp
+++ b/test/kernel/integration/smp/service.cpp
@@ -21,12 +21,12 @@
 #include <timers>
 #include <kernel/irq_manager.hpp>
 
-struct per_cpu_test
+struct alignas(SMP_ALIGN) per_cpu_test
 {
   int value;
   
-} __attribute__((aligned(64)));
-static std::array<per_cpu_test, 16> testing;
+};
+static std::array<per_cpu_test, SMP_MAX_CORES> testing;
 
 static int times = 0;
 


### PR DESCRIPTION
- Cache-aligned SMP per-cpu structures
- Experiment with cache-aligned IP-layer in virtionet
- Fix SMP bug that caused problems
- Automatically move network stacks to current CPU (if instantiated on that CPU)