### PR TITLE
solo5: should not set booted_at to the new reboot time after a solo5_exec

### DIFF
--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -144,9 +144,8 @@ void OS::start(char* _cmdline, uintptr_t mem_size)
   extern void __platform_init();
   __platform_init();
 
-  booted_at_ = solo5_clock_monotonic();
   MYINFO("Booted at monotonic_ns=%lld walltime_ns=%lld",
-         booted_at_, solo5_clock_wall());
+         solo5_clock_monotonic(), solo5_clock_wall());
 
   MYINFO("Initializing RNG");
   PROFILE("RNG init");


### PR DESCRIPTION
When doing a `solo5_exec` we are resetting `uptime` and `micros_since_boot`. This is wrong as `micros_since_boot` should measure the time since the first boot (not the reboot due to the exec).
This change fixes that by not setting the `booted_at_` variable at every boot; instead, it leaves it at 0. This is a good approximation as `booted_at_` usually has less than 1 ms (~700000 nanoseconds).

@fwsGonzo ^^^