### PR TITLE
Functionality required by the latest LiveUpdate

### DIFF
--- a/api/hw/devices.hpp
+++ b/api/hw/devices.hpp
@@ -49,6 +49,7 @@ namespace hw {
     /** List all devices (decorated, as seen in boot output) */
     inline static void print_devices();
 
+    inline static void flush_all();
 
     inline static void deactivate_all();
 
@@ -160,6 +161,11 @@ namespace hw {
   {
     deactivate_type(devices<hw::Block_device>());
     deactivate_type(devices<hw::Nic>());
+  }
+  inline void Devices::flush_all()
+  {
+    for (auto& dev : devices<hw::Nic>())
+        dev->flush();
   }
 
 } //< namespace hw

--- a/api/posix/sys/mman.h
+++ b/api/posix/sys/mman.h
@@ -35,6 +35,7 @@ struct posix_typed_mem_info
 int    mlock(const void *, size_t);
 int    mlockall(int);
 void  *mmap(void *, size_t, int, int, int, off_t);
+void  *mremap(void*, size_t, size_t, int flags, ... /* void *new_address */);
 int    mprotect(void *, size_t, int);
 int    msync(void *, size_t, int);
 int    munlock(const void *, size_t);
@@ -67,6 +68,9 @@ int    shm_unlink(const char *);
 
 // Returned on failure to allocate pages
 #define MAP_FAILED    ((void*)-1)
+
+#define MREMAP_FIXED    0x2
+#define MREMAP_MAYMOVE  0x4
 
 #ifdef __cplusplus
 }

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -55,9 +55,9 @@ extern uintptr_t _ELF_END_;
 bool  OS::power_   = true;
 bool  OS::boot_sequence_passed_ = false;
 MHz   OS::cpu_mhz_ {-1};
-uintptr_t OS::low_memory_size_  {0};
-uintptr_t OS::high_memory_size_ {0};
-uintptr_t OS::memory_end_ {0};
+uintptr_t OS::low_memory_size_  = 0;
+uintptr_t OS::high_memory_size_ = 0;
+uintptr_t OS::memory_end_ = 0;
 uintptr_t OS::heap_max_ {0xfffffff};
 const uintptr_t OS::elf_binary_size_ {(uintptr_t)&_ELF_END_ - (uintptr_t)&_ELF_START_};
 std::string OS::cmdline{Service::binary_name()};
@@ -114,11 +114,12 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr)
   }
   Expects(high_memory_size_);
 
+  // NOTE: end of physical memory can be set by soft-reset
+  OS::memory_end_ = OS::high_memory_size_ + 0x100000;
+
   PROFILE("Memory map");
   // Assign memory ranges used by the kernel
   auto& memmap = memory_map();
-
-  OS::memory_end_ = high_memory_size_ + 0x100000;
   MYINFO("Assigning fixed memory ranges (Memory map)");
 
   memmap.assign_range({0x6000, 0x8fff, "Statman", "Statistics"});
@@ -286,12 +287,14 @@ size_t OS::print(const char* str, const size_t len)
 void OS::legacy_boot() {
   // Fetch CMOS memory info (unfortunately this is maximally 10^16 kb)
   auto mem = hw::CMOS::meminfo();
-  low_memory_size_ = mem.base.total * 1024;
-  INFO2("* Low memory: %i Kib", mem.base.total);
-  high_memory_size_ = mem.extended.total * 1024;
-
-  // Use memsize provided by Make / linker unless CMOS knows this is wrong
-  INFO2("* High memory (from cmos): %i Kib", mem.extended.total);
+  if (low_memory_size_ == 0) {
+    low_memory_size_ = mem.base.total * 1024;
+    INFO2("* Low memory: %i Kib", mem.base.total);
+  }
+  if (high_memory_size_ == 0) {
+    high_memory_size_ = mem.extended.total * 1024;
+    INFO2("* High memory (from cmos): %i Kib", mem.extended.total);
+  }
 
   auto& memmap = memory_map();
 

--- a/src/kernel/softreset.cpp
+++ b/src/kernel/softreset.cpp
@@ -45,6 +45,8 @@ void OS::resume_softreset(intptr_t addr)
 
   /// restore known values
   OS::memory_end_ = data->high_mem;
+  OS::low_memory_size_ = 0x100000;
+  OS::high_memory_size_ = OS::memory_end_ - 0x100000;
   OS::cpu_mhz_    = data->cpu_freq;
   x86::apic_timer_set_ticks(data->apic_ticks);
 


### PR DESCRIPTION
- hw::Devices::flush_all()
- Soft reset preserves memory limits properly