### PR TITLE
Work-around for ghost in the machine, remove another work-around

### DIFF
--- a/api/net/tls/server.hpp
+++ b/api/net/tls/server.hpp
@@ -37,10 +37,10 @@ public:
 
   Server(Connection_ptr remote,
          Botan::RandomNumberGenerator& rng,
-         Botan::Credentials_Manager& credman) 
+         Botan::Credentials_Manager& credman)
   : tcp::Stream({remote}),
     m_creds(credman),
-    m_session_manager(rng),
+    m_session_manager(),
     m_tls(*this, m_session_manager, m_creds, m_policy, rng)
   {
     assert(tcp->is_connected());
@@ -140,7 +140,7 @@ protected:
     {
       auto buffff = std::shared_ptr<uint8_t> (new uint8_t[buf_len]);
       memcpy(buffff.get(), buf, buf_len);
-      
+
       o_read(buffff, buf_len);
     }
   }
@@ -157,7 +157,7 @@ private:
 
   Botan::Credentials_Manager&   m_creds;
   Botan::TLS::Strict_Policy     m_policy;
-  Botan::TLS::Session_Manager_In_Memory m_session_manager;
+  Botan::TLS::Session_Manager_Noop m_session_manager;
 
   Botan::TLS::Server m_tls;
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,9 +70,6 @@ set(OS_OBJECTS
 )
 
 add_library(os STATIC ${OS_OBJECTS} apic_boot.o)
-
-set_source_files_properties(os virtio/virtio.cpp PROPERTIES COMPILE_FLAGS "-mno-avx -msse3")
-
 add_dependencies(os PrecompiledLibraries botan)
 
 file(GLOB CXX_ABI crt/cxxabi/*.cpp)

--- a/src/drivers/virtionet.cpp
+++ b/src/drivers/virtionet.cpp
@@ -169,10 +169,16 @@ VirtioNet::VirtioNet(hw::PCI_Device& d)
   }
 #endif
 
+  CHECK(this->link_up(), "Link up");
   // Done
-  INFO("VirtioNet", "Driver initialization complete");
-  CHECK(_conf.status & 1, "Link up\n");
-  rx_q.kick();
+  if (this->link_up()) {
+    rx_q.kick();
+  }
+}
+
+bool VirtioNet::link_up() const noexcept
+{
+  return _conf.status & 1;
 }
 
 void VirtioNet::msix_conf_handler()
@@ -259,9 +265,9 @@ VirtioNet::recv_packet(uint8_t* data, uint16_t size)
 #endif
 
   new (ptr) net::Packet(
-      sizeof(virtio_net_hdr), 
-      size - sizeof(virtio_net_hdr), 
-      sizeof(virtio_net_hdr) + packet_len(), 
+      sizeof(virtio_net_hdr),
+      size - sizeof(virtio_net_hdr),
+      sizeof(virtio_net_hdr) + packet_len(),
       &bufstore());
 
   return net::Packet_ptr(ptr);
@@ -274,9 +280,9 @@ VirtioNet::create_packet(int link_offset)
   auto* ptr = (net::Packet*) buffer.addr;
 
   new (ptr) net::Packet(
-        sizeof(virtio_net_hdr) + link_offset, 
-        0, 
-        sizeof(virtio_net_hdr) + packet_len(), 
+        sizeof(virtio_net_hdr) + link_offset,
+        0,
+        sizeof(virtio_net_hdr) + packet_len(),
         buffer.bufstore);
 
   return net::Packet_ptr(ptr);

--- a/src/drivers/virtionet.hpp
+++ b/src/drivers/virtionet.hpp
@@ -156,6 +156,8 @@ public:
     return tx_q.num_free() / 2;
   }
 
+  bool link_up() const noexcept;
+
   void deactivate() override;
 
   void move_to_this_cpu() override;

--- a/src/virtio/virtio.cpp
+++ b/src/virtio/virtio.cpp
@@ -134,23 +134,18 @@ Virtio::Virtio(hw::PCI_Device& dev)
   }
 
   INFO("Virtio", "Initialization complete");
-
-  // It would be nice if we new that all queues were the same size.
-  // Then we could pass this size on to the device-specific constructor
-  // But, it seems there aren't any guarantees in the standard.
-
-  // @note this is "the Legacy interface" according to Virtio std. 4.1.4.8.
-  // uint32_t queue_size = hw::inpd(_iobase + 0x0C);
 }
 
-void Virtio::get_config(void* buf, int len){
+void Virtio::get_config(void* buf, int len)
+{
   // io addr is different when MSI-X is enabled
   uint32_t ioaddr = _iobase;
   ioaddr += (has_msix()) ? VIRTIO_PCI_CONFIG_MSIX : VIRTIO_PCI_CONFIG;
 
   uint8_t* ptr = (uint8_t*) buf;
-  for (int i = 0; i < len; i++)
+  for (int i = 0; i < len; i++) {
     ptr[i] = hw::inp(ioaddr + i);
+  }
 }
 
 
@@ -162,7 +157,7 @@ uint8_t Virtio::get_legacy_irq()
 {
   // Get legacy IRQ from PCI
   uint32_t value = _pcidev.read_dword(PCI::CONFIG_INTR);
-  if ((value & 0xFF) > 0 && (value & 0xFF) < 32){
+  if ((value & 0xFF) != 0xFF) {
     return value & 0xFF;
   }
   return 0;
@@ -173,7 +168,6 @@ uint32_t Virtio::queue_size(uint16_t index) {
   return hw::inpw(iobase() + VIRTIO_PCI_QUEUE_SIZE);
 }
 
-#define BTOP(x) ((unsigned long)(x) >> PAGESHIFT)
 bool Virtio::assign_queue(uint16_t index, const void* queue_desc)
 {
   hw::outpw(iobase() + VIRTIO_PCI_QUEUE_SEL, index);
@@ -196,20 +190,12 @@ uint32_t Virtio::probe_features() {
 }
 
 void Virtio::negotiate_features(uint32_t features) {
-  _features = hw::inpd(_iobase + VIRTIO_PCI_HOST_FEATURES);
-  //_features &= features; //SanOS just adds features
-  _features = features;
-  debug("<Virtio> Wanted features: 0x%lx \n",_features);
+  //_features = hw::inpd(_iobase + VIRTIO_PCI_HOST_FEATURES);
+  this->_features = features;
+  debug("<Virtio> Wanted features: 0x%lx \n", _features);
   hw::outpd(_iobase + VIRTIO_PCI_GUEST_FEATURES, _features);
   _features = probe_features();
   debug("<Virtio> Got features: 0x%lx \n",_features);
-
-}
-
-void Virtio::setup_complete(bool ok) {
-  uint8_t status = ok ? VIRTIO_CONFIG_S_DRIVER_OK : VIRTIO_CONFIG_S_FAILED;
-  debug("<VIRTIO> status: %i ",status);
-  hw::outp(_iobase + VIRTIO_PCI_STATUS, hw::inp(_iobase + VIRTIO_PCI_STATUS) | status);
 }
 
 void Virtio::move_to_this_cpu()
@@ -231,4 +217,14 @@ void Virtio::move_to_this_cpu()
       IRQ_manager::get().subscribe(this->irqs[i], nullptr);
     }
   }
+}
+
+void Virtio::setup_complete(bool ok)
+{
+  uint8_t value = hw::inp(_iobase + VIRTIO_PCI_STATUS);
+  value |= ok ? VIRTIO_CONFIG_S_DRIVER_OK : VIRTIO_CONFIG_S_FAILED;
+  if (!ok) {
+    INFO("Virtio", "Setup failed, status: %hhx", value);
+  }
+  hw::outp(_iobase + VIRTIO_PCI_STATUS, value);
 }


### PR DESCRIPTION
The problem isn't in virtio anyways, and this allows for building virtio.cpp without the no-avx work-around
