### PR TITLE
Add support to boot for connecting the vm to an arbitrary bridge

### DIFF
--- a/etc/boot
+++ b/etc/boot
@@ -42,8 +42,11 @@ parser.add_argument("-b", "--build", dest="build", action="store_true", default=
 parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False,
                     help="Verbose output when building")
 
-parser.add_argument("--create-bridge", dest="bridge", action="store_true",
-                    help="Create bridge43, used in local testing when TAP devices are supported")
+parser.add_argument("--bridge", dest="bridge", action="store", type=str, default="bridge43", metavar="BRIDGE",
+					help="Specify the name of the bridge to use. Default is bridge43.")
+
+parser.add_argument("--create-bridge", dest="create_bridge", action="store_true",
+                    help="Create a bridge, used in local testing when TAP devices are supported.")
 
 parser.add_argument("-g", "--grub", dest="grub", action="store_true",
                     help="Create image with GRUB bootloader that will boot provided binary")
@@ -127,7 +130,11 @@ if args.clean:
     vm.clean()
 
 if args.bridge:
-    print INFO, "Creating bridge"
+	print INFO, "Override default bridge - ", args.bridge
+	os.environ["INCLUDEOS_BRIDGE"] = args.bridge
+
+if args.create_bridge:
+    print INFO, "Creating bridge ", args.bridge # Note we pick this up through ENV if set.
     subprocess.call(INCLUDEOS_PREFIX + "/includeos/scripts/create_bridge.sh", shell=True)
 
 # If the binary name is a folder, such as ".", build the service

--- a/etc/scripts/create_bridge.sh
+++ b/etc/scripts/create_bridge.sh
@@ -9,7 +9,6 @@ then
   BRIDGE=bridge43
   NETMASK=255.255.0.0
   GATEWAY=10.0.0.1
-
 elif [ $# -eq 3 ]
 then
   BRIDGE=$1
@@ -21,7 +20,15 @@ else
   exit 1
 fi
 
-echo "    Creating bridge $BRIDGE, netmask $NETMASK, gateway $GATEWAY "
+# override bridge name based on ENV
+
+if [ -n $INCLUDEOS_BRIDGE ]
+then
+    BRIDGE=$INCLUDEOS_BRIDGE
+fi
+
+
+echo "    Creating bridge $BRIDGE ($INCLUDEOS_BRIDGE), netmask $NETMASK, gateway $GATEWAY "
 
 # Håreks cool hack:
 # - First two bytes is fixed to "c001" because it's cool

--- a/etc/scripts/qemu-ifdown
+++ b/etc/scripts/qemu-ifdown
@@ -1,0 +1,30 @@
+#! /bin/sh
+# ==============================================================================
+# Simple tap-networking for IncludeOS on Qemu
+# ==============================================================================
+
+# The name of the bridge VM's are added to
+
+if [ -n $INCLUDEOS_BRIDGE ]
+then
+    BRIDGE=$INCLUDEOS_BRIDGE
+else    
+   BRIDGE="bridge43"
+fi
+
+if [ -n "$1" ];then
+    
+    ifconfig $1 down
+
+    if uname -s | grep Darwin > /dev/null 2>&1; then
+        ifconfig $BRIDGE deletem $1
+    else
+        brctl delif $BRIDGE $1
+    fi
+    exit 0
+
+else
+    echo "Error: no interface specified"
+    exit 1
+fi
+

--- a/etc/scripts/qemu-ifup
+++ b/etc/scripts/qemu-ifup
@@ -10,7 +10,13 @@
 
 
 # The name of the bridge VM's are added to
-BRIDGE=bridge43
+
+if [ -n $INCLUDEOS_BRIDGE ]
+then
+    BRIDGE=$INCLUDEOS_BRIDGE
+else    
+   BRIDGE="bridge43"
+fi
 
 # ==============================================================================
 # Bringing up the bridge:

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -11,6 +11,7 @@ import validate_vm
 import signal
 import psutil
 import magic
+from shutil import copyfile
 
 from prettify import color
 
@@ -611,6 +612,12 @@ class vm:
         print INFO, "Building with cmake (%s)" % args
         # install dir:
         INSTDIR = os.getcwd()
+
+        if not os.path.isfile("CMakeLists.txt"):
+            # No makefile present. Copy the one from seed, inform user and pray.
+            # copyfile will throw errors if it encounters any.
+            copyfile(INCLUDEOS_HOME + "/includeos/seed/service/CMakeLists.txt", "CMakeLists.txt")
+            print INFO, "No CMakeList.txt present. File copied from seed. Please adapt to your needs."
 
         # create build directory
         try:

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -214,6 +214,7 @@ class qemu(hypervisor):
 
     def net_arg(self, backend, device, if_name = "net0", mac = None, bridge = None):
         qemu_ifup = INCLUDEOS_HOME + "/includeos/scripts/qemu-ifup"
+        qemu_ifdown = INCLUDEOS_HOME + "/includeos/scripts/qemu-ifdown"
 
         # FIXME: this needs to get removed, e.g. fetched from the schema
         names = {"virtio" : "virtio-net", "vmxnet" : "vmxnet3", "vmxnet3" : "vmxnet3"}
@@ -227,7 +228,7 @@ class qemu(hypervisor):
         if backend == "tap":
             if self._kvm_present:
                 netdev += ",vhost=on"
-            netdev += ",script=" + qemu_ifup
+            netdev += ",script=" + qemu_ifup + ",downscript=" + qemu_ifdown
 
         if bridge:
             netdev = "bridge,id=" + if_name + ",br=" + bridge
@@ -375,7 +376,8 @@ class qemu(hypervisor):
             vga_arg = ["-vga", str(self._config["vga"])]
 
         # TODO: sudo is only required for tap networking and kvm. Check for those.
-        command = ["sudo", "qemu-system-x86_64"]
+        # preserve-env is to signal to qemu-ifup to use a certain bridge
+        command = ["sudo", "--preserve-env", "qemu-system-x86_64"]
         if self._kvm_present: command.extend(["--enable-kvm", "-cpu", "host"])
 
         command += kernel_args


### PR DESCRIPTION
I've modified the boot script to attach VMs to arbitrary VM. @AndreasAakesson mentioned he needs this in order to simplify the injection of VLAN-tagged packets.

I've also supplied a qemu-ifdown so qemu doesn't whine as much.