### PR TITLE
Improvements to dependency installation

### DIFF
--- a/etc/install_build_requirements.sh
+++ b/etc/install_build_requirements.sh
@@ -1,11 +1,71 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Install dependencies
 
-SYSTEM=$1
-RELEASE=$2
+############################################################
+# OPTIONS:
+############################################################
 
-DEPENDENCIES="curl make clang cmake nasm bridge-utils qemu jq python-jsonschema python-psutil"
+BUILD_DEPENDENCIES="curl make clang cmake nasm bridge-utils qemu jq python-jsonschema python-psutil"
+TEST_DEPENDENCIES="g++ g++-multilib python-junit.xml"
+
+############################################################
+# COMMAND LINE PROPERTIES:
+############################################################
+
+# Initialize variables:
+SYSTEM=0
+RELEASE=0
+CHECK_INSTALLED=0
+DEPENDENCIES_TO_INSTALL=build
+
+while getopts "h?s:r:cd:" opt; do
+    case "$opt" in
+    h|\?)
+        printf "%s\n" "Options:"\
+                "-s System: What system to install on"\
+                "-r Release: What release of said system"\
+                "-c Check installed: Flag for checking if dependencies are installed"
+                "-d Dependencies to install: [build | test | all] are the options"
+        exit 0 ;;
+    s)  SYSTEM=$OPTARG ; shift 2 ;;
+    r)  RELEASE=$OPTARG ; shift 2 ;;
+    c)  CHECK_INSTALLED=1 ;;
+	d)  DEPENDENCIES_TO_INSTALL=$OPTARG ; shift 2 ;;
+    esac
+done
+
+# Figure out which dependencies to check
+case "$DEPENDENCIES_TO_INSTALL" in
+	build) ALL_DEPENDENCIES=$BUILD_DEPENDENCIES ;;
+	test) ALL_DEPENDENCIES=$TEST_DEPENDENCIES ;;
+	all) ALL_DEPENDENCIES="$BUILD_DEPENDENCIES $TEST_DEPENDENCIES" ;;
+esac
+
+############################################################
+# CHECK INSTALLED PACKAGES:
+############################################################
+
+if [ $CHECK_INSTALLED -eq 1 ]; then
+	printf "%-15s %-20s %s \n"\
+		   "Status" "Package" "Version"\
+		   "------" "-------" "-------"
+	for package in $ALL_DEPENDENCIES; do
+		dpkg-query -W $package > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			printf '\e[32m%-15s\e[0m %-20s %s \n'\
+				"INSTALLED" $(dpkg-query -W $package)
+		else
+			printf '\e[31m%-15s\e[0m %-20s %s \n'\
+				"MISSING" $package
+			DEPENDENCIES="$DEPENDENCIES $package"
+		fi
+	done
+fi
+
+############################################################
+# INSTALL MISSING PACKAGES:
+############################################################
 
 case $SYSTEM in
     "Darwin")

--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,7 @@ fi
 
 # Install dependencies if there are any missing
 if [ ! -z $missing_dependencies ]; then
-	if ! ./etc/install_build_requirements.sh -s $SYSTEM -r $RELEASE; then
+	if ! ./etc/install_build_requirements.sh -s $SYSTEM -r $RELEASE -d $dependency_level; then
 		printf "%s\n" ">>> Sorry <<<"\
 				"Could not install dependencies"
 		exit 1


### PR DESCRIPTION
1. Much more visual what packages are installed by install.sh. (and yes there are colors)
2. Added another set of dependencies that are needed when installing with `INCLUDEOS_ENABLE_TEST`. These are automatically added when set to `ON`
3. Added command line options to `etc/install_build_requirements.sh`

```
/install_build_requirements.sh -h
Options:
-s System: What system to install on
-r Release: What release of said system
-c Only check: Will only check what packages are needed (will always print status as well)
-p Print install status: Flag for wheter or not to print dependency status
-d Dependencies to install: [build | test | all] are the options
```

```bash
ubuntu@test:~/IncludeOS$ ./install.sh
>>> Dependencies required:
Status          Package              Version
------          -------              -------
INSTALLED       curl                 7.47.0-1ubuntu2
INSTALLED       make
MISSING         clang
MISSING         cmake
MISSING         nasm
MISSING         bridge-utils
MISSING         qemu
MISSING         jq
MISSING         python-jsonschema
MISSING         python-psutil
MISSING         g++
MISSING         g++-multilib
MISSING         python-junit.xml


>>> IncludeOS will be installed with the following options:

    [NOTICE] Missing dependencies will be installed

    Env variable              Description               Value
    ------------              -----------               -----
    INCLUDEOS_SRC             Source dir of IncludeOS   /home/ubuntu/IncludeOS
    INCLUDEOS_PREFIX          Install location          /home/ubuntu/IncludeOS_install
    INCLUDEOS_ENABLE_TEST     Enable test compilation   ON
Is this correct [Y/n]?n
```