### PR TITLE
syscalls: new panic signature

### DIFF
--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -41,6 +41,9 @@
 // We can't use the usual "info", as printf isn't available after call to exit
 #define SYSINFO(TEXT, ...) kprintf("%13s ] " TEXT "\n", "[ Kernel", ##__VA_ARGS__)
 
+// Emitted if and only if panic (unrecoverable system wide error) happens
+const char* panic_signature = "\x15\x07\t**** PANIC ****";
+
 char*   __env[1] {nullptr};
 char**  environ {__env};
 extern "C" {
@@ -92,7 +95,7 @@ int kill(pid_t pid, int sig) THROW {
   }
   SMP::global_unlock();
 
-  panic("\tKilling a process doesn't make sense in IncludeOS. Panic.");
+  panic("kill called");
   errno = ESRCH;
   return -1;
 }
@@ -130,9 +133,8 @@ bool OS::is_panicking() noexcept
  * Display reason for kernel panic
  * Display last crash context value, if it exists
  * Display no-heap backtrace of stack
- * Print EOT character to stderr, to signal outside that PANIC occured
- * Call on_panic handler function, which determines what to do when
- *    the kernel panics
+ * Call on_panic handler function, to allow application specific panic behavior
+ * Print EOT character to stderr, to signal outside that PANIC output completed
  * If the handler returns, go to (permanent) sleep
 **/
 void panic(const char* why)
@@ -144,8 +146,9 @@ void panic(const char* why)
 
   /// display informacion ...
   SMP::global_lock();
-  fprintf(stderr, "\n\t**** CPU %d PANIC: ****\n %s\n",
-          current_cpu, why);
+
+  fprintf(stderr, "\n%s\nCPU: %d, Reason: %s\n",
+          panic_signature, current_cpu, why);
 
   // crash context (can help determine source of crash)
   const int len = strnlen(get_crash_context_buffer(), get_crash_context_length());
@@ -158,9 +161,9 @@ void panic(const char* why)
   typedef unsigned long ulong;
   uintptr_t heap_total = OS::heap_max() - heap_begin;
   double total = (heap_end - heap_begin) / (double) heap_total;
-  fprintf(stderr, "\tHeap is at: %p / %p  (diff=%lu)\n",
+  fprintf(stderr, "Heap is at: %p / %p  (diff=%lu)\n",
          (void*) heap_end, (void*) OS::heap_max(), (ulong) (OS::heap_max() - heap_end));
-  fprintf(stderr, "\tHeap usage: %lu / %lu Kb\n", // (%.2f%%)\n",
+  fprintf(stderr, "Heap usage: %lu / %lu Kb\n", // (%.2f%%)\n",
          (ulong) (heap_end - heap_begin) / 1024,
          (ulong) heap_total / 1024); //, total * 100.0);
 

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -473,7 +473,7 @@ class vm:
         self._on_panic =  self.panic
         self._on_timeout = self.timeout
         self._on_output = {
-            "PANIC" : self._on_panic,
+            "\\x15\\x07\\t\*\*\*\* PANIC \*\*\*\*" : self._on_panic,
             "SUCCESS" : self._on_success }
 
         # Initialize hypervisor with config


### PR DESCRIPTION
Added a new panic signature to emitted if and only if a panic happened. The reasoning is that we'd like to identify panic from `boot`, with extremely little chance of false positives. We also want:
* To be able to extract panic reports from log files
* Keep output nice and readable (hence non-printing ascii)
* To be able to look for panic cheaply while searching logs / output, but return early if no panic (first char is rare)
* Retain semantics of non printable acii chars. 0x15 is NAK (negative ack - error), 0x07 is Bell. (Yes, this might get picked up by your terminal, resulting in a visual / audible response if you're looking at boot output while panicking.)
* Have the panic signature be easily expressed in multiple languages, e.g. python, go, c++, javascript. `"\x15\x07\t**** PANIC ****"` means the same thing in all those languages and they can all identify panic using native string equality test.

There are a few caveats, such as chrome potentially interpreting the contents of the file as binary if the panic happens really early, and that the regex for capturing this will have lots of backslashes. For now I think the benefits outweigh the disadvantages, but feel free to argue!