### PR TITLE
Removed g++-multilib from fedora dependencies

### DIFF
--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -141,7 +141,8 @@ case $SYSTEM in
                 sudo apt-get -qqy install $DEPENDENCIES > /dev/null || exit 1
                 ;;
             "fedora")
-                DEPENDENCIES="$DEPENDENCIES"
+                # Removes g++-multilib from dependencies
+                DEPENDENCIES=${DEPENDENCIES%g++-multilib}
                 sudo dnf install $DEPENDENCIES || exit 1
                 ;;
             "arch")


### PR DESCRIPTION
The g++-multilib package is not in the fedora repositories. 

This causes the installation to crash when it tries to install the dependencies.  


