### PR TITLE
clang_install: easier to install different clang versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ IncludeOS is free software, with "no warranties or restrictions of any kind".
 
 |        | Build from bundle | Integration tests |
 |--------|-------------------|-------------------|
-| Master | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_master_bundle)](https://jenkins.includeos.org/job/shield_master_bundle/) |  Coming soon |
-| Dev    | [![Build Status](https://jenkins.includeos.org/buildStatus/icon?job=shield_dev_bundle)](https://jenkins.includeos.org/job/shield_dev_bundle/)      | [![Jenkins tests](https://img.shields.io/jenkins/t/https/jenkins.includeos.org/shield_dev_integration_tests.svg)](https://jenkins.includeos.org/job/shield_dev_integration_tests/) |
+| Master | [![Build Status](https://img.shields.io/jenkins/s/https/jenkins.includeos.org/shield_master_bundle.svg)](https://jenkins.includeos.org/job/shield_master_bundle/) |  Coming soon |
+| Dev    | [![Build Status](https://img.shields.io/jenkins/s/https/jenkins.includeos.org/shield_dev_bundle.svg)](https://jenkins.includeos.org/job/shield_dev_bundle/)      | [![Jenkins tests](https://img.shields.io/jenkins/t/https/jenkins.includeos.org/shield_dev_integration_tests.svg)](https://jenkins.includeos.org/job/shield_dev_integration_tests/) |
 
 ### Key features
 

--- a/etc/install_clang_version.sh
+++ b/etc/install_clang_version.sh
@@ -1,16 +1,27 @@
-# Install a specific version of clang
-export clang_version=3.6
+#!/bin/bash
 
-sudo apt-get install -y clang-$clang_version
+# Install a specific version of clang on a specific ubuntu version
+clang_version=${1:-3.9}
+ubuntu_version=${2:-$(lsb_release -cs)}
 
-# Symlink. 
-if ! command clang --version; then
-    echo -e "\n\n >>> SYMLINKING CLANG (requires sudo) \n"
-    sudo ln -s /usr/bin/clang-$clang_version /usr/bin/clang
+# Check if wanted version of clang is installed
+if [[ $(command -v clang-$clang_version) && $(command -v clang++-$clang_version) ]]; then
+	echo clang-$clang_version and clang++-$clang_version are already installed 
+	exit 0
 fi
 
-if ! command clang++ --version; then
-    echo -e "\n\n >>> SYMLINKING CLANG++ (requires sudo) \n"
-    sudo ln -s /usr/bin/clang++-$clang_version /usr/bin/clang++
-fi
+# Construct apt string which is added to sources.list
+printf -v apt_string "deb http://apt.llvm.org/%s/ llvm-toolchain-%s-%s main
+deb-src http://apt.llvm.org/%s/ llvm-toolchain-%s-%s main" $name $name $clang_version $name $name $clang_version
 
+# Add to sources.list
+sudo sh -c 'echo $apt_string >> /etc/apt/sources.list'
+
+# Retrieve the archive signature
+wget -qO - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+
+# Update
+sudo apt-get -qq update
+
+# Install
+sudo apt-get install -qqy clang-$clang_version

--- a/etc/install_clang_version.sh
+++ b/etc/install_clang_version.sh
@@ -11,11 +11,11 @@ if [[ $(command -v clang-$clang_version) && $(command -v clang++-$clang_version)
 fi
 
 # Construct apt string which is added to sources.list
-printf -v apt_string "deb http://apt.llvm.org/%s/ llvm-toolchain-%s-%s main
-deb-src http://apt.llvm.org/%s/ llvm-toolchain-%s-%s main" $name $name $clang_version $name $name $clang_version
+export apt_string=$(printf "deb http://apt.llvm.org/%s/ llvm-toolchain-%s-%s main
+deb-src http://apt.llvm.org/%s/ llvm-toolchain-%s-%s main" $ubuntu_version $ubuntu_version $clang_version $ubuntu_version $ubuntu_version $clang_version)
 
 # Add to sources.list
-sudo sh -c 'echo $apt_string >> /etc/apt/sources.list'
+sudo -E sh -c 'echo $apt_string >> /etc/apt/sources.list'
 
 # Retrieve the archive signature
 wget -qO - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -

--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -6,9 +6,9 @@
 # OPTIONS:
 ############################################################
 
-BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip"
+BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip g++-multilib"
 CLANG_VERSION="3.9"
-TEST_DEPENDENCIES="g++ g++-multilib"
+TEST_DEPENDENCIES="g++"
 PYTHON_DEPENDENCIES="jsonschema psutil junit-xml filemagic"
 INSTALLED_PIP=0
 INSTALLED_CLANG=0

--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -6,10 +6,12 @@
 # OPTIONS:
 ############################################################
 
-BUILD_DEPENDENCIES="curl make clang cmake nasm bridge-utils qemu jq python-pip"
+BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip"
+CLANG_VERSION="3.9"
 TEST_DEPENDENCIES="g++ g++-multilib"
 PYTHON_DEPENDENCIES="jsonschema psutil junit-xml filemagic"
 INSTALLED_PIP=0
+INSTALLED_CLANG=0
 
 ############################################################
 # COMMAND LINE PROPERTIES:
@@ -67,6 +69,19 @@ if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
 		fi
 	done
 
+	# Check clang version
+	if [[ $(command -v clang-$CLANG_VERSION) ]]; then
+		INSTALLED_CLANG=1
+		if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
+			printf "\n%s\n" "clang-$CLANG_VERSION -> INSTALLED"
+	   	fi
+	else
+		if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
+			printf "%s\n\n" "clang-$CLANG_VERSION -> MISSING"
+		fi
+
+	fi
+
 	# Check if pip is installed
 	if pip --version > /dev/null 2>&1; then
 		INSTALLED_PIP=1
@@ -98,7 +113,7 @@ if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
 
 	# Exits if CHECK_ONLY is set, exit code 1 if there are packages to install
 	if [ $CHECK_ONLY -eq 1 ]; then
-		if [[ -z "$DEPENDENCIES" && -z "$PYTHON_DEPS_TO_INSTALL" ]]; then
+		if [[ -z "$DEPENDENCIES" && -z "$PYTHON_DEPS_TO_INSTALL" && $INSTALLED_CLANG -eq 1 ]]; then
 			exit 0
 		else
 			exit 1
@@ -136,5 +151,7 @@ case $SYSTEM in
                 ;;
         esac
 esac
+
+$INCLUDEOS_SRC/etc/install_clang_version.sh $CLANG_VERSION
 
 sudo -H pip -q install $PYTHON_DEPENDENCIES

--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -78,7 +78,7 @@ if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
 			if [ $? -eq 0 ]; then
 				if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
 					printf '     \e[32m%-15s\e[0m %-20s %s \n'\
-						"INSTALLED" $(pip list --format=legacy 2> /dev/null | grep $package)
+						"INSTALLED" $(pip list 2> /dev/null | grep $package)
 				fi
 			else
 				if [ $PRINT_INSTALL_STATUS -eq 1 ]; then


### PR DESCRIPTION
- all shields now use shields.io
- pip deps properly display
- clang install improvements
- g++-multilib is always needed, now a default dependency