### PR TITLE
syslog_test: Added seperate interface for test

### DIFF
--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -7,7 +7,7 @@
 ############################################################
 
 BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip g++-multilib"
-CLANG_VERSION="3.9"
+CLANG_VERSION="3.8"
 TEST_DEPENDENCIES="g++"
 PYTHON_DEPENDENCIES="jsonschema psutil junit-xml filemagic"
 INSTALLED_PIP=0
@@ -77,7 +77,7 @@ if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
 	   	fi
 	else
 		if [ $PRINT_INSTALL_STATUS -eq 1 ]; then
-			printf "%s\n\n" "clang-$CLANG_VERSION -> MISSING"
+			printf "\n%s\n" "clang-$CLANG_VERSION -> MISSING"
 		fi
 
 	fi

--- a/test/posix/integration/syslog_plugin/service.cpp
+++ b/test/posix/integration/syslog_plugin/service.cpp
@@ -40,7 +40,7 @@ int main()
                                    {  10,  0,  0,  1} );   // DNS
 
   // Setting IP and port for the syslog messages
-  Syslog::settings( {10, 0, 0, 1}, 6514 );
+  Syslog::settings( {10, 0, 0, 2}, 6514 );
   printf("Syslog messages are sent to IP %s and port %d\n", Syslog::ip().str().c_str(), Syslog::port());
 
   // Starts the python integration test:

--- a/test/posix/integration/syslog_plugin/test.py
+++ b/test/posix/integration/syslog_plugin/test.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 import sys
 import os
+import subprocess
+import atexit
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -12,9 +14,17 @@ vm = vmrunner.vms[0]
 
 import socket
 
-# Gateway IP is 10.0.0.1 - syslog sends its messages here on port 6514
+# Gateway IP is 10.0.0.2 - syslog sends its messages here on port 6514
 
-UDP_IP = "10.0.0.1"
+# Set up a temporary interface
+subprocess.call(["sudo", "ifconfig", "bridge43:0", "10.0.0.2/24"])
+
+# Tear down interface on exit
+@atexit.register
+def tear_down():
+    subprocess.call(["sudo", "ifconfig", "bridge43:0", "down"])
+
+UDP_IP = "10.0.0.2"
 UDP_PORT = 6514
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.bind((UDP_IP, UDP_PORT))


### PR DESCRIPTION
Should now pass the syslog_plugin test. This is a bit of a dirty hack while we await a better solution to cases like this. 

Only test that should not pass now is the posix/main test