### PR TITLE
solo5: don't call timers::ready before initializing devices

### DIFF
--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -168,6 +168,8 @@ void OS::start(char* _cmdline, uintptr_t mem_size)
     }
   }
 
+  Solo5_manager::init();
+
   // We don't need a start or stop function in solo5.
   Timers::init(
     // timer start function
@@ -189,8 +191,6 @@ void OS::start(char* _cmdline, uintptr_t mem_size)
          static_cast<int>(sizeof(uintptr_t)) * 8);
   printf(" +--> Running [ %s ]\n", Service::name().c_str());
   FILLINE('~');
-
-  Solo5_manager::init();
 
   Service::start();
   // NOTE: this is a feature for service writers, don't move!


### PR DESCRIPTION
Some apps like tcp-perf do their work inside `Service::ready` instead of `Service::start`, so they expect a network stack at `ready`. Solo5 initialization currently calls `Timers::init` which calls `Service::ready` before initializing devices (in `Solo5_manager::init`). This change reorders that.