### PR TITLE
Fix IPv4 address validation

### DIFF
--- a/api/net/ip4/addr.hpp
+++ b/api/net/ip4/addr.hpp
@@ -107,10 +107,9 @@ struct Addr {
 
     const static std::regex ipv4_address_pattern
     {
-      "^\\s*(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
-        "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
-        "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\."
-        "(25[0–5]|2[0–4]\\d|[01]?\\d\\d?)\\s*$"
+#define OCTET_PATTERN "(25[0-5]|2[0-4]\\d|[01]?\\d\\d?)"
+      "^\\s*" OCTET_PATTERN "\\." OCTET_PATTERN "\\." OCTET_PATTERN "\\." OCTET_PATTERN "\\s*$"
+#undef OCTET_PATTERN
     };
 
     std::smatch ipv4_parts;

--- a/test/net/unit/ip4_addr.cpp
+++ b/test/net/unit/ip4_addr.cpp
@@ -52,6 +52,15 @@ CASE("Create IP4 addresses from strings")
   Addr ipv4_address {extra_whitespace_addr_str};
   EXPECT(ipv4_address.str() == "10.0.0.42");
 
+  EXPECT_NO_THROW(Addr("202.209.27.78"));
+  EXPECT_NO_THROW(Addr("212.209.27.78"));
+  EXPECT_NO_THROW(Addr("222.209.27.78"));
+  EXPECT_NO_THROW(Addr("232.209.27.78"));
+  EXPECT_NO_THROW(Addr("242.209.27.78"));
+  EXPECT_NO_THROW(Addr("255.209.27.78"));
+  EXPECT_THROWS(Addr("265.209.27.78"));
+  EXPECT_THROWS(Addr("256.209.27.78"));
+
   EXPECT_THROWS(Addr{"LUL"});
   EXPECT_THROWS(Addr{"12310298310298301283"});
   EXPECT_THROWS(const Addr invalid{"256.256.256.256"});


### PR DESCRIPTION
The regex had an en-dash instead of a hyphen in the character range