### PR TITLE
Utilize hardware CRC32-support when possible

### DIFF
--- a/src/kernel/sanity_checks.cpp
+++ b/src/kernel/sanity_checks.cpp
@@ -40,9 +40,7 @@ static void self_test_gconstr() {
 
 static uint32_t generate_ro_crc() noexcept
 {
-  uint32_t crc = CRC32_BEGIN();
-  crc = crc32(crc, &_TEXT_START_, &_RODATA_END_ - &_TEXT_START_);
-  return CRC32_VALUE(crc);
+  return crc32_fast(&_TEXT_START_, &_RODATA_END_ - &_TEXT_START_);
 }
 
 extern "C"

--- a/src/kernel/softreset.cpp
+++ b/src/kernel/softreset.cpp
@@ -35,7 +35,7 @@ void OS::resume_softreset(intptr_t addr)
   /// validate soft-reset data
   const uint32_t csum_copy = data->checksum;
   data->checksum = 0;
-  uint32_t crc = crc32(data, sizeof(softreset_t));
+  uint32_t crc = crc32_fast(data, sizeof(softreset_t));
   if (crc != csum_copy) {
     kprintf("[!] Failed to verify CRC of softreset data: %08x vs %08x\n",
             crc, csum_copy);
@@ -66,7 +66,7 @@ void* __os_store_soft_reset(void* extra, size_t extra_len)
   data->extra       = extra;
   data->extra_len   = extra_len;
 
-  uint32_t csum = crc32(data, sizeof(softreset_t));
+  uint32_t csum = crc32_fast(data, sizeof(softreset_t));
   data->checksum = csum;
   return data;
 }


### PR DESCRIPTION
- This reduces LiveUpdate time from 20ms to 11ms, so its cut by about half.
- crc32_fast() cannot be mixed with outside checksums, as it uses an Intel polynomial