### PR TITLE
Make CPU features optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,13 @@ string(STRIP ${OS_VERSION} OS_VERSION)
 # create random hex string as stack protector canary
 string(RANDOM LENGTH 8 ALPHABET 0123456789ABCDEF STACK_PROTECTOR_VALUE)
 
-set(CAPABS "-mavx -maes -mfma -fstack-protector-strong -D_STACK_GUARD_VALUE_=0x${STACK_PROTECTOR_VALUE} ")
-
+set(CAPABS "-fstack-protector-strong -D_STACK_GUARD_VALUE_=0x${STACK_PROTECTOR_VALUE}")
+option(cpu_feat_vanilla "Restrict use of CPU features to vanilla" ON)
+if(cpu_feat_vanilla)
+  set(CAPABS "-msse3 -maes ${CAPABS}")
+else()
+  set(CAPABS "-mavx -maes -mfma ${CAPABS}")
+endif(cpu_feat_vanilla)
 # Various global defines
 # * NO_DEBUG disables output from the debug macro
 # * OS_TERMINATE_ON_CONTRACT_VIOLATION provides classic assert-like output from Expects / Ensures
@@ -160,10 +165,24 @@ endif(rapidjson)
 #
 # Installation
 #
+
+# Install cmake files
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/etc/service.cmake DESTINATION includeos)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/etc/library.cmake DESTINATION includeos)
-install(DIRECTORY vmrunner DESTINATION includeos/)
+
+# Install vmrunner
+install(DIRECTORY vmrunner DESTINATION includeos)
+if(cpu_feat_vanilla)
+  set(DEFAULT_VM "vm.vanilla.json")
+else()
+  set(DEFAULT_VM "vm.cpu_feat.json")
+endif(cpu_feat_vanilla)
+install(FILES vmrunner/${DEFAULT_VM} DESTINATION includeos/vmrunner/ RENAME vm.default.json)
+
+# Install toolchain
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/i686-elf-toolchain.cmake DESTINATION includeos)
+
+# Install seed
 install(DIRECTORY seed/ DESTINATION includeos/seed)
 
 # Install boot util

--- a/vmrunner/vm.cpu_feat.json
+++ b/vmrunner/vm.cpu_feat.json
@@ -1,0 +1,10 @@
+{
+  "description" : "Single virtio nic with extended cpu features",
+  "net" : [
+    {"device" : "virtio", "backend" : "tap" }
+  ],
+  "cpu" : {
+    "model" : "host",
+    "features" : ["xsave", "avx", "aes"]
+  }
+}

--- a/vmrunner/vm.schema.json
+++ b/vmrunner/vm.schema.json
@@ -1,6 +1,23 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "title" : "Virtual Machine Image",
+
+  "definitions" : {
+    "cpu" : {
+      "description" : "The virtual CPU",
+      "type"    : "object",
+      "properties": {
+        "model" : {
+          "enum" : ["host", "pentium", "qemu64", "kvm64"]
+        },
+        "features" : {
+          "type" : "array",
+          "items" : { "enum" : ["xsave", "avx", "aes"] }
+        }
+      }
+    }
+  },
+
   "type" : "object",
   "properties" : {
 
@@ -61,11 +78,7 @@
       "default" : 128
     },
 
-    "cpu" : {
-      "description" : "The virtual CPU",
-      "type"    : "string",
-      "default" : "host,+xsave,+avx,+aes"
-    },
+    "cpu" : { "$ref": "#/definitions/cpu" },
 
     "smp" : {
       "description" : "Number of virtual CPU's",

--- a/vmrunner/vm.vanilla.json
+++ b/vmrunner/vm.vanilla.json
@@ -1,0 +1,6 @@
+{
+  "description" : "Single virtio nic with vanilla cpu features",
+  "net" : [
+    {"device" : "virtio", "backend" : "tap" }
+  ]
+}


### PR DESCRIPTION
Since AVX was introduced there was some issues with running on Mac with qemu (it didnt work).

This PR makes vmrunner have a default config that's installed in `includeos/vmrunner/vm.default.json`. This can be edited to your own liking. Additional local `vm.json` will extend and override any duplicate entry (it has higher priority).

I also had to add an CMake option to build IncludeOS different (without AVX etc), and called this `cpu_feat_vanilla` which is by default **ON**. This also determine which default vm config that should be installed.