### PR TITLE
fs: add deprecated attribute to new_shared_memdisk function

### DIFF
--- a/api/memdisk
+++ b/api/memdisk
@@ -34,7 +34,7 @@ namespace fs
   }
   // new_shared_memdisk() very likely contains FAT
   // Note: deprecated!
-  inline Disk_ptr new_shared_memdisk()
+  [[deprecated]] inline Disk_ptr new_shared_memdisk()
   {
     static MemDisk device;
     return std::make_shared<Disk> (device);


### PR DESCRIPTION
Nobody reads comments! :) Adding the `deprecated` [attribute](http://en.cppreference.com/w/cpp/language/attributes) will make the compiler output an actual warning:

```
[ 55%] Building CXX object CMakeFiles/service.dir/test_stat_ftw.cpp.obj
/Users/ingve/IncludeOS/test/posix/integration/stat/test_stat_ftw.cpp:28:26: warning: 'new_shared_memdisk' is deprecated [-Wdeprecated-declarations]
  static auto disk = fs::new_shared_memdisk();
                         ^
/Users/ingve/IncludeOS_install/includeos/api/memdisk:37:34: note: 'new_shared_memdisk' has been explicitly marked deprecated here
  [[deprecated]] inline Disk_ptr new_shared_memdisk()
                                 ^
1 warning generated.
```