### PR TITLE
solo5: Force page-aligment for first ELF segment

### DIFF
--- a/src/arch/x86_64/linker.ld
+++ b/src/arch/x86_64/linker.ld
@@ -23,7 +23,8 @@ SECTIONS
   PROVIDE ( _ELF_START_ = . + 0xA00000);
   PROVIDE ( _LOAD_START_ = _ELF_START_); /* For convenience w. multiboot */
 
-  .multiboot (_ELF_START_ + SIZEOF_HEADERS): {
+  . = _ELF_START_ + SIZEOF_HEADERS;
+  .multiboot ALIGN(0x1000): {
       PROVIDE(_MULTIBOOT_START_ = .);
       *(.multiboot)
    }


### PR DESCRIPTION
Force the ELF's first segment to be page aligned.

From this (from `readelf -a`):
```
Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  LOAD           0x00000000000000e8 0x0000000000a000e8 0x0000000000a000e8 <===not aligned
                 0x00000000002c3ecb 0x0000000000455e28  RWE    80
  GNU_EH_FRAME   0x0000000000204138 0x0000000000c04138 0x0000000000c04138
                 0x000000000000873c 0x000000000000873c  R      4
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RWE    10
```
to this:
```
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  LOAD           0x0000000000000100 0x0000000000a01000 0x0000000000a01000
                 0x00000000002c3eb3 0x0000000000455f10  RWE    80
  GNU_EH_FRAME   0x0000000000204138 0x0000000000c05038 0x0000000000c05038
                 0x000000000000873c 0x000000000000873c  R      4
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RWE    10
```