### PR TITLE
lib: Make LiveUpdate::resume boolean

### DIFF
--- a/lib/LiveUpdate/liveupdate.hpp
+++ b/lib/LiveUpdate/liveupdate.hpp
@@ -53,7 +53,7 @@ struct LiveUpdate
   // Register a function to be called when serialization phase begins
   // Internally it will be stored as its own partition and can be restored using
   // the same @key value during the resume process
-  static void register_serialization_callback(std::string key, storage_func);
+  static void register_partition(std::string key, storage_func);
 
   // Start a live update process, storing all user-defined data
   // If no storage functions are registered no state will be saved
@@ -76,7 +76,9 @@ struct LiveUpdate
   static bool is_resumable(void* location);
 
   // Restore existing state for a partition named @key.
-  static void resume(std::string key, resume_func handler);
+  // Returns false if there was no such partition
+  // Can throw lots of standard exceptions
+  static bool resume(std::string key, resume_func handler);
 
   // When explicitly resuming from heap, heap overrun checks are disabled
   static void resume_from_heap(void* location, std::string key, resume_func);

--- a/lib/LiveUpdate/partition.cpp
+++ b/lib/LiveUpdate/partition.cpp
@@ -59,7 +59,7 @@ int storage_header::find_partition(const char* key)
       throw std::runtime_error("Invalid CRC in partition '" + std::string(key) + "'");
     }
   }
-  throw std::out_of_range("Could not find partition named " + std::string(key));
+  return -1;
 }
 void storage_header::finish_partition(int p)
 {

--- a/lib/LiveUpdate/update.cpp
+++ b/lib/LiveUpdate/update.cpp
@@ -36,9 +36,8 @@
 
 static const int SECT_SIZE   = 512;
 static const int ELF_MINIMUM = 164;
-
-extern "C"
-void solo5_exec(const char*, size_t);
+// hotswapping functions
+extern "C" void solo5_exec(const char*, size_t);
 static void* HOTSWAP_AREA = (void*) 0x8000;
 extern "C" void  hotswap(const char*, int, char*, uintptr_t, void*);
 extern "C" char  __hotswap_length;
@@ -61,7 +60,7 @@ static size_t update_store_data(void* location, const buffer_t*);
 // serialization callbacks
 static std::unordered_map<std::string, LiveUpdate::storage_func> storage_callbacks;
 
-void LiveUpdate::register_serialization_callback(std::string key, storage_func callback)
+void LiveUpdate::register_partition(std::string key, storage_func callback)
 {
   auto it = storage_callbacks.find(key);
   if (it == storage_callbacks.end())
@@ -86,7 +85,7 @@ inline bool validate_header(const Class* hdr)
 
 void LiveUpdate::exec(const buffer_t& blob, std::string key, storage_func func)
 {
-  if (func != nullptr) register_serialization_callback(key, func);
+  if (func != nullptr) LiveUpdate::register_partition(key, func);
   LiveUpdate::exec(blob);
 }
 

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -47,7 +47,7 @@ namespace uplink {
   {
     OS::add_stdout({this, &WS_uplink::send_log});
 
-    liu::LiveUpdate::register_serialization_callback("uplink", {this, &WS_uplink::store});
+    liu::LiveUpdate::register_partition("uplink", {this, &WS_uplink::store});
 
     read_config();
     CHECK(config_.reboot, "Reboot on panic");

--- a/test/kernel/integration/LiveUpdate/service.cpp
+++ b/test/kernel/integration/LiveUpdate/service.cpp
@@ -31,5 +31,7 @@ void Service::start()
   {
     auto& inet = net::Super_stack::get<net::IP4>(0);
     setup_liveupdate_server(inet, 666, func);
+    // signal test.py that the server is up
+    printf("Ready to receive binary blob\n");
   }
 }

--- a/test/kernel/integration/LiveUpdate/test.py
+++ b/test/kernel/integration/LiveUpdate/test.py
@@ -4,7 +4,7 @@ import os
 import socket
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
-                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
+           os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src)
 
 from vmrunner import vmrunner

--- a/test/kernel/integration/LiveUpdate/test_boot.cpp
+++ b/test/kernel/integration/LiveUpdate/test_boot.cpp
@@ -28,17 +28,15 @@ static void boot_resume_all(Restore& thing)
 
 LiveUpdate::storage_func begin_test_boot()
 {
-  try {
-    LiveUpdate::resume("test", boot_resume_all);
-    // if we are here,
-    // resume() must have succeeded
+  if (LiveUpdate::resume("test", boot_resume_all))
+  {
     if (timestamps.size() >= 30)
     {
       // calculate median by sorting
       std::sort(timestamps.begin(), timestamps.end());
       auto median = timestamps[timestamps.size()/2];
       // show information
-      printf("Median boot time over %lu samples: %llu micros\n",
+      printf("Median boot time over %lu samples: %ld micros\n",
               timestamps.size(), median);
       /*
       for (auto& stamp : timestamps) {
@@ -52,9 +50,6 @@ LiveUpdate::storage_func begin_test_boot()
       // immediately liveupdate
       LiveUpdate::exec(bloberino, "test", boot_save);
     }
-  }
-  catch (std::exception& e) {
-    printf("Ready to receive binary blob\n");
   }
   // wait for update
   return boot_save;


### PR DESCRIPTION
Also rename `register_serialization_callback` to simply `register_partition`.

Resume setup is simplified if normal execution simply returns false if there is nothing to resume.