### PR TITLE
i686: Add stack sentinel support, fix GDT issue, TLS verified

### DIFF
--- a/src/arch/i686/arch_start.asm
+++ b/src/arch/i686/arch_start.asm
@@ -28,6 +28,9 @@ __arch_start:
     push ebp
     mov ebp, esp
 
+    ;; hack to avoid stack protector
+    mov DWORD [0x1014], 0x89abcdef
+
     ;; Push params on 16-byte aligned stack
     sub esp, 8
     and esp, -16
@@ -40,3 +43,11 @@ __arch_start:
     mov esp, ebp
     pop ebp
     ret
+
+sentinel_table:
+    dd sentinel_table ;; 0x0
+    dd 0 ;; 0x8
+    dd 0 ;; 0x10
+    dd 0 ;; 0x18
+    dd 0 ;; 0x20
+    dd 0x123456789ABCDEF

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -150,7 +150,7 @@ SECTIONS
     _DATA_END_ = .;
   }
 
-  .tdata :
+  .tdata ALIGN(0x10) :
   {
     _TDATA_START_ = .;
     *(.tdata .tdata.*)

--- a/src/platform/x86_pc/gdt.cpp
+++ b/src/platform/x86_pc/gdt.cpp
@@ -50,21 +50,21 @@ void GDT::initialize() noexcept
   data.base_hi  = 0;
 }
 
-int GDT::create_data(void* ptr, uint16_t pages) noexcept
+int GDT::create_data(void* ptr, int size) noexcept
 {
   uintptr_t base = (uintptr_t) ptr;
-  assert((base & 0xf) == 0); // at least 16-byte aligned
-  this->create_data(base, pages);
+  assert((base & 0x3) == 0); // at least 4-byte aligned
+  this->create_data(base, size);
   return this->count-1;
 }
 
-gdt_entry& GDT::create_data(uint32_t base, uint16_t size) noexcept
+gdt_entry& GDT::create_data(uint32_t base, int size) noexcept
 {
   auto& ent = create();
-  ent.limit_lo = size;
+  ent.limit_lo = size & 0xffff;
   ent.base_lo  = base & 0xffffff;
   ent.access   = ACCESS_DATA;
-  ent.limit_hi = 0x0;
+  ent.limit_hi = (size >> 16) & 0xf;
   ent.flags    = FLAGS_X32_PAGE;
   ent.base_hi  = (base >> 24) & 0xff;
   return ent;

--- a/src/platform/x86_pc/gdt.hpp
+++ b/src/platform/x86_pc/gdt.hpp
@@ -85,10 +85,10 @@ struct GDT
   }
 
   // create new data entry and return index
-  int create_data(void* base, uint16_t pages) noexcept;
+  int create_data(void* base, int) noexcept;
 
 private:
-  gdt_entry& create_data(uint32_t base, uint16_t size) noexcept;
+  gdt_entry& create_data(uint32_t base, int size) noexcept;
 
   uint16_t  count = 0;
   gdt_desc  desc;

--- a/src/platform/x86_pc/start.asm
+++ b/src/platform/x86_pc/start.asm
@@ -73,6 +73,7 @@ rock_bottom:
   mov ds, cx
   mov es, cx
   mov fs, cx
+  mov cx, 0x18 ;; GS segment
   mov gs, cx
 
   ;; Set up stack.
@@ -185,6 +186,12 @@ gdt32:
   dw 0x0000          ;Base 15:00
   db 0x00            ;Base 23:16
   dw 0xcf92          ;Flags / Limit / Type [F,L,F,Type]
+  db 0x00            ;Base 32:24
+  ;; Entry 0x18: GS Data segment
+  dw 0x0100          ;Limit
+  dw 0x1000          ;Base 15:00
+  db 0x00            ;Base 23:16
+  dw 0x4092          ;Flags / Limit / Type [F,L,F,Type]
   db 0x00            ;Base 32:24
 gdt32_end:
 


### PR DESCRIPTION
Bottom line: 
- TLS support on i386
- Fixes SERIOUS issue on 32-bit with uninitialized stack guard
- 64-bit also lacked stack guard initialization, but was fixed in previous commit