### PR TITLE
x86: Move IDT and CPU exceptions to x86 IDT

### DIFF
--- a/api/arch.hpp
+++ b/api/arch.hpp
@@ -29,6 +29,11 @@ extern void __arch_poweroff();
 extern void __arch_reboot();
 extern void __arch_enable_legacy_irq(uint8_t);
 extern void __arch_disable_legacy_irq(uint8_t);
+
+extern void __arch_install_irq(uint8_t, void(*)());
+extern void __arch_subscribe_irq(uint8_t);
+extern void __arch_unsubscribe_irq(uint8_t);
+
 inline void __arch_hw_barrier() noexcept;
 inline void __sw_barrier() noexcept;
 inline uint64_t __arch_cpu_cycles() noexcept;

--- a/src/kernel/irq_manager.cpp
+++ b/src/kernel/irq_manager.cpp
@@ -23,10 +23,7 @@
 #include <statman>
 #include <kprint>
 #include <smp>
-
 //#define DEBUG_SMP
-#define LAPIC_IRQ_BASE   120
-#define RING0_CODE_SEG   0x8
 
 static std::array<IRQ_manager, SMP_MAX_CORES> managers;
 
@@ -55,169 +52,6 @@ void IRQ_manager::register_irq(uint8_t irq)
   count_received[irq]++;
 }
 
-extern "C" {
-  extern void* get_cpu_esp();
-  extern void unused_interrupt_handler();
-  extern void modern_interrupt_handler();
-  extern void spurious_intr();
-}
-
-static const char* exception_names[] =
-{
-  "Divide-by-zero Error",
-  "Debug",
-  "Non-maskable Interrupt",
-  "Breakpoint",
-  "Overflow",
-  "Bound Range Exceeded",
-  "Invalid Opcode",
-  "Device Not Available",
-  "Double Fault",
-  "Reserved",
-  "Invalid TSS",
-  "Segment Not Present",
-  "Stack-Segment Fault",
-  "General Protection Fault",
-  "Page Fault",
-  "Reserved",
-  "x87 Floating-point Exception",
-  "Alignment Check",
-  "Machine Check",
-  "SIMD Floating-point Exception",
-  "Virtualization Exception",
-  "Reserved",
-  "Reserved",
-  "Reserved",
-  "Reserved",
-  "Reserved",
-  "Reserved",
-  "Reserved",
-  "Reserved",
-  "Reserved",
-  "Security Exception",
-  "Reserved"
-};
-
-// Only certain exceptions have error codes
-template <int NR>
-typename std::enable_if<((NR >= 8 and NR <= 15) or NR == 17 or NR == 30)>::type
-print_error_code(uint32_t err){
-  kprintf("Error code: 0x%x \n", err);
-}
-
-// Default: no error code
-template <int NR>
-typename std::enable_if<((NR < 8 or NR > 15) and NR != 17 and NR != 30)>::type
-print_error_code(uint32_t){}
-
-inline void cpu_dump_regs()
-{
-#if defined(ARCH_x86_64)
-  // CPU registers
-  uintptr_t regs[24];
-  asm ("movq %%rax, %0" : "=a" (regs[0]));
-  asm ("movq %%rbx, %0" : "=b" (regs[1]));
-  asm ("movq %%rcx, %0" : "=c" (regs[2]));
-  asm ("movq %%rdx, %0" : "=d" (regs[3]));
-  asm ("movq %%rbp, %0" : "=a" (regs[4]));
-
-  asm ("movq %%r8, %0"  : "=a" (regs[5]));
-  asm ("movq %%r9, %0"  : "=b" (regs[6]));
-  asm ("movq %%r10, %0" : "=c" (regs[7]));
-  asm ("movq %%r11, %0" : "=d" (regs[8]));
-  asm ("movq %%r12, %0" : "=a" (regs[9]));
-  asm ("movq %%r13, %0" : "=b" (regs[10]));
-  asm ("movq %%r14, %0" : "=c" (regs[11]));
-  asm ("movq %%r15, %0" : "=d" (regs[12]));
-
-  asm ("movq %%rsp, %0" : "=a" (regs[13]));
-  asm ("movq %%rsi, %0" : "=b" (regs[14]));
-  asm ("movq %%rdi, %0" : "=c" (regs[15]));
-  asm ("leaq (%%rip), %0" : "=d" (regs[16]));
-
-  asm ("pushf; popq %0" : "=a" (regs[17]));
-  asm ("movq %%cr0, %0" : "=b" (regs[18]));
-  regs[19] = 0;
-  asm ("movq %%cr2, %0" : "=c" (regs[20]));
-  asm ("movq %%cr3, %0" : "=d" (regs[21]));
-  asm ("movq %%cr4, %0" : "=a" (regs[22]));
-  asm ("movq %%cr8, %0" : "=b" (regs[23]));
-
-  struct desc_table_t {
-    uint16_t  limit;
-    uintptr_t location;
-  } __attribute__((packed))  gdt, idt;
-  asm ("sgdtq %0" : : "m" (* &gdt));
-  asm ("sidtq %0" : : "m" (* &idt));
-
-  fprintf(stderr, "\n");
-  printf("  RAX:  %016lx  R 8:  %016lx\n", regs[0], regs[5]);
-  printf("  RBX:  %016lx  R 9:  %016lx\n", regs[1], regs[6]);
-  printf("  RCX:  %016lx  R10:  %016lx\n", regs[2], regs[7]);
-  printf("  RDX:  %016lx  R11:  %016lx\n", regs[3], regs[8]);
-  fprintf(stderr, "\n");
-
-  printf("  RBP:  %016lx  R12:  %016lx\n", regs[4], regs[9]);
-  printf("  RSP:  %016lx  R13:  %016lx\n", regs[13], regs[10]);
-  printf("  RSI:  %016lx  R14:  %016lx\n", regs[14], regs[11]);
-  printf("  RDI:  %016lx  R15:  %016lx\n", regs[15], regs[12]);
-  printf("  RIP:  %016lx  FLA:  %016lx\n", regs[16], regs[17]);
-  fprintf(stderr, "\n");
-
-  printf("  CR0:  %016lx  CR4:  %016lx\n", regs[18], regs[22]);
-  printf("  CR1:  %016lx  CR8:  %016lx\n", regs[19], regs[23]);
-  printf("  CR2:  %016lx  GDT:  %016lx (%u)\n", regs[20], gdt.location, gdt.limit);
-  printf("  CR3:  %016lx  IDT:  %016lx (%u)\n", regs[21], idt.location, idt.limit);
-
-#elif defined(ARCH_i686)
-  // CPU registers
-  uintptr_t regs[16];
-  asm ("movl %%eax, %0" : "=a" (regs[0]));
-  asm ("movl %%ebx, %0" : "=b" (regs[1]));
-  asm ("movl %%ecx, %0" : "=c" (regs[2]));
-  asm ("movl %%edx, %0" : "=d" (regs[3]));
-
-  asm ("movl %%ebp, %0" : "=r" (regs[4]));
-  asm ("movl %%esp, %0" : "=r" (regs[5]));
-  asm ("movl %%esi, %0" : "=r" (regs[6]));
-  asm ("movl %%edi, %0" : "=r" (regs[7]));
-
-  asm ("movl (%%esp), %0" : "=r" (regs[8]));
-  asm ("pushf; popl %0" : "=r" (regs[9]));
-
-  fprintf(stderr, "\n");
-  printf("  EAX:  %08x  EBP:  %08x\n", regs[0], regs[4]);
-  printf("  EBX:  %08x  ESP:  %08x\n", regs[1], regs[5]);
-  printf("  ECX:  %08x  ESI:  %08x\n", regs[2], regs[6]);
-  printf("  EDX:  %08x  EDI:  %08x\n", regs[3], regs[7]);
-  printf("  EIP:  %08x  EFL:  %08x\n", regs[8], regs[9]);
-
-#else
-  #error "Implement me"
-#endif
-  fprintf(stderr, "\n");
-}
-
-template <int NR>
-void cpu_exception(void** eip, uint32_t error)
-{
-  SMP::global_lock();
-  cpu_dump_regs();
-  kprintf("\n>>>> !!! CPU %u EXCEPTION !!! <<<<\n", SMP::cpu_id());
-  kprintf("    %s (%d)   EIP  %p\n", exception_names[NR], NR, eip);
-  print_error_code<NR>(error);
-  SMP::global_unlock();
-  // call panic, which will decide what to do next
-  char buffer[64];
-  snprintf(buffer, sizeof(buffer), "%s (%d)", exception_names[NR], NR);
-  panic(buffer);
-}
-
-
-void IRQ_manager::enable_interrupts() {
-  asm volatile("sti");
-}
-
 void IRQ_manager::init()
 {
   get().init_local();
@@ -234,103 +68,6 @@ void IRQ_manager::init_local()
   // prevent get_free_irq from returning taken IDs
   for (uint8_t irq = 0; irq < 32; irq++)
       irq_subs.set(irq);
-
-  if (SMP::cpu_id() == 0)
-      INFO("INTR", "Creating exception handlers");
-  set_exception_handler(0, cpu_exception<0>);
-  set_exception_handler(1, cpu_exception<1>);
-  set_exception_handler(2, cpu_exception<2>);
-  set_exception_handler(3, cpu_exception<3>);
-  set_exception_handler(4, cpu_exception<4>);
-  set_exception_handler(5, cpu_exception<5>);
-  set_exception_handler(6, cpu_exception<6>);
-  set_exception_handler(7, cpu_exception<7>);
-  set_exception_handler(8, cpu_exception<8>);
-  set_exception_handler(9, cpu_exception<9>);
-  set_exception_handler(10, cpu_exception<10>);
-  set_exception_handler(11, cpu_exception<11>);
-  set_exception_handler(12, cpu_exception<12>);
-  set_exception_handler(13, cpu_exception<13>);
-  set_exception_handler(14, cpu_exception<14>);
-  set_exception_handler(15, cpu_exception<15>);
-  set_exception_handler(16, cpu_exception<16>);
-  set_exception_handler(17, cpu_exception<17>);
-  set_exception_handler(18, cpu_exception<18>);
-  set_exception_handler(19, cpu_exception<19>);
-  set_exception_handler(20, cpu_exception<20>);
-  set_exception_handler(30, cpu_exception<30>);
-
-  if (SMP::cpu_id() == 0)
-      INFO2("+ Default interrupt gates set for irq >= 32");
-  for (size_t i = 32; i < INTR_LINES - 1; i++){
-    set_handler(i, unused_interrupt_handler);
-  }
-  // spurious interrupt handler
-  set_handler(INTR_LINES - 1, spurious_intr);
-
-  // Load IDT
-  IDTR idt_reg;
-  idt_reg.limit = INTR_LINES * sizeof(IDTDescr) - 1;
-  idt_reg.base = (uintptr_t) idt;
-  asm volatile ("lidt %0": :"m"(idt_reg) );
-}
-
-// A union to be able to extract the lower and upper part of an address
-union addr_union {
-  uintptr_t whole;
-  struct {
-    uint16_t lo16;
-    uint16_t hi16;
-#ifdef ARCH_x86_64
-    uint32_t top32;
-#endif
-  };
-};
-
-void IRQ_manager::create_gate(
-    IDTDescr* idt_entry,
-    intr_func func,
-    uint16_t segment_sel,
-    char attributes)
-{
-  addr_union addr;
-  addr.whole           = (uintptr_t) func;
-  idt_entry->offset_1  = addr.lo16;
-  idt_entry->offset_2  = addr.hi16;
-#ifdef ARCH_x86_64
-  idt_entry->offset_3  = addr.top32;
-#endif
-  idt_entry->selector  = segment_sel;
-  idt_entry->type_attr = attributes;
-  idt_entry->zero      = 0;
-}
-
-IRQ_manager::intr_func IRQ_manager::get_handler(uint8_t vec) {
-  addr_union addr;
-  addr.lo16  = idt[vec].offset_1;
-  addr.hi16  = idt[vec].offset_2;
-#ifdef ARCH_x86_64
-  addr.top32 = idt[vec].offset_3;
-#endif
-
-  return (intr_func) addr.whole;
-}
-IRQ_manager::intr_func IRQ_manager::get_irq_handler(uint8_t irq)
-{
-  return get_handler(irq + IRQ_BASE);
-}
-
-void IRQ_manager::set_handler(uint8_t vec, intr_func func) {
-  create_gate(&idt[vec], func, RING0_CODE_SEG, 0x8e);
-}
-
-void IRQ_manager::set_exception_handler(uint8_t vec, exception_func func) {
-  create_gate(&idt[vec], (intr_func) func, RING0_CODE_SEG, 0x8e);
-}
-
-void IRQ_manager::set_irq_handler(uint8_t irq, intr_func func)
-{
-  set_handler(irq + IRQ_BASE, func);
 }
 
 void IRQ_manager::enable_irq(uint8_t irq) {
@@ -353,7 +90,7 @@ void IRQ_manager::subscribe(uint8_t irq, irq_delegate del)
     panic("IRQ value out of range (too high)!");
 
   // cheap way of changing from unused handler to event loop irq marker
-  set_irq_handler(irq, modern_interrupt_handler);
+  __arch_subscribe_irq(irq);
 
   // Mark IRQ as subscribed to
   irq_subs.atomic_set(irq);

--- a/src/kernel/profile.cpp
+++ b/src/kernel/profile.cpp
@@ -91,7 +91,7 @@ static Sampler& get() {
 void StackSampler::begin()
 {
   // install interrupt handler
-  IRQ_manager::get().set_irq_handler(0, parasite_interrupt_handler);
+  __arch_install_irq(0, parasite_interrupt_handler);
   // start taking samples using PIT interrupts
   get().begin();
 }

--- a/src/platform/x86_nano/CMakeLists.txt
+++ b/src/platform/x86_nano/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PLATFORM_OBJECTS
   ../x86_pc/block.cpp
   ../x86_pc/softreset.cpp
   ../x86_pc/sanity_checks.cpp
+  ../x86_pc/idt.cpp
   platform.cpp
   kernel_start.cpp
   )

--- a/src/platform/x86_nano/platform.cpp
+++ b/src/platform/x86_nano/platform.cpp
@@ -4,6 +4,7 @@
 #include "../x86_pc/apic.hpp"
 #include "../x86_pc/apic_timer.hpp"
 #include "../x86_pc/ioapic.hpp"
+#include "../x86_pc/idt.hpp"
 
 using namespace x86;
 using namespace std::chrono;
@@ -16,9 +17,10 @@ void __arch_poweroff()
   __builtin_unreachable();
 }
 
-void __platform_init(){
-  // FIXME: set up minimal CPU exception handlers
-  // TODO: set up minimal CPU exception handlers
+void __platform_init()
+{
+  // setup CPU exception handlers
+  x86::idt_initialize_for_cpu(0);
 }
 
 void __arch_reboot(){}

--- a/src/platform/x86_pc/CMakeLists.txt
+++ b/src/platform/x86_pc/CMakeLists.txt
@@ -17,6 +17,7 @@ set(X86_PC_OBJECTS
   pic.cpp
   softreset.cpp
   sanity_checks.cpp
+  idt.cpp
   )
 
 add_custom_command(

--- a/src/platform/x86_pc/apic_revenant.cpp
+++ b/src/platform/x86_pc/apic_revenant.cpp
@@ -2,6 +2,7 @@
 
 #include "apic.hpp"
 #include "apic_timer.hpp"
+#include "idt.hpp"
 #include <kernel/irq_manager.hpp>
 #include <kernel/rng.hpp>
 #include <kprint>
@@ -79,9 +80,10 @@ void revenant_main(int cpu)
   SMP::global_unlock();
   assert(cpu == SMP::cpu_id());
 
+  x86::idt_initialize_for_cpu(cpu);
   IRQ_manager::init();
   // enable interrupts
-  IRQ_manager::enable_interrupts();
+  asm volatile("sti");
   // init timer system
   APIC_Timer::init();
   // subscribe to task and timer interrupts

--- a/src/platform/x86_pc/idt.cpp
+++ b/src/platform/x86_pc/idt.cpp
@@ -1,0 +1,304 @@
+#include "idt.hpp"
+#include <kernel/irq_manager.hpp>
+#include <kernel/syscalls.hpp>
+#include <kprint>
+#include <info>
+#define RING0_CODE_SEG   0x8
+
+extern "C" {
+  extern void* get_cpu_esp();
+  extern void unused_interrupt_handler();
+  extern void modern_interrupt_handler();
+  extern void spurious_intr();
+}
+
+#define INTR_LINES IRQ_manager::INTR_LINES
+#define IRQ_LINES  IRQ_manager::IRQ_LINES
+
+namespace x86
+{
+typedef void (*intr_handler_t)();
+typedef void (*except_handler_t)(void**, uint32_t);
+
+struct x86_IDT
+{
+  IDTDescr entry[INTR_LINES] __attribute__((aligned(16)));
+
+  intr_handler_t get_handler(uint8_t vec);
+  void set_handler(uint8_t, intr_handler_t);
+  void set_exception_handler(uint8_t, except_handler_t);
+
+  void init();
+};
+static std::array<x86_IDT, SMP_MAX_CORES> idt;
+
+void idt_initialize_for_cpu(int cpu) {
+  idt.at(cpu).init();
+}
+
+/// CPU EXCEPTIONS ///
+
+static const char* exception_names[] =
+{
+  "Divide-by-zero Error",
+  "Debug",
+  "Non-maskable Interrupt",
+  "Breakpoint",
+  "Overflow",
+  "Bound Range Exceeded",
+  "Invalid Opcode",
+  "Device Not Available",
+  "Double Fault",
+  "Reserved",
+  "Invalid TSS",
+  "Segment Not Present",
+  "Stack-Segment Fault",
+  "General Protection Fault",
+  "Page Fault",
+  "Reserved",
+  "x87 Floating-point Exception",
+  "Alignment Check",
+  "Machine Check",
+  "SIMD Floating-point Exception",
+  "Virtualization Exception",
+  "Reserved",
+  "Reserved",
+  "Reserved",
+  "Reserved",
+  "Reserved",
+  "Reserved",
+  "Reserved",
+  "Reserved",
+  "Reserved",
+  "Security Exception",
+  "Reserved"
+};
+
+// Only certain exceptions have error codes
+template <int NR>
+typename std::enable_if<((NR >= 8 and NR <= 15) or NR == 17 or NR == 30)>::type
+print_error_code(uint32_t err){
+  kprintf("Error code: 0x%x \n", err);
+}
+
+// Default: no error code
+template <int NR>
+typename std::enable_if<((NR < 8 or NR > 15) and NR != 17 and NR != 30)>::type
+print_error_code(uint32_t){}
+
+inline void cpu_dump_regs()
+{
+#if defined(ARCH_x86_64)
+  // CPU registers
+  uintptr_t regs[24];
+  asm ("movq %%rax, %0" : "=a" (regs[0]));
+  asm ("movq %%rbx, %0" : "=b" (regs[1]));
+  asm ("movq %%rcx, %0" : "=c" (regs[2]));
+  asm ("movq %%rdx, %0" : "=d" (regs[3]));
+  asm ("movq %%rbp, %0" : "=a" (regs[4]));
+
+  asm ("movq %%r8, %0"  : "=a" (regs[5]));
+  asm ("movq %%r9, %0"  : "=b" (regs[6]));
+  asm ("movq %%r10, %0" : "=c" (regs[7]));
+  asm ("movq %%r11, %0" : "=d" (regs[8]));
+  asm ("movq %%r12, %0" : "=a" (regs[9]));
+  asm ("movq %%r13, %0" : "=b" (regs[10]));
+  asm ("movq %%r14, %0" : "=c" (regs[11]));
+  asm ("movq %%r15, %0" : "=d" (regs[12]));
+
+  asm ("movq %%rsp, %0" : "=a" (regs[13]));
+  asm ("movq %%rsi, %0" : "=b" (regs[14]));
+  asm ("movq %%rdi, %0" : "=c" (regs[15]));
+  asm ("leaq (%%rip), %0" : "=d" (regs[16]));
+
+  asm ("pushf; popq %0" : "=a" (regs[17]));
+  asm ("movq %%cr0, %0" : "=b" (regs[18]));
+  regs[19] = 0;
+  asm ("movq %%cr2, %0" : "=c" (regs[20]));
+  asm ("movq %%cr3, %0" : "=d" (regs[21]));
+  asm ("movq %%cr4, %0" : "=a" (regs[22]));
+  asm ("movq %%cr8, %0" : "=b" (regs[23]));
+
+  struct desc_table_t {
+    uint16_t  limit;
+    uintptr_t location;
+  } __attribute__((packed))  gdt, idt;
+  asm ("sgdtq %0" : : "m" (* &gdt));
+  asm ("sidtq %0" : : "m" (* &idt));
+
+  fprintf(stderr, "\n");
+  printf("  RAX:  %016lx  R 8:  %016lx\n", regs[0], regs[5]);
+  printf("  RBX:  %016lx  R 9:  %016lx\n", regs[1], regs[6]);
+  printf("  RCX:  %016lx  R10:  %016lx\n", regs[2], regs[7]);
+  printf("  RDX:  %016lx  R11:  %016lx\n", regs[3], regs[8]);
+  fprintf(stderr, "\n");
+
+  printf("  RBP:  %016lx  R12:  %016lx\n", regs[4], regs[9]);
+  printf("  RSP:  %016lx  R13:  %016lx\n", regs[13], regs[10]);
+  printf("  RSI:  %016lx  R14:  %016lx\n", regs[14], regs[11]);
+  printf("  RDI:  %016lx  R15:  %016lx\n", regs[15], regs[12]);
+  printf("  RIP:  %016lx  FLA:  %016lx\n", regs[16], regs[17]);
+  fprintf(stderr, "\n");
+
+  printf("  CR0:  %016lx  CR4:  %016lx\n", regs[18], regs[22]);
+  printf("  CR1:  %016lx  CR8:  %016lx\n", regs[19], regs[23]);
+  printf("  CR2:  %016lx  GDT:  %016lx (%u)\n", regs[20], gdt.location, gdt.limit);
+  printf("  CR3:  %016lx  IDT:  %016lx (%u)\n", regs[21], idt.location, idt.limit);
+
+#elif defined(ARCH_i686)
+  // CPU registers
+  uintptr_t regs[16];
+  asm ("movl %%eax, %0" : "=a" (regs[0]));
+  asm ("movl %%ebx, %0" : "=b" (regs[1]));
+  asm ("movl %%ecx, %0" : "=c" (regs[2]));
+  asm ("movl %%edx, %0" : "=d" (regs[3]));
+
+  asm ("movl %%ebp, %0" : "=r" (regs[4]));
+  asm ("movl %%esp, %0" : "=r" (regs[5]));
+  asm ("movl %%esi, %0" : "=r" (regs[6]));
+  asm ("movl %%edi, %0" : "=r" (regs[7]));
+
+  asm ("movl (%%esp), %0" : "=r" (regs[8]));
+  asm ("pushf; popl %0" : "=r" (regs[9]));
+
+  fprintf(stderr, "\n");
+  printf("  EAX:  %08x  EBP:  %08x\n", regs[0], regs[4]);
+  printf("  EBX:  %08x  ESP:  %08x\n", regs[1], regs[5]);
+  printf("  ECX:  %08x  ESI:  %08x\n", regs[2], regs[6]);
+  printf("  EDX:  %08x  EDI:  %08x\n", regs[3], regs[7]);
+  printf("  EIP:  %08x  EFL:  %08x\n", regs[8], regs[9]);
+
+#else
+  #error "Unknown architecture"
+#endif
+  fprintf(stderr, "\n");
+}
+
+template <int NR>
+void cpu_exception(void** eip, uint32_t error)
+{
+  SMP::global_lock();
+  cpu_dump_regs();
+  kprintf("\n>>>> !!! CPU %u EXCEPTION !!! <<<<\n", SMP::cpu_id());
+  kprintf("    %s (%d)   EIP  %p\n", exception_names[NR], NR, eip);
+  print_error_code<NR>(error);
+  SMP::global_unlock();
+  // call panic, which will decide what to do next
+  char buffer[64];
+  snprintf(buffer, sizeof(buffer), "%s (%d)", exception_names[NR], NR);
+  panic(buffer);
+}
+
+// A union to be able to extract the lower and upper part of an address
+union addr_union {
+  uintptr_t whole;
+  struct {
+    uint16_t lo16;
+    uint16_t hi16;
+#ifdef ARCH_x86_64
+    uint32_t top32;
+#endif
+  };
+};
+
+static void set_intr_entry(
+    IDTDescr* idt_entry,
+    intr_handler_t func,
+    uint16_t segment_sel,
+    char attributes)
+{
+  addr_union addr;
+  addr.whole           = (uintptr_t) func;
+  idt_entry->offset_1  = addr.lo16;
+  idt_entry->offset_2  = addr.hi16;
+#ifdef ARCH_x86_64
+  idt_entry->offset_3  = addr.top32;
+#endif
+  idt_entry->selector  = segment_sel;
+  idt_entry->type_attr = attributes;
+#ifdef ARCH_x86_64
+  idt_entry->ist       = 0;
+#else
+  idt_entry->zero      = 0;
+#endif
+}
+
+intr_handler_t x86_IDT::get_handler(uint8_t vec)
+{
+  addr_union addr;
+  addr.lo16  = entry[vec].offset_1;
+  addr.hi16  = entry[vec].offset_2;
+#ifdef ARCH_x86_64
+  addr.top32 = entry[vec].offset_3;
+#endif
+
+  return (intr_handler_t) addr.whole;
+}
+
+void x86_IDT::set_handler(uint8_t vec, intr_handler_t func) {
+  set_intr_entry(&entry[vec], func, RING0_CODE_SEG, 0x8e);
+}
+void x86_IDT::set_exception_handler(uint8_t vec, except_handler_t func) {
+  set_intr_entry(&entry[vec], (intr_handler_t) func, RING0_CODE_SEG, 0x8e);
+}
+
+void x86_IDT::init()
+{
+  if (SMP::cpu_id() == 0)
+      INFO("INTR", "Creating exception handlers");
+  set_exception_handler(0, cpu_exception<0>);
+  set_exception_handler(1, cpu_exception<1>);
+  set_exception_handler(2, cpu_exception<2>);
+  set_exception_handler(3, cpu_exception<3>);
+  set_exception_handler(4, cpu_exception<4>);
+  set_exception_handler(5, cpu_exception<5>);
+  set_exception_handler(6, cpu_exception<6>);
+  set_exception_handler(7, cpu_exception<7>);
+  set_exception_handler(8, cpu_exception<8>);
+  set_exception_handler(9, cpu_exception<9>);
+  set_exception_handler(10, cpu_exception<10>);
+  set_exception_handler(11, cpu_exception<11>);
+  set_exception_handler(12, cpu_exception<12>);
+  set_exception_handler(13, cpu_exception<13>);
+  set_exception_handler(14, cpu_exception<14>);
+  set_exception_handler(15, cpu_exception<15>);
+  set_exception_handler(16, cpu_exception<16>);
+  set_exception_handler(17, cpu_exception<17>);
+  set_exception_handler(18, cpu_exception<18>);
+  set_exception_handler(19, cpu_exception<19>);
+  set_exception_handler(20, cpu_exception<20>);
+  set_exception_handler(30, cpu_exception<30>);
+
+  if (SMP::cpu_id() == 0)
+      INFO2("+ Default interrupt gates set for irq >= 32");
+
+  for (size_t i = 32; i < INTR_LINES - 1; i++) {
+    set_handler(i, unused_interrupt_handler);
+  }
+  // spurious interrupt handler
+  set_handler(INTR_LINES - 1, spurious_intr);
+
+  // Load IDT
+  IDTR idt_reg;
+  idt_reg.limit = INTR_LINES * sizeof(IDTDescr) - 1;
+  idt_reg.base = (uintptr_t) &entry[0];
+  asm volatile ("lidt %0" : : "m"(idt_reg));
+}
+
+} // x86
+
+void __arch_subscribe_irq(uint8_t irq)
+{
+  assert(irq < IRQ_LINES);
+  PER_CPU(x86::idt).set_handler(IRQ_BASE + irq, modern_interrupt_handler);
+}
+void __arch_install_irq(uint8_t irq, x86::intr_handler_t handler)
+{
+  assert(irq < IRQ_LINES);
+  PER_CPU(x86::idt).set_handler(IRQ_BASE + irq, handler);
+}
+void __arch_unsubscribe_irq(uint8_t irq)
+{
+  assert(irq < IRQ_LINES);
+  PER_CPU(x86::idt).set_handler(IRQ_BASE + irq, unused_interrupt_handler);
+}

--- a/src/platform/x86_pc/idt.hpp
+++ b/src/platform/x86_pc/idt.hpp
@@ -20,21 +20,36 @@
 
 #include <arch.hpp>
 
+namespace x86
+{
+#ifdef ARCH_x86_64
+// 64-bit
+struct IDTDescr {
+  uint16_t offset_1;  // offset bits 0..15
+  uint16_t selector;  // a code segment selector in GDT or LDT
+  uint8_t  ist;       // 3-bit interrupt stack table offset
+  uint8_t  type_attr; // type and attributes, see below
+  uint16_t offset_2;  // offset bits 16..31
+  uint32_t offset_3;  // 32..63
+  uint32_t zero2;
+};
+#else
+// 32-bit
 struct IDTDescr {
   uint16_t offset_1;  // offset bits 0..15
   uint16_t selector;  // a code segment selector in GDT or LDT
   uint8_t  zero;      // unused, set to 0
   uint8_t  type_attr; // type and attributes, see below
   uint16_t offset_2;  // offset bits 16..31
-#ifdef ARCH_x86_64
-  uint32_t offset_3;  // 32..63
-  uint32_t zero2;
-#endif
 };
+#endif
 
 struct IDTR {
   uint16_t  limit;
   uintptr_t base;
 }__attribute__((packed));
+
+extern void idt_initialize_for_cpu(int cpu);
+}
 
 #endif

--- a/src/platform/x86_pc/pit.cpp
+++ b/src/platform/x86_pc/pit.cpp
@@ -53,10 +53,8 @@ namespace x86
     auto temp_mode     = get().current_mode_;
     auto temp_freq_div = get().current_freq_divider_;
 
-    auto prev_irq_handler = IRQ_manager::get().get_irq_handler(0);
-
     debug("<CPU frequency> Measuring...\n");
-    IRQ_manager::get().set_irq_handler(0, cpu_sampling_irq_entry);
+    __arch_install_irq(0, cpu_sampling_irq_entry);
 
     // GO!
     get().set_mode(RATE_GEN);
@@ -70,7 +68,7 @@ namespace x86
     get().set_mode(temp_mode);
     get().set_freq_divider(temp_freq_div);
 
-    IRQ_manager::get().set_irq_handler(0, prev_irq_handler);
+    __arch_subscribe_irq(0);
     return freq;
   }
 

--- a/src/platform/x86_pc/platform.cpp
+++ b/src/platform/x86_pc/platform.cpp
@@ -63,6 +63,7 @@ static_assert(offsetof(smp_table, guard) == 0x28, "Linux stack sentinel");
 using namespace x86;
 namespace x86 {
   void initialize_tls_for_smp();
+  extern void idt_initialize_for_cpu(int);
 }
 
 void __platform_init()
@@ -79,6 +80,7 @@ void __platform_init()
   initialize_gdt_for_cpu(APIC::get().get_id());
 
   // IDT manager: Interrupt and exception handlers
+  x86::idt_initialize_for_cpu(0);
   IRQ_manager::init();
 
   // initialize and start registered APs found in ACPI-tables
@@ -88,7 +90,7 @@ void __platform_init()
 
   // enable interrupts
   MYINFO("Enabling interrupts");
-  IRQ_manager::enable_interrupts();
+  asm volatile("sti");
 
   // Estimate CPU frequency
   MYINFO("Estimating CPU-frequency");

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -94,6 +94,7 @@ void OS::multiboot(unsigned) {}
 
 extern "C" {
 
+/// Kernel ///
   char _binary_apic_boot_bin_end;
   char _binary_apic_boot_bin_start;
   char _ELF_START_;
@@ -107,6 +108,7 @@ extern "C" {
     return 0xdeadbeef;
   }
 
+/// C ABI ///
   void _init_c_runtime() {}
   void _init_bss() {}
   void _init_heap(uintptr_t) {}
@@ -117,13 +119,6 @@ extern "C" {
 
   void __libc_init_array () {}
 
-  /// IRQ manager ///
-  void modern_interrupt_handler() {}
-  void unused_interrupt_handler() {}
-  void spurious_intr() {}
-  void cpu_sampling_irq_entry() {}
-
-
   uintptr_t _multiboot_free_begin(uintptr_t) {
     return 0;
   }
@@ -131,10 +126,7 @@ extern "C" {
     return 0;
   }
 
-  void reboot_os() {
-    assert(0 && "Reboot called");
-  }
-
+  /// malloc ///
   struct mallinfo { int x; };
   struct mallinfo mallinfo() {
     return {0};
@@ -162,9 +154,11 @@ extern "C" void kernel_sanity_checks() {}
 /// arch ///
 void __arch_poweroff() {}
 void __arch_reboot() {}
+void __arch_subscribe_irq(uint8_t) {}
 void __arch_enable_legacy_irq(uint8_t) {}
 void __arch_disable_legacy_irq(uint8_t) {}
 
+/// smp ///
 #include <smp>
 int SMP::cpu_id() noexcept {
   return 0;


### PR DESCRIPTION
... in preparation for adding long-mode TSS, interrupt stack tables and enabling red-zone