### PR TITLE
build: Cache ARCH, ignore build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,9 @@ src/compile_commands.json
 /examples/demo_service/IncludeOS_Demo_Service
 /seed/My_Service
 
-build
+build/
+build_i686/
+build_x86_64/
 
 # cmake related
 CMakeFiles*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,10 @@ cmake_minimum_required(VERSION 2.8.9)
 set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/)
 
 # Target CPU Architecture
-set(ARCH x86_64)
 if(DEFINED ENV{ARCH})
-  set(ARCH $ENV{ARCH})
+  set(ARCH "$ENV{ARCH}" CACHE STRING "Architecture")
+else()
+  set(ARCH "x86_64" CACHE STRING "Architecture (default)")
 endif()
 
 message(STATUS "Target CPU ${ARCH}")


### PR DESCRIPTION
This fixes the issue with ARCH environment variable breaking build folders