### PR TITLE
cmake: external projects now build always

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ if(vmbuild)
   # Install vmbuilder as an external project
   ExternalProject_Add(vmbuild
     PREFIX vmbuild # Build where
+    BUILD_ALWAYS 1
     SOURCE_DIR ${INCLUDEOS_ROOT}/vmbuild # Where is project located
     BINARY_DIR ${INCLUDEOS_ROOT}/vmbuild/build
     INSTALL_DIR ${BIN} # Where to install
@@ -151,6 +152,7 @@ endif(vmbuild)
 option(diskbuilder "Build and install memdisk helper tool" ON)
 if(diskbuilder)
   ExternalProject_Add(diskbuilder
+    BUILD_ALWAYS 1
     SOURCE_DIR ${INCLUDEOS_ROOT}/diskimagebuild
     BINARY_DIR ${INCLUDEOS_ROOT}/diskimagebuild/build
     INSTALL_DIR ${BIN}

--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -7,7 +7,7 @@
 ############################################################
 
 BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip g++-multilib"
-CLANG_VERSION="3.8"
+[ ! -z "$CC" ] && { CLANG_VERSION=${CC: -3}; } || CLANG_VERSION="3.8"
 TEST_DEPENDENCIES="g++"
 PYTHON_DEPENDENCIES="jsonschema psutil junit-xml filemagic"
 INSTALLED_PIP=0


### PR DESCRIPTION
Fixes #1385.
Adding `BUILD_ALWAYS` does not slow down the make step if no changes have been made (which I thought it would do). It performs as I would hope where it builds again if either the output files have been deleted, or if there are changes made to the src files.