### PR TITLE
cmake: arch-specific objcpy target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(CAPABS "${CAPABS} -mno-red-zone -fstack-protector-strong -D_STACK_GUARD_VALU
 # * _GNU_SOURCE enables POSIX-extensions in newlib, such as strnlen. ("everything newlib has", ref. cdefs.h)
 set(CAPABS "${CAPABS} -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_GNU_SOURCE")
 
-set(WARNS "-Wall -Wextra -Wno-expansion-to-defined")
+set(WARNS "-Wall -Wextra")
 
 # configure options
 option(debug "Build with debugging symbols (OBS: Dramatically increases binary size)" OFF)

--- a/etc/build_chainloader.sh
+++ b/etc/build_chainloader.sh
@@ -13,6 +13,13 @@ export ARCH=i686
 
 echo -e "\n\n>>> Building chainloader deps, $ARCH / $PLATFORM"
 
+if [ "Darwin" = "$SYSTEM" ]; then
+	if ! ./etc/install_dependencies_macos.sh; then
+		printf "%s\n" ">>> Sorry <<<"\
+					 "Could not install dependencies"
+	fi
+fi
+
 $INCLUDEOS_SRC/etc/install_from_bundle.sh
 
 echo -e "\n\n>>> Building chainloader"

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ done
 # SYSTEM PROPERTIES:
 ############################################################
 
-SYSTEM=`uname -s`
+export SYSTEM=`uname -s`
 
 read_linux_release() {
     LINE=`grep "^ID=" /etc/os-release`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,11 +2,14 @@
 # see: https://cmake.org/Bug/bug_relationship_graph.php?bug_id=13166
 if ("${ARCH}" STREQUAL "i686")
   set(CMAKE_ASM_NASM_OBJECT_FORMAT "elf")
+  set(OBJCPY_TARGET "elf32-i386")
 else()
   set(CMAKE_ASM_NASM_OBJECT_FORMAT "elf64")
+  set(OBJCPY_TARGET "elf64-x86-64")
 endif()
 
 enable_language(ASM_NASM)
+
 
 add_definitions(-DARCH_${ARCH})
 add_definitions(-DARCH="${ARCH}")

--- a/src/platform/x86_pc/CMakeLists.txt
+++ b/src/platform/x86_pc/CMakeLists.txt
@@ -17,7 +17,7 @@ set(X86_PC_OBJECTS
 add_custom_command(
 	OUTPUT apic_boot.o
 	COMMAND ${CMAKE_ASM_NASM_COMPILER} -f bin -o apic_boot.bin ${CMAKE_CURRENT_SOURCE_DIR}/apic_boot.asm
-	COMMAND ${CMAKE_OBJCOPY} -I binary -O elf64-x86-64 apic_boot.bin apic_boot.o
+	COMMAND ${CMAKE_OBJCOPY} -I binary -O ${OBJCPY_TARGET} apic_boot.bin apic_boot.o
 	DEPENDS apic_boot.asm
 )
 


### PR DESCRIPTION
This fixes building on mac for me. Still need a small fix to mac install script to trigger full build of dual toolchain though.