### PR TITLE
Some single-threaded work, SHA1 raw variant use vector

### DIFF
--- a/api/smp
+++ b/api/smp
@@ -23,8 +23,6 @@
 #include <arch.hpp>
 #include <delegate>
 
-#define INCLUDEOS_SINGLE_THREADED
-
 #ifdef INCLUDEOS_SINGLE_THREADED
 #define SMP_MAX_CORES   1
 #else

--- a/api/util/sha1.hpp
+++ b/api/util/sha1.hpp
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 class SHA1
 {
@@ -34,14 +35,15 @@ public:
     SHA1();
     // update with new data
     void update(const std::string&);
+    void update(const std::vector<char>&);
     void update(const char*, size_t);
     // finalize values
-    std::string as_raw();  // 20 bytes
-    std::string as_hex();  // 40 bytes
+    std::vector<char> as_raw();  // 20 bytes
+    std::string       as_hex();  // 40 bytes
 
-    // 20 byte SHA1 sum of string
-    static std::string oneshot_raw(const std::string&);
-    // 40 byte hex string of SHA1 sum
+    // 20 byte SHA1 raw value
+    static std::vector<char> oneshot_raw(const std::vector<char>&);
+    // 40 byte SHA1 hex string
     static std::string oneshot_hex(const std::string&);
 
 private:

--- a/cmake/post.service.cmake
+++ b/cmake/post.service.cmake
@@ -42,6 +42,7 @@ option(stripped "Strip symbols to further reduce size" OFF)
 
 add_definitions(-DARCH_${ARCH})
 add_definitions(-DARCH="${ARCH}")
+add_definitions(-DINCLUDEOS_SINGLE_THREADED)
 
 # Compiler optimization
 set(OPTIMIZE "-O2")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ enable_language(ASM_NASM)
 
 add_definitions(-DARCH_${ARCH})
 add_definitions(-DARCH="${ARCH}")
+add_definitions(-DINCLUDEOS_SINGLE_THREADED)
 
 include_directories(${INCLUDEOS_ROOT}/api/posix)
 include_directories(${LIBCXX_INCLUDE_DIR})

--- a/src/arch/x86/acpi.cpp
+++ b/src/arch/x86/acpi.cpp
@@ -377,7 +377,7 @@ namespace x86 {
   __attribute__((noreturn))
   void ACPI::shutdown()
   {
-    asm volatile("cli");
+    asm("cli");
 
     // ACPI shutdown
     get().acpi_shutdown();
@@ -393,8 +393,6 @@ namespace x86 {
 
     // VMWare poweroff when "gui.exitOnCLIHLT" is true
     printf("Shutdown failed :(\n");
-    while (true) {
-      asm volatile("cli; hlt" : : : "memory");
-    }
+    while (true) asm ("cli; hlt");
   }
 }

--- a/src/arch/x86/smp.cpp
+++ b/src/arch/x86/smp.cpp
@@ -120,9 +120,13 @@ std::vector<smp_done_func> SMP::get_completed()
 /// implementation of the SMP interface ///
 int ::SMP::cpu_id() noexcept
 {
+#ifdef INCLUDEOS_SINGLE_THREADED
+  return 0;
+#else
   int cpuid;
   asm volatile("movl %%fs:(0x0), %0" : "=r" (cpuid));
   return cpuid;
+#endif
 }
 int ::SMP::cpu_count() noexcept
 {

--- a/src/arch/x86_64/apic_asm.asm
+++ b/src/arch/x86_64/apic_asm.asm
@@ -50,4 +50,4 @@ reboot_os:
 
 reset_idtr:
     dw      400h - 1
-    dd      0
+    dq      0

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -282,11 +282,6 @@ void OS::shutdown()
   MYINFO("Soft shutdown signalled");
   power_ = false;
 }
-void OS::on_panic(on_panic_func func)
-{
-  extern on_panic_func panic_handler;
-  panic_handler = func;
-}
 
 void OS::add_stdout(OS::print_func func)
 {

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -108,7 +108,13 @@ char*  get_crash_context_buffer()
 }
 
 static bool panic_reenter = false;
-OS::on_panic_func panic_handler = nullptr;
+static OS::on_panic_func panic_handler = nullptr;
+
+void OS::on_panic(on_panic_func func)
+{
+  panic_handler = std::move(func);
+}
+
 /**
  * panic:
  * Display reason for kernel panic
@@ -179,7 +185,7 @@ void panic(const char* why)
   while (1) asm("cli; hlt");
   __builtin_unreachable();
 #else
-#warning "panic() handler not implemented for selected arch"
+  #warning "panic() handler not implemented for selected arch"
 #endif
 }
 

--- a/src/util/sha1.cpp
+++ b/src/util/sha1.cpp
@@ -285,12 +285,12 @@ void SHA1::finalize()
     transform(digest, block, transforms);
 }
 
-std::string SHA1::as_raw()
+std::vector<char> SHA1::as_raw()
 {
     finalize();
 
-    /* Result as hex string */
-    std::string result;  result.resize(20);
+    /* Result as raw character array */
+    std::vector<char> result(20);
     for (int i = 0; i < 5; i++) {
       result[i * 4 + 0] = digest[i] >> 24;
       result[i * 4 + 1] = digest[i] >> 16;
@@ -301,7 +301,7 @@ std::string SHA1::as_raw()
     /* Reset for next run */
     reset(digest, transforms);
     buffer_len = 0;
-    
+
     return result;
 }
 std::string SHA1::as_hex()
@@ -310,20 +310,20 @@ std::string SHA1::as_hex()
 
     /* Result as hex string */
     std::string result;  result.resize(40);
-    sprintf(&result[0], "%08x%08x%08x%08x%08x", 
+    sprintf(&result[0], "%08x%08x%08x%08x%08x",
              digest[0], digest[1], digest[2], digest[3], digest[4]);
 
     /* Reset for next run */
     reset(digest, transforms);
     buffer_len = 0;
-    
+
     return result;
 }
 
-std::string SHA1::oneshot_raw(const std::string& buffer)
+std::vector<char> SHA1::oneshot_raw(const std::vector<char>& vec)
 {
   SHA1 object;
-  object.update(buffer.c_str(), buffer.size());
+  object.update(vec.data(), vec.size());
   return object.as_raw();
 }
 std::string SHA1::oneshot_hex(const std::string& buffer)


### PR DESCRIPTION
- Move INCLUDEOS_SINGLE_THREADED to cmake build system
- Don't read fs/gs in single threaded mode at all
- Fix SHA1 not using vectors for raw variant

and others