### PR TITLE
x86: Use CMOS century register to calculate year correctly

### DIFF
--- a/api/hw/cmos.hpp
+++ b/api/hw/cmos.hpp
@@ -153,8 +153,7 @@ namespace hw
        * (For initialization. Recommended practice by CG I.24)
        **/
       struct Fields {
-        uint8_t century = 0;
-        uint8_t year = 0;
+        int     year = 0;
         uint8_t month = 0;
         uint8_t day_of_month = 0;
         uint8_t day_of_week = 0;
@@ -163,8 +162,7 @@ namespace hw
         uint8_t second = 0;
       };
 
-      uint8_t century() { return f.century; }
-      uint16_t year() { return f.century * 100 + f.year; }
+      uint16_t year() { return f.year; }
       uint8_t month() { return f.month; }
       uint8_t day_of_month() { return f.day_of_month; }
       uint8_t day_of_week() { return f.day_of_week; }

--- a/api/hw/cmos.hpp
+++ b/api/hw/cmos.hpp
@@ -45,7 +45,7 @@ namespace hw
     static const reg_t r_day = 0x7;
     static const reg_t r_month = 0x8;
     static const reg_t r_year = 0x9;
-    static const reg_t r_cent = 0x48;
+    //static const reg_t r_cent = 0x48;
 
     // RTC Alarm registers
     static const reg_t r_alarm_sec = 0x1;
@@ -164,7 +164,7 @@ namespace hw
       };
 
       uint8_t century() { return f.century; }
-      uint16_t year() { return (f.century + 20) * 100 + f.year; }
+      uint16_t year() { return f.century * 100 + f.year; }
       uint8_t month() { return f.month; }
       uint8_t day_of_month() { return f.day_of_month; }
       uint8_t day_of_week() { return f.day_of_week; }

--- a/src/hw/cmos.cpp
+++ b/src/hw/cmos.cpp
@@ -1,5 +1,6 @@
 #include <hw/cmos.hpp>
 #include <statman>
+#include "../platform/x86_pc/acpi.hpp"
 
 using namespace hw;
 uint8_t   CMOS::reg_b_value = 0;
@@ -18,6 +19,7 @@ void CMOS::init()
 CMOS::Time& CMOS::Time::hw_update() {
   // We're supposed to check this before every read
   while (update_in_progress());
+  const reg_t r_cent = x86::ACPI::get().cmos_century();
 
   if (CMOS::mode_binary()) {
     f.second = get(r_sec);
@@ -36,7 +38,7 @@ CMOS::Time& CMOS::Time::hw_update() {
     f.day_of_month = bcd_to_binary(get(r_day));
     f.month = bcd_to_binary(get(r_month));
     f.year =  bcd_to_binary(get(r_year));
-    f.century = get(r_cent);
+    f.century = bcd_to_binary(get(r_cent));
   }
 
   // Convert to 24-hour clock if necessary
@@ -51,7 +53,7 @@ CMOS::Time& CMOS::Time::hw_update() {
 std::string CMOS::Time::to_string(){
   std::array<char,20> str;
   sprintf(str.data(), "%.2i-%.2i-%iT%.2i:%.2i:%.2iZ",
-          (f.century + 20) * 100 + f.year,
+          f.century * 100 + f.year,
           f.month,
           f.day_of_month,
           f.hour, f.minute, f.second);

--- a/src/hw/cmos.cpp
+++ b/src/hw/cmos.cpp
@@ -30,7 +30,7 @@ CMOS::Time& CMOS::Time::hw_update() {
     f.day_of_month = get(r_day);
     f.month = get(r_month);
     f.year =  get(r_year);
-    century = get(r_cent);
+    if (r_cent) century = get(r_cent);
   } else {
     f.second = bcd_to_binary(get(r_sec));
     f.minute = bcd_to_binary(get(r_min));
@@ -39,12 +39,12 @@ CMOS::Time& CMOS::Time::hw_update() {
     f.day_of_month = bcd_to_binary(get(r_day));
     f.month = bcd_to_binary(get(r_month));
     f.year =  bcd_to_binary(get(r_year));
-    century = bcd_to_binary(get(r_cent));
+    if (r_cent) century = bcd_to_binary(get(r_cent));
   }
 
   // Insanity
   #define CURRENT_YEAR  2017  // Change this each year!
-  if (century != 0) {
+  if (r_cent != 0) {
     f.year += century * 100;
   } else {
     f.year += (CURRENT_YEAR / 100) * 100;


### PR DESCRIPTION
Fixes https://github.com/hioa-cs/IncludeOS/issues/1305