### PR TITLE
test: remove redundant definition of INCLUDEOS_SINGLE_THREADED

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ if ("${ARCH}" STREQUAL "")
   set (ARCH "ARCH_X86")
 endif("${ARCH}" STREQUAL "")
 
-add_definitions(-D${ARCH} -DINCLUDEOS_SINGLE_THREADED)
+add_definitions(-D${ARCH})
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_C_FLAGS "-m32 -g -O0 -std=c11 -Wall -Wextra")


### PR DESCRIPTION
Defer to existing definition in `api/smp` to avoid getting a bazillion warnings when building unittests