### PR TITLE
Changes to Inet on_config

### DIFF
--- a/api/net/dhcp/dh4client.hpp
+++ b/api/net/dhcp/dh4client.hpp
@@ -56,7 +56,7 @@ namespace net {
     IP4::addr    ipaddr, netmask, router, dns_server;
     std::string  domain_name;
     uint32_t     lease_time;
-    std::vector<config_func> config_handlers_;
+    config_func  config_handler_;
     Timer        timeout_timer_;
     bool         in_progress;
   };

--- a/api/net/dhcp/dh4client.hpp
+++ b/api/net/dhcp/dh4client.hpp
@@ -56,7 +56,7 @@ namespace net {
     IP4::addr    ipaddr, netmask, router, dns_server;
     std::string  domain_name;
     uint32_t     lease_time;
-    config_func  config_handler_;
+    std::vector<config_func> config_handlers_;
     Timer        timeout_timer_;
     bool         in_progress;
   };

--- a/api/net/inet.hpp
+++ b/api/net/inet.hpp
@@ -87,8 +87,12 @@ namespace net {
     /** Use DHCP to configure this interface */
     virtual void negotiate_dhcp(double timeout = 10.0, dhcp_timeout_func = nullptr) = 0;
 
-    /** Assign callback to when DHCP finishes */
-    virtual void on_config(dhcp_timeout_func handler) = 0;
+    virtual bool is_configured() const = 0;
+
+    using on_configured_func = delegate<void(Stack&)>;
+
+    /** Assign callback to when the stack has been configured */
+    virtual void on_config(on_configured_func handler) = 0;
 
     /** Get a list of virtual IP4 addresses assigned to this interface */
     virtual const Vip_list virtual_ips() const = 0;

--- a/api/net/inet4.hpp
+++ b/api/net/inet4.hpp
@@ -183,10 +183,17 @@ namespace net {
      */
     void negotiate_dhcp(double timeout = 10.0, dhcp_timeout_func = nullptr) override;
 
-    // handler called after the network successfully, or
-    // unsuccessfully negotiated with DHCP-server
-    // the timeout parameter indicates whether dhcp negotitation failed
-    void on_config(dhcp_timeout_func handler) override;
+    bool is_configured() const override
+    {
+      return ip4_addr_ != 0;
+    }
+
+    // handler called after the network is configured,
+    // either by DHCP or static network configuration
+    void on_config(on_configured_func handler) override
+    {
+      configured_handlers_.push_back(handler);
+    }
 
     /** We don't want to copy or move an IP-stack. It's tied to a device. */
     Inet4(Inet4&) = delete;
@@ -194,19 +201,10 @@ namespace net {
     Inet4& operator=(Inet4) = delete;
     Inet4 operator=(Inet4&&) = delete;
 
-    virtual void
-    network_config(IP4::addr addr, IP4::addr nmask, IP4::addr gateway, IP4::addr dns = IP4::ADDR_ANY) override
-    {
-      this->ip4_addr_  = addr;
-      this->netmask_   = nmask;
-      this->gateway_    = gateway;
-      this->dns_server_ = (dns == IP4::ADDR_ANY) ? gateway : dns;
-      INFO("Inet4", "Network configured");
-      INFO2("IP: \t\t%s", ip4_addr_.str().c_str());
-      INFO2("Netmask: \t%s", netmask_.str().c_str());
-      INFO2("Gateway: \t%s", gateway_.str().c_str());
-      INFO2("DNS Server: \t%s", dns_server_.str().c_str());
-    }
+    void network_config(IP4::addr addr,
+                        IP4::addr nmask,
+                        IP4::addr gateway,
+                        IP4::addr dns = IP4::ADDR_ANY) override;
 
     virtual void
     reset_config() override
@@ -334,6 +332,8 @@ namespace net {
     std::string domain_name_;
 
     std::shared_ptr<net::DHClient> dhcp_{};
+
+    std::vector<on_configured_func> configured_handlers_;
 
     int   cpu_id;
     const uint16_t MTU_;

--- a/src/net/dhcp/dh4client.cpp
+++ b/src/net/dhcp/dh4client.cpp
@@ -45,7 +45,7 @@ namespace net {
   void DHClient::on_config(config_func handler)
   {
     assert(handler);
-    config_handlers_.push_back(handler);
+    config_handler_ = handler;
   }
 
   void DHClient::timeout()
@@ -55,8 +55,10 @@ namespace net {
     this->in_progress = false;
 
     // call on_config with timeout = true
-    for(auto handler : this->config_handlers_)
-      handler(true);
+    if(config_handler_)
+      config_handler_(true);
+
+    config_handler_.reset();
   }
 
   void DHClient::negotiate(uint32_t timeout_secs)
@@ -312,8 +314,8 @@ namespace net {
     in_progress = false;
 
     // run some post-DHCP event to release the hounds
-    for (auto handler : config_handlers_)
-      handler(false);
+    if(config_handler_)
+      config_handler_(false);
   }
 
 }

--- a/src/net/dhcp/dh4client.cpp
+++ b/src/net/dhcp/dh4client.cpp
@@ -45,7 +45,7 @@ namespace net {
   void DHClient::on_config(config_func handler)
   {
     assert(handler);
-    config_handler_ = handler;
+    config_handlers_.push_back(handler);
   }
 
   void DHClient::timeout()
@@ -55,10 +55,8 @@ namespace net {
     this->in_progress = false;
 
     // call on_config with timeout = true
-    if(config_handler_)
-      config_handler_(true);
-
-    config_handler_.reset();
+    for(auto& handler : this->config_handlers_)
+      handler(true);
   }
 
   void DHClient::negotiate(uint32_t timeout_secs)
@@ -314,8 +312,8 @@ namespace net {
     in_progress = false;
 
     // run some post-DHCP event to release the hounds
-    if(config_handler_)
-      config_handler_(false);
+    for(auto& handler : this->config_handlers_)
+      handler(false);
   }
 
 }

--- a/src/net/inet4.cpp
+++ b/src/net/inet4.cpp
@@ -120,11 +120,25 @@ void Inet4::negotiate_dhcp(double timeout, dhcp_timeout_func handler) {
       dhcp_->on_config(handler);
 }
 
-void Inet4::on_config(dhcp_timeout_func handler)
+void Inet4::network_config(IP4::addr addr,
+                           IP4::addr nmask,
+                           IP4::addr gateway,
+                           IP4::addr dns)
 {
-  if(!dhcp_)
-      throw std::runtime_error("DHCP is not yet initialized");
-  dhcp_->on_config(handler);
+  this->ip4_addr_   = addr;
+  this->netmask_    = nmask;
+  this->gateway_    = gateway;
+  this->dns_server_ = (dns == IP4::ADDR_ANY) ? gateway : dns;
+  INFO("Inet4", "Network configured");
+  INFO2("IP: \t\t%s", ip4_addr_.str().c_str());
+  INFO2("Netmask: \t%s", netmask_.str().c_str());
+  INFO2("Gateway: \t%s", gateway_.str().c_str());
+  INFO2("DNS Server: \t%s", dns_server_.str().c_str());
+
+  for(auto& handler : configured_handlers_)
+    handler(*this);
+
+  configured_handlers_.clear();
 }
 
 void Inet4::process_sendq(size_t packets) {


### PR DESCRIPTION
You can now ask Inet if its configured, or setup one or more on_config events. These will only be called when the stack is being configured (no timeout). Negotiating DHCP works as usual (with the timeout callback). DHCP no longer got a vector of config handler but one on_config (default is printing to console that it has timed out).

Opinions?