### PR TITLE
Point to upstream Solo5

### DIFF
--- a/cmake/cross_compiled_libraries.txt
+++ b/cmake/cross_compiled_libraries.txt
@@ -32,36 +32,38 @@ if (WITH_SOLO5)
 ExternalProject_Add(solo5_repo
 	PREFIX precompiled
 	BUILD_IN_SOURCE 1
-	GIT_REPOSITORY https://github.com/ricarkol/solo5.git
-	GIT_TAG includeos64
-	CONFIGURE_COMMAND ./configure.sh
+	GIT_REPOSITORY https://github.com/solo5/solo5.git
+	GIT_TAG f8a277f83807333685742228ffef0d87270207cf
+	CONFIGURE_COMMAND CC=gcc ./configure.sh
 	UPDATE_COMMAND ""
-	BUILD_COMMAND make build
+	BUILD_COMMAND make
 	INSTALL_COMMAND ""
 )
 
 set(SOLO5_REPO_DIR ${CMAKE_CURRENT_BINARY_DIR}/precompiled/src/solo5_repo)
-set(SOLO5_INCLUDE_DIR ${SOLO5_REPO_DIR}/build/include/)
-set(SOLO5_LIB_DIR ${SOLO5_REPO_DIR}/build/${ARCH})
+set(SOLO5_INCLUDE_DIR ${SOLO5_REPO_DIR}/kernel)
 
 # solo5 in ukvm mode (let's call it "solo5")
 add_library(solo5 STATIC IMPORTED)
-set_target_properties(solo5 PROPERTIES IMPORTED_LOCATION ${SOLO5_LIB_DIR}/ukvm/solo5.o)
+set_target_properties(solo5 PROPERTIES IMPORTED_LOCATION ${SOLO5_REPO_DIR}/kernel/ukvm/solo5.o)
 
 # ukvm-bin
 add_library(ukvm-bin STATIC IMPORTED)
-set_target_properties(solo5 PROPERTIES IMPORTED_LOCATION ${SOLO5_LIB_DIR}/ukvm/ukvm-bin)
+set_target_properties(solo5 PROPERTIES IMPORTED_LOCATION ${SOLO5_REPO_DIR}/ukvm/ukvm-bin)
 
 add_dependencies(solo5 solo5_repo)
 add_dependencies(ukvm-bin solo5_repo)
 
 # Some OS components depend on solo5 (for solo5.h for example)
 add_dependencies(PrecompiledLibraries solo5)
+add_dependencies(PrecompiledLibraries ukvm-bin)
 
 # Only x86_64 supported at the moment
 if ("${ARCH}" STREQUAL "x86_64")
-  install(FILES ${SOLO5_LIB_DIR}/ukvm/solo5.o ${SOLO5_LIB_DIR}/ukvm/ukvm-bin DESTINATION includeos/${ARCH}/lib)
+  install(FILES ${SOLO5_REPO_DIR}/kernel/ukvm/solo5.o ${SOLO5_REPO_DIR}/ukvm/ukvm-bin DESTINATION includeos/${ARCH}/lib)
 endif()
+
+install(FILES ${SOLO5_INCLUDE_DIR}/solo5.h DESTINATION includeos/${ARCH}/include)
 
 endif (WITH_SOLO5)
 
@@ -98,8 +100,6 @@ set(CRTBEGIN ${PRECOMPILED_DIR}/crt/crtbegin.o)
 install(DIRECTORY ${LIBCXX_INCLUDE_DIR} DESTINATION includeos/${ARCH}/include/libcxx)
 
 install(DIRECTORY ${NEWLIB_INCLUDE_DIR} DESTINATION includeos/${ARCH}/include/newlib)
-
-install(DIRECTORY ${SOLO5_INCLUDE_DIR} DESTINATION includeos/${ARCH}/include/solo5)
 
 install(FILES ${CRTEND} ${CRTBEGIN} DESTINATION includeos/${ARCH}/lib)
 


### PR DESCRIPTION
Two changes:
- Point to solo5 master as of today, commit `f8a277f83807`.
- Don't rely on `make build` (which doesn't exist in master), and just copy solo5.o, ukvm-bin, and solo5.h by hand.

Tested with `test_ukvm.sh` on a docker container (started with `--privileged --net=host`) running Ubuntu 16.04.3 LTS and gcc 5.4.0.

cc @alfred-bratterud 