### PR TITLE
Refactored UDP to use Port_util (and more)

### DIFF
--- a/api/net/inet.hpp
+++ b/api/net/inet.hpp
@@ -118,7 +118,7 @@ namespace net {
     virtual IP_addr get_source_addr(IP_addr dest) = 0;
 
     /** Determine if an IP address is a valid source address for this stack */
-    virtual bool is_valid_source(IP_addr) = 0;
+    virtual bool is_valid_source(IP_addr) const = 0;
 
 
     /**

--- a/api/net/inet4.hpp
+++ b/api/net/inet4.hpp
@@ -337,7 +337,7 @@ namespace net {
       return ip_addr();
     }
 
-    bool is_valid_source(IP4::addr src) override
+    bool is_valid_source(IP4::addr src) const override
     { return src == ip_addr() or is_loopback(src); }
 
     virtual std::shared_ptr<Conntrack>& conntrack() override

--- a/api/net/ip4/packet_udp.hpp
+++ b/api/net/ip4/packet_udp.hpp
@@ -19,6 +19,7 @@
 
 #include "udp.hpp"
 #include "packet_ip4.hpp"
+#include <net/socket.hpp>
 #include <cassert>
 
 namespace net
@@ -58,6 +59,12 @@ namespace net
     {
       return htons(header().dport);
     }
+
+    Socket source() const
+    { return Socket{ip_src(), src_port()}; }
+
+    Socket destination() const
+    { return Socket{ip_dst(), dst_port()}; }
 
     uint16_t length() const noexcept
     {

--- a/api/net/ip4/packet_udp.hpp
+++ b/api/net/ip4/packet_udp.hpp
@@ -85,6 +85,9 @@ namespace net
       return ip_data_ptr() + sizeof(UDP::header);
     }
 
+    const Byte* data() const
+    { return ip_data_ptr() + sizeof(UDP::header); }
+
     Byte* begin()
     {
       return data();

--- a/api/net/ip4/udp.hpp
+++ b/api/net/ip4/udp.hpp
@@ -137,6 +137,9 @@ namespace net {
 
     bool is_bound(const Socket) const;
 
+    bool is_bound(const port_t port) const
+    { return is_bound({stack_.ip_addr(), port}); }
+
     /** Close a socket **/
     void close(const Socket socket);
 

--- a/api/net/ip4/udp.hpp
+++ b/api/net/ip4/udp.hpp
@@ -35,6 +35,11 @@ namespace net {
   class PacketUDP;
   class UDPSocket;
 
+  struct UDP_error : public std::runtime_error {
+    using base = std::runtime_error;
+    using base::base;
+  };
+
   /** Basic UDP support. @todo Implement UDP sockets.  */
   class UDP {
   public:
@@ -43,6 +48,8 @@ namespace net {
 
     using Packet_ptr    = std::unique_ptr<PacketUDP, std::default_delete<net::Packet>>;
     using Stack         = IP4::Stack;
+
+    using Sockets       = std::map<Socket, UDPSocket>;
 
     typedef delegate<void()> sendto_handler;
     typedef delegate<void(const Error&)> error_handler;
@@ -117,15 +124,21 @@ namespace net {
     void transmit(UDP::Packet_ptr udp);
 
     //! @param port local port
-    UDPSocket& bind(port_t port);
+    UDPSocket& bind(port_t port)
+    { return bind({stack_.ip_addr(), port}); }
+
+    UDPSocket& bind(const Socket socket);
 
     //! returns a new UDP socket bound to a random port
-    UDPSocket& bind();
+    UDPSocket& bind()
+    { return bind(stack_.ip_addr()); }
 
-    bool is_bound(port_t port);
+    UDPSocket& bind(const ip4::Addr addr);
 
-    /** Close a port **/
-    void close(port_t port);
+    bool is_bound(const Socket) const;
+
+    /** Close a socket **/
+    void close(const Socket socket);
 
     //! construct this UDP module with @inet
     UDP(Stack& inet);
@@ -145,19 +158,17 @@ namespace net {
     uint16_t max_datagram_size() noexcept
     { return stack().ip_obj().MDDS() - sizeof(header); }
 
-    class Port_in_use_exception : public std::exception {
+    class Port_in_use_exception : public UDP_error {
     public:
       Port_in_use_exception(UDP::port_t p)
-        : port_(p) {}
+        : UDP_error{"UDP port already in use: " + std::to_string(p)},
+          port_(p) {}
 
-      virtual const char* what() const noexcept
-      { return "UDP port already in use"; }
-
-      UDP::port_t port()
+      UDP::port_t port() const
       { return port_; }
 
     private:
-      UDP::port_t port_;
+      const UDP::port_t port_;
     };
 
   private:
@@ -166,11 +177,24 @@ namespace net {
     std::chrono::minutes        flush_interval_{5};
     downstream                  network_layer_out_;
     Stack&                      stack_;
-    std::map<port_t, UDPSocket> ports_;
-    port_t                      current_port_;
+    Sockets                     sockets_;
+    Stack::Port_utils&          ports_;
 
     // the async send queue
     std::deque<WriteBuffer> sendq;
+
+
+    Sockets::iterator find(const Socket socket)
+    {
+      Sockets::iterator it = sockets_.find(socket);
+      return it;
+    }
+
+    Sockets::const_iterator cfind(const Socket socket) const
+    {
+      Sockets::const_iterator it = sockets_.find(socket);
+      return it;
+    }
 
     /** Error entries are just error callbacks and timestamps */
     class Error_entry {

--- a/api/net/ip4/udp_socket.hpp
+++ b/api/net/ip4/udp_socket.hpp
@@ -36,7 +36,7 @@ namespace net
     typedef UDP::error_handler error_handler;
 
     // constructors
-    UDPSocket(UDP&, port_t port);
+    UDPSocket(UDP&, Socket socket);
     UDPSocket(const UDPSocket&) = delete;
     // ^ DON'T USE THESE. We could create our own allocators just to prevent
     // you from creating sockets, but then everyone is wasting time.
@@ -58,17 +58,20 @@ namespace net
                error_handler ecb = nullptr);
 
     void close()
-    { udp_.close(l_port); }
+    { udp_.close(socket_); }
 
     void join(multicast_group_addr);
     void leave(multicast_group_addr);
 
     // stuff
     addr_t local_addr() const
-    { return udp_.local_ip(); }
+    { return socket_.address(); }
 
     port_t local_port() const
-    { return l_port; }
+    { return socket_.port(); }
+
+    const Socket& local() const
+    { return socket_; }
 
     UDP& udp()
     { return udp_; }
@@ -77,8 +80,8 @@ namespace net
     void packet_init(UDP::Packet_ptr, addr_t, addr_t, port_t, uint16_t);
     void internal_read(UDP::Packet_ptr);
 
-    UDP& udp_;
-    port_t l_port;
+    UDP&    udp_;
+    Socket  socket_;
     recvfrom_handler on_read_handler =
       [] (addr_t, port_t, const char*, size_t) {};
 

--- a/api/net/ip4/udp_socket.hpp
+++ b/api/net/ip4/udp_socket.hpp
@@ -78,7 +78,7 @@ namespace net
 
   private:
     void packet_init(UDP::Packet_ptr, addr_t, addr_t, port_t, uint16_t);
-    void internal_read(UDP::Packet_ptr);
+    void internal_read(const PacketUDP&);
 
     UDP&    udp_;
     Socket  socket_;

--- a/api/net/socket.hpp
+++ b/api/net/socket.hpp
@@ -26,8 +26,7 @@ namespace net {
 /**
  * An IP address and port
  */
-class Socket {
-public:
+union Socket {
 
   using Address = ip4::Addr;
   using port_t = uint16_t;
@@ -56,6 +55,15 @@ public:
     : address_{address}, port_{port}
   {}
 
+  Socket(const Socket& other) noexcept
+   : data_{other.data_} {}
+
+  Socket& operator=(const Socket& other) noexcept
+  {
+    data_ = other.data_;
+    return *this;
+  }
+
   /**
    * Get the socket's network address
    *
@@ -64,9 +72,6 @@ public:
   constexpr Address address() const noexcept
   { return address_; }
 
-  void set_address(const Address address) noexcept
-  { address_ = address; }
-
   /**
    * Get the socket's port value
    *
@@ -74,9 +79,6 @@ public:
    */
   constexpr port_t port() const noexcept
   { return port_; }
-
-  void set_port(const port_t port) noexcept
-  { port_ = port; }
 
   /**
    * Get a string representation of this class
@@ -104,8 +106,7 @@ public:
    */
   constexpr bool operator==(const Socket& other) const noexcept
   {
-    return (address() == other.address())
-       and (port() == other.port());
+    return data_ == other.data_;
   }
 
   /**
@@ -147,10 +148,16 @@ public:
   { return not (*this < other); }
 
 private:
-  Address address_;
-  port_t  port_;
+  struct {
+    Address   address_;
+    port_t    port_;
+    uint16_t  padding{0};
+  };
+  uint64_t data_;
 
 }; //< class Socket
+
+static_assert(sizeof(Socket) == 8, "Socket not 8 byte");
 
 /**
  * @brief      A pair of Sockets

--- a/api/net/tcp/tcp.hpp
+++ b/api/net/tcp/tcp.hpp
@@ -607,7 +607,7 @@ namespace net {
      * @return     True if valid source, False otherwise.
      */
     bool is_valid_source(const tcp::Address addr) const noexcept
-    { return addr == address() or addr == 0; /* temp */ }
+    { return addr == 0 or inet_.is_valid_source(addr); }
 
     /**
      * @brief      Try to find the listener bound to socket.

--- a/src/net/dhcp/dh4client.cpp
+++ b/src/net/dhcp/dh4client.cpp
@@ -72,7 +72,8 @@ namespace net {
     this->progress = 0;
     this->retries  = NUM_RETRIES;
     // close UDP socket
-    stack.udp().close(DHCP_CLIENT_PORT);
+    Expects(this->socket != nullptr);
+    this->socket->close();
     this->socket = nullptr;
     // call on_config with timeout = true
     for(auto& handler : this->config_handlers_)

--- a/src/net/inet4.cpp
+++ b/src/net/inet4.cpp
@@ -102,23 +102,21 @@ void Inet4::error_report(Error& err, Packet_ptr orig_pckt) {
   bool too_big = false;
 
   // Get the destination to the original packet
-  Socket dest;
-  switch (pckt_ip4->ip_protocol()) {
-    case Protocol::UDP: {
-      auto pckt_udp = static_unique_ptr_cast<PacketUDP>(std::move(pckt_ip4));
-      dest.set_address(pckt_udp->ip_dst());
-      dest.set_port(pckt_udp->dst_port());
-      break;
+  Socket dest = [](const PacketIP4& pkt)->Socket {
+    switch (pkt.ip_protocol()) {
+      case Protocol::UDP: {
+        const auto& udp = static_cast<const PacketUDP&>(pkt);
+        return udp.destination();
+      }
+      case Protocol::TCP: {
+        const auto& tcp = static_cast<const tcp::Packet&>(pkt);
+        return tcp.destination();
+      }
+      default:
+        return {};
     }
-    case Protocol::TCP: {
-      auto pckt_tcp = static_unique_ptr_cast<tcp::Packet>(std::move(pckt_ip4));
-      dest.set_address(pckt_tcp->ip_dst());
-      dest.set_port(pckt_tcp->dst_port());
-      break;
-    }
-    default:
-      return;
-  }
+  }(*pckt_ip4);
+
 
   if (err.is_icmp()) {
     auto* icmp_err = dynamic_cast<ICMP_error*>(&err);

--- a/src/net/ip4/udp.cpp
+++ b/src/net/ip4/udp.cpp
@@ -62,13 +62,16 @@ namespace net {
     if(is_bcast) {
       auto dport = udp_packet->dst_port();
       PRINT("<%s> UDP received broadcast on port %d\n", stack_.ifname().c_str(), dport);
-      for(auto& pair : sockets_)
+
+      for(auto it = sockets_.begin(); it != sockets_.end();)
       {
-        if(pair.first.port() == dport)
+        auto current = it++; // internal_read() may result in close,
+                             // this is to avoid iterator invalidation
+        if(current->first.port() == dport)
         {
           PRINT("<%s> UDP found broadcast receiver: %s\n",
-              stack_.ifname().c_str(), pair.first.to_string().c_str());
-          pair.second.internal_read(*udp_packet);
+              stack_.ifname().c_str(), current->first.to_string().c_str());
+          current->second.internal_read(*udp_packet);
         }
       }
       return;

--- a/src/net/ip4/udp_socket.cpp
+++ b/src/net/ip4/udp_socket.cpp
@@ -40,8 +40,8 @@ namespace net
     assert(p->data_length() == length);
   }
 
-  void UDPSocket::internal_read(UDP::Packet_ptr udp)
-  { on_read_handler(udp->ip_src(), udp->src_port(), (const char*) udp->data(), udp->data_length()); }
+  void UDPSocket::internal_read(const PacketUDP& udp)
+  { on_read_handler(udp.ip_src(), udp.src_port(), (const char*) udp.data(), udp.data_length()); }
 
   void UDPSocket::sendto(
      addr_t destIP,

--- a/src/net/ip4/udp_socket.cpp
+++ b/src/net/ip4/udp_socket.cpp
@@ -21,8 +21,8 @@
 
 namespace net
 {
-  UDPSocket::UDPSocket(UDP& udp_instance, port_t port)
-    : udp_(udp_instance), l_port(port)
+  UDPSocket::UDPSocket(UDP& udp_instance, Socket socket)
+    : udp_{udp_instance}, socket_{socket}
   {}
 
   void UDPSocket::packet_init(
@@ -32,7 +32,7 @@ namespace net
       port_t port,
       uint16_t length)
   {
-    p->init(this->l_port, port);
+    p->init(this->local_port(), port);
     p->set_ip_src(srcIP);
     p->set_ip_dst(destIP);
     p->set_data_length(length);
@@ -54,7 +54,7 @@ namespace net
     if (UNLIKELY(length == 0)) return;
     udp_.sendq.emplace_back(
        (const uint8_t*) buffer, length, cb, ecb, this->udp_,
-       local_addr(), this->l_port, destIP, port);
+       local_addr(), this->local_port(), destIP, port);
 
     // UDP packets are meant to be sent immediately, so try flushing
     udp_.flush();
@@ -71,7 +71,7 @@ namespace net
     if (UNLIKELY(length == 0)) return;
     udp_.sendq.emplace_back(
          (const uint8_t*) buffer, length, cb, ecb, this->udp_,
-         srcIP, this->l_port, IP4::ADDR_BCAST, port);
+         srcIP, this->local_port(), IP4::ADDR_BCAST, port);
 
     // UDP packets are meant to be sent immediately, so try flushing
     udp_.flush();

--- a/src/plugins/syslogd.cpp
+++ b/src/plugins/syslogd.cpp
@@ -43,7 +43,7 @@ void Syslog_facility::syslog(const std::string& log_message) {
 
 Syslog_facility::~Syslog_facility() {
   if (sock_)
-    sock_->udp().close(sock_->local_port());
+    sock_->close();
 }
 
 void Syslog_facility::open_socket() {
@@ -53,7 +53,7 @@ void Syslog_facility::open_socket() {
 
 void Syslog_facility::close_socket() {
 	if (sock_) {
-    sock_->udp().close(sock_->local_port());
+    sock_->close();
     sock_ = nullptr;
 	}
 }

--- a/src/plugins/unik.cpp
+++ b/src/plugins/unik.cpp
@@ -35,7 +35,7 @@ void unik::Client::register_instance(net::Inet<net::IP4>& inet, const net::UDP::
 
   // Set up an UDP port for receiving UniK heartbeat
   auto& sock = inet.udp().bind(port);
-  CHECK(net::Inet4::stack<0>().udp().is_bound(port), "Unik UDP port is bound as expected");
+  CHECK(net::Inet4::stack<0>().udp().is_bound(sock.local()), "Unik UDP port is bound as expected");
   sock.on_read([&sock, &inet] (auto addr, auto port, const char* data, size_t len) {
 
       static bool registered_with_unik = false;

--- a/src/posix/udp_fd.cpp
+++ b/src/posix/udp_fd.cpp
@@ -72,7 +72,7 @@ UDP_FD::~UDP_FD()
 {
   // shutdown underlying socket, makes sure no callbacks are called on dead fd
   if(this->sock)
-    sock->udp().close(sock->local_port());
+    sock->close();
 }
 int UDP_FD::read(void* buffer, size_t len)
 {


### PR DESCRIPTION
For NAT MASQUERADE to work correctly, UDP needs to get it's port from the stack. Use of Port_util will avoid any conflict.

UDPSocket is now also made to bind on a specific address (default is the `stack.ip_addr()`) by using `Socket` as identifier in the collection. UDP *do not* support listening on all addresses by binding to `ANY_ADDR`, due to then we no longer know what source IP to use when using `sendto()`.
This could be solved by either:
1. Passing source addr into sendto call (not very nice and unnecessary in most cases)
2. Let the IP module set the source IP depending on destination (no idea how that algorithm would look like)

@alfred-bratterud @fwsGonzo 