### PR TITLE
TCP Connection Stream interface

### DIFF
--- a/api/net/http/client_connection.hpp
+++ b/api/net/http/client_connection.hpp
@@ -36,7 +36,7 @@ namespace http {
     using timeout_duration  = std::chrono::milliseconds;
 
   public:
-    explicit Client_connection(Client&, TCP_conn);
+    explicit Client_connection(Client&, Stream_ptr);
 
     bool available() const
     { return on_response_ == nullptr && keep_alive_; }

--- a/api/net/http/server.hpp
+++ b/api/net/http/server.hpp
@@ -63,7 +63,7 @@ namespace http {
      *
      * @param[in]  port  The port to listen on
      */
-    void listen(uint16_t port);
+    virtual void listen(uint16_t port);
 
     /**
      * @brief      Setup handler for when a Request is received
@@ -90,21 +90,6 @@ namespace http {
      */
     Response_ptr create_response(status_t code = http::OK) const;
 
-    /**
-     * @brief      Returns a vector of all TCP connections currently connected to the server
-     *
-     * @return     A vector of TCP connections
-     */
-    std::vector<TCP_conn> active_tcp_connections() const;
-
-    /**
-     * @brief      Reconnects a TCP connection by creating a Server connection
-     *
-     * @param[in]  conn  The TCP connection
-     */
-    void reconnect(TCP_conn conn)
-    { if (conn != nullptr) connect(conn); }
-
     ~Server();
 
   private:
@@ -124,7 +109,10 @@ namespace http {
     Stat& stat_req_bad_;
     Stat& stat_timeouts_;
 
-    void connect(TCP_conn conn);
+    void connect(TCP_conn conn)
+    { connect(std::make_unique<Connection::Stream>(conn)); }
+
+    void connect(Connection::Stream_ptr stream);
 
     void close(Server_connection&);
 

--- a/api/net/http/server_connection.hpp
+++ b/api/net/http/server_connection.hpp
@@ -33,7 +33,7 @@ namespace http {
     static constexpr size_t DEFAULT_BUFSIZE = 1460;
 
   public:
-    explicit Server_connection(Server&, TCP_conn, size_t idx, const size_t bufsize = DEFAULT_BUFSIZE);
+    explicit Server_connection(Server&, Stream_ptr, size_t idx, const size_t bufsize = DEFAULT_BUFSIZE);
 
     void send(Response_ptr res);
 

--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -56,6 +56,9 @@ public:
   struct Disconnect;
   /** Reason for packet being dropped */
   enum class Drop_reason;
+  /** A Connection stream */
+  class Stream;
+
   using Byte = uint8_t;
 
   using WriteBuffer = Write_queue::WriteBuffer;
@@ -214,6 +217,205 @@ public:
    */
   inline void abort();
 
+  /**
+   * @brief      Exposes a TCP Connection as a Stream with only the most necessary features.
+   *             May be overrided by extensions like TLS etc for additional functionality.
+   */
+  class Stream {
+  public:
+    /**
+     * @brief      Construct a Stream for a Connection ptr
+     *
+     * @param[in]  conn  The connection
+     */
+    Stream(Connection_ptr conn)
+      : ptr{std::move(conn)}
+    {}
+
+    /** Called when the stream is ready to use. */
+    using ConnectCallback = delegate<void(Stream& self)>;
+    /**
+     * @brief      Event when the stream is connected/established/ready to use.
+     *
+     * @param[in]  cb    The connect callback
+     */
+    virtual void on_connect(ConnectCallback cb)
+    {
+      ptr->on_connect(Connection::ConnectCallback::make_packed(
+          [this, cb] (Connection_ptr)
+          { cb(*this); }));
+    }
+
+    /** Called with a shared buffer and the length of the data when received. */
+    using ReadCallback            = delegate<void(buffer_t, size_t)>;
+    /**
+     * @brief      Event when data is received.
+     *
+     * @param[in]  n     The size of the receive buffer
+     * @param[in]  cb    The read callback
+     */
+    virtual void on_read(size_t n, ReadCallback cb)
+    { ptr->on_read(n, cb); }
+
+    /** Called with nothing ¯\_(ツ)_/¯ */
+    using CloseCallback           = delegate<void()>;
+    /**
+     * @brief      Event for when the Stream is being closed.
+     *
+     * @param[in]  cb    The close callback
+     */
+    virtual void on_close(CloseCallback cb)
+    { ptr->on_close(cb); }
+
+    /** Called with the number of bytes written. */
+    using WriteCallback           = delegate<void(size_t)>;
+    /**
+     * @brief      Event for when data has been written.
+     *
+     * @param[in]  cb    The write callback
+     */
+    virtual void on_write(WriteCallback cb)
+    { ptr->on_write(cb); }
+
+    /**
+     * @brief      Async write of a data with a length.
+     *
+     * @param[in]  buf   data
+     * @param[in]  n     length
+     */
+    virtual void write(const void* buf, size_t n)
+    { ptr->write(buf, n); }
+
+    /**
+     * @brief      Async write of a chunk.
+     *
+     * @param[in]  c     A chunk
+     */
+    virtual void write(Chunk c)
+    { ptr->write(c); }
+
+    /**
+     * @brief      Async write of a shared buffer with a length.
+     *             Calls write(Chunk c).
+     *
+     * @param[in]  buffer  shared buffer
+     * @param[in]  n       length
+     */
+    virtual void write(buffer_t buf, size_t n)
+    { ptr->write(buf, n); }
+
+    /**
+     * @brief      Async write of a string.
+     *             Calls write(const void* buf, size_t n)
+     *
+     * @param[in]  str   The string
+     */
+    void write(const std::string& str)
+    { write(str.data(), str.size()); }
+
+    /**
+     * @brief      Closes the stream.
+     */
+    virtual void close()
+    { ptr->close(); }
+
+    /**
+     * @brief      Aborts (terminates) the stream.
+     */
+    virtual void abort()
+    { ptr->abort(); }
+
+    /**
+     * @brief      Resets all callbacks.
+     */
+    virtual void reset_callbacks()
+    { ptr->reset_callbacks(); }
+
+    /**
+     * @brief      Returns the streams local socket.
+     *
+     * @return     A TCP Socket
+     */
+    tcp::Socket local() const
+    { return ptr->local(); }
+
+    /**
+     * @brief      Returns the streams remote socket.
+     *
+     * @return     A TCP Socket
+     */
+    tcp::Socket remote() const
+    { return ptr->remote(); }
+
+    /**
+     * @brief      Returns the local port.
+     *
+     * @return     A TCP port
+     */
+    uint16_t local_port() const
+    { return ptr->local_port(); }
+
+    /**
+     * @brief      Returns a string representation of the stream.
+     *
+     * @return     String representation of the stream.
+     */
+    virtual std::string to_string() const noexcept
+    { return ptr->to_string(); }
+
+    /**
+     * @brief      Determines if connected (established).
+     *
+     * @return     True if connected, False otherwise.
+     */
+    virtual bool is_connected() const noexcept
+    { return ptr->is_connected(); }
+
+    /**
+     * @brief      Determines if writable. (write is allowed)
+     *
+     * @return     True if writable, False otherwise.
+     */
+    virtual bool is_writable() const noexcept
+    { return ptr->is_writable(); }
+
+    /**
+     * @brief      Determines if readable. (data can be received)
+     *
+     * @return     True if readable, False otherwise.
+     */
+    virtual bool is_readable() const noexcept
+    { return ptr->is_readable(); }
+
+    /**
+     * @brief      Determines if closing.
+     *
+     * @return     True if closing, False otherwise.
+     */
+    virtual bool is_closing() const noexcept
+    { return ptr->is_closing(); }
+
+    /**
+     * @brief      Determines if closed.
+     *
+     * @return     True if closed, False otherwise.
+     */
+    virtual bool is_closed() const noexcept
+    { return ptr->is_closed(); };
+
+  protected:
+    /**
+     * @brief      Returns the underlying TCP connection.
+     *
+     * @return     A TCP Connection ptr
+     */
+    Connection_ptr tcp()
+    { return ptr; };
+
+  private:
+    Connection_ptr ptr;
+
+  }; // < class Connection::Stream
 
   /**
    * @brief      Reason for disconnect event.

--- a/api/net/tcp/options.hpp
+++ b/api/net/tcp/options.hpp
@@ -106,6 +106,12 @@ struct Option {
         ecr{htonl(echo)}
     {}
 
+    uint32_t get_val() const noexcept
+    { return ntohl(val); }
+
+    uint32_t get_ecr() const noexcept
+    { return ntohl(ecr); }
+
   } __attribute__((packed));
 
   /**

--- a/api/util/async.hpp
+++ b/api/util/async.hpp
@@ -28,9 +28,9 @@ class Async
 public:
   static const size_t PAYLOAD_SIZE = 64000;
 
-  typedef net::tcp::Connection_ptr Connection;
-  using Disk = fs::Disk_ptr;
-  typedef fs::Dirent Dirent;
+  using Stream  = net::tcp::Connection::Stream;
+  using Disk    = fs::Disk_ptr;
+  using Dirent  = fs::Dirent;
 
   typedef delegate<void(bool)> next_func;
   typedef delegate<void(fs::error_t, bool)> on_after_func;
@@ -39,7 +39,7 @@ public:
   static void upload_file(
       Disk,
       const Dirent&,
-      Connection,
+      Stream&,
       on_after_func,
       size_t = PAYLOAD_SIZE);
 

--- a/lib/mana/src/response.cpp
+++ b/lib/mana/src/response.cpp
@@ -53,7 +53,7 @@ void Response::send_file(const File& file)
   reswriter_->write_header(http::OK);
 
   /* Send file over connection */
-  auto conn = reswriter_->connection().tcp();
+  auto& stream = *reswriter_->connection().stream();
   #ifdef VERBOSE_WEBSERVER
   printf("<Response> Sending file: %s (%llu B).\n",
     entry.name().c_str(), entry.size());
@@ -62,28 +62,28 @@ void Response::send_file(const File& file)
   Async::upload_file(
     file.disk,
     file.entry,
-    conn,
+    stream,
     Async::on_after_func::make_packed(
     [
-      conn,
+      stream,
       req{shared_from_this()}, // keep the response (and conn) alive until done
       entry
-    ] (fs::error_t err, bool good)
+    ] (fs::error_t err, bool good) mutable
     {
       if(good) {
         #ifdef VERBOSE_WEBSERVER
         printf("<Response> Success sending %s => %s\n",
-          entry.name().c_str(), conn->remote().to_string().c_str());
+          entry.name().c_str(), stream.remote().to_string().c_str());
         #endif
       }
       else {
         printf("<Response> Error sending %s => %s [%s]\n",
-          entry.name().c_str(), conn->remote().to_string().c_str(),
-          conn->is_closing() ? "Connection closing" : err.to_string().c_str());
+          entry.name().c_str(), stream.remote().to_string().c_str(),
+          stream.is_closing() ? "Connection closing" : err.to_string().c_str());
       }
       // remove on_write triggering for other
       // writes on the same connection
-      conn->on_write(nullptr);
+      stream.on_write(nullptr);
     })
   );
 }

--- a/src/net/http/client.cpp
+++ b/src/net/http/client.cpp
@@ -63,7 +63,7 @@ namespace http {
   {
     Expects(cb != nullptr);
     using namespace std;
-    
+
     if (url.host_is_ip4())
     {
       std::string host = url.host().to_string();
@@ -82,7 +82,7 @@ namespace http {
     }
     else
     {
-      tcp_.stack().resolve(url.host().to_string(), 
+      tcp_.stack().resolve(url.host().to_string(),
       ResolveCallback::make_packed(
       [
         this,
@@ -233,7 +233,7 @@ namespace http {
     }
 
     // no non-occupied connections, emplace a new one
-    cset.push_back(std::make_unique<Client_connection>(*this, tcp_.connect(host)));
+    cset.push_back(std::make_unique<Client_connection>(*this, std::make_unique<Connection::Stream>(tcp_.connect(host))));
     return *cset.back();
   }
 

--- a/src/net/http/client_connection.cpp
+++ b/src/net/http/client_connection.cpp
@@ -22,8 +22,8 @@
 
 namespace http {
 
-  Client_connection::Client_connection(Client& client, TCP_conn tcpconn)
-    : Connection{std::move(tcpconn)},
+  Client_connection::Client_connection(Client& client, Stream_ptr stream)
+    : Connection{std::move(stream)},
       client_(client),
       req_(nullptr),
       res_(nullptr),
@@ -32,7 +32,7 @@ namespace http {
       timeout_dur_{timeout_duration::zero()}
   {
     // setup close event
-    tcpconn_->on_close({this, &Client_connection::close});
+    stream_->on_close({this, &Client_connection::close});
   }
 
   void Client_connection::send(Request_ptr req, Response_handler on_res, const size_t bufsize, timeout_duration timeout)
@@ -53,9 +53,9 @@ namespace http {
   {
     keep_alive_ = (req_->header().value(header::Connection) != "close");
 
-    tcpconn_->on_read(bufsize, {this, &Client_connection::recv_response});
+    stream_->on_read(bufsize, {this, &Client_connection::recv_response});
 
-    tcpconn_->write(req_->to_string());
+    stream_->write(req_->to_string());
   }
 
   void Client_connection::recv_response(buffer_t buf, size_t len)

--- a/src/net/http/response_writer.cpp
+++ b/src/net/http/response_writer.cpp
@@ -32,14 +32,14 @@ namespace http {
   {
     pre_write(data.size());
 
-    connection_.tcp()->write(std::move(data));
+    connection_.stream()->write(std::move(data));
   }
 
   void Response_writer::write(Chunk chunk)
   {
     pre_write(chunk.length());
 
-    connection_.tcp()->write(std::move(chunk));
+    connection_.stream()->write(std::move(chunk));
   }
 
   void Response_writer::pre_write(size_t len)
@@ -81,7 +81,7 @@ namespace http {
       std::ostringstream header;
       header << response_->status_line() << "\r\n" << response_->header();
 
-      connection_.tcp()->write(header.str());
+      connection_.stream()->write(header.str());
 
       // disable keep alive if "Connection: close" is present
       if(response_->header().value(http::header::Connection) == "close")

--- a/src/net/http/server_connection.cpp
+++ b/src/net/http/server_connection.cpp
@@ -21,21 +21,21 @@
 
 namespace http {
 
- Server_connection::Server_connection(Server& server, TCP_conn conn, size_t idx, const size_t bufsize)
-    : Connection(std::move(conn)),
+ Server_connection::Server_connection(Server& server, Stream_ptr stream, size_t idx, const size_t bufsize)
+    : Connection(std::move(stream)),
       server_(server),
       req_(nullptr),
       idx_(idx),
       idle_since_{0}
   {
-    tcpconn_->on_read(bufsize, {this, &Server_connection::recv_request});
+    stream_->on_read(bufsize, {this, &Server_connection::recv_request});
     // setup close event
-    tcpconn_->on_close({this, &Server_connection::close});
+    stream_->on_close({this, &Server_connection::close});
   }
 
   void Server_connection::send(Response_ptr res)
   {
-    tcpconn_->write(res->to_string());
+    stream_->write(res->to_string());
   }
 
   void Server_connection::recv_request(buffer_t buf, size_t len)

--- a/src/util/async.cpp
+++ b/src/util/async.cpp
@@ -29,17 +29,17 @@ inline unsigned roundup(unsigned n, unsigned div) {
 void Async::upload_file(
     Disk          disk,
     const Dirent& ent,
-    Connection    conn,
+    Stream&       stream,
     on_after_func callback,
     const size_t  CHUNK_SIZE)
 {
   disk_transfer(disk, ent,
-  [conn] (fs::buffer_t buffer,
-          size_t       length,
-          next_func    next)
+  [stream] (fs::buffer_t buffer,
+            size_t       length,
+            next_func    next) mutable
   {
     // temp
-    conn->on_write(net::tcp::Connection::WriteCallback::make_packed(
+    stream.on_write(net::tcp::Connection::WriteCallback::make_packed(
       [length, next] (size_t n) {
 
         // if all data written, go to next chunk
@@ -50,7 +50,7 @@ void Async::upload_file(
     );
 
     // write chunk to TCP connection
-    conn->write(buffer, length);
+    stream.write(buffer, length);
 
   }, callback, CHUNK_SIZE);
 }

--- a/test/net/integration/http/vm.json
+++ b/test/net/integration/http/vm.json
@@ -1,6 +1,5 @@
 {
   "image" : "test_http.img",
   "net" : [{"device" : "virtio", "mac" : "c0:01:0a:00:00:2a"}],
-  "cpu"   : "host",
   "mem"   : 256
 }


### PR DESCRIPTION
A `Connection::Stream` can now be constructed with a `tcp::Connection_ptr`. This exposes only the most important functionality of a TCP Connection and is overridable (virtual). The idea is to have other "extension" of a TCP Connection inherit and override the Stream interface, and by that support secure connections.

I also made HTTP able to support HTTPS (TLS) connections by replacing Connection with Stream.