### PR TITLE
net: Use refactor WebSocket header creation to be safer

### DIFF
--- a/api/net/ws/header.hpp
+++ b/api/net/ws/header.hpp
@@ -34,8 +34,6 @@ namespace net {
     PONG      = 10
   }; // < op_code
 
-  static constexpr uint8_t WS_HEADER_MAXLEN{16};
-
   struct ws_header
   {
     uint16_t bits;
@@ -115,7 +113,16 @@ namespace net {
     }
 
     uint16_t header_length() const noexcept
-    { return sizeof(ws_header) + data_offset(); }
+    {
+      return sizeof(ws_header) + data_offset();
+    }
+    static size_t header_length(size_t len, bool client) noexcept
+    {
+      size_t ofs = sizeof(ws_header) + (client ? 4 : 0);
+      if (len > 65535) return ofs + 8;
+      if (len > 125)   return ofs + 2;
+      return ofs;
+    }
 
     const char* data() const noexcept {
       return &vla[data_offset()];

--- a/src/net/ws/websocket.cpp
+++ b/src/net/ws/websocket.cpp
@@ -288,26 +288,34 @@ void WebSocket::finalize_message() {
   case op_code::PONG:
     break;
   default:
-    printf("Unknown opcode: %d\n", (int) hdr.opcode());
+    //printf("Unknown opcode: %d\n", (int) hdr.opcode());
     break;
   }
   message.reset();
 }
 
-
-static size_t make_header(char* dest, size_t len, op_code code, bool client)
+/** create a websocket message with only the header present
+    with the intention of appending the message on the returned buffer */
+static Stream::buffer_t create_wsmsg(size_t len, op_code code, bool client)
 {
-  new (dest) ws_header;
-  auto& hdr = *(ws_header*) dest;
+  // generate header length based on buffer length
+  const size_t header_len = net::ws_header::header_length(len, client);
+  // create shared buffer with position at end of header
+  auto buffer = tcp::construct_buffer();
+  buffer->reserve(header_len + len);
+  buffer->resize(header_len);
+  // create header on buffer
+  new (buffer->data()) ws_header;
+  auto& hdr = *(ws_header*) buffer->data();
   hdr.bits = 0;
   hdr.set_final();
   hdr.set_payload(len);
   hdr.set_opcode(code);
   if (client) {
-    hdr.set_masked(OS::cycles_since_boot() & 0xffffffff);
+    hdr.set_masked((OS::cycles_since_boot() ^ (uintptr_t) buffer.get()) & 0xffffffff);
   }
-  // header size + data offset
-  return sizeof(ws_header) + hdr.data_offset();
+  assert(header_len == sizeof(ws_header) + hdr.data_offset());
+  return buffer;
 }
 
 void WebSocket::write(const char* buffer, size_t len, op_code code)
@@ -324,11 +332,8 @@ void WebSocket::write(const char* buffer, size_t len, op_code code)
   Expects((code == op_code::TEXT or code == op_code::BINARY)
     && "Write currently only supports TEXT or BINARY");
 
-  // allocate header and data at the same time
-  auto buf = tcp::construct_buffer(WS_HEADER_MAXLEN + len);
   // fill header
-  int  header_len = make_header((char*) buf->data(), len, code, clientside);
-  buf->resize(header_len);
+  auto buf = create_wsmsg(len, code, clientside);
   // get data offset & fill in data into buffer
   std::copy(buffer, buffer + len, std::back_inserter(*buf));
   // for client-side we have to mask the data
@@ -358,13 +363,11 @@ void WebSocket::write(net::tcp::buffer_t buffer, op_code code)
   }
 
   Expects((code == op_code::TEXT or code == op_code::BINARY)
-    && "Write currently only supports TEXT or BINARY");
+        && "Write currently only supports TEXT or BINARY");
 
   /// write header
-  char header[WS_HEADER_MAXLEN];
-  int  header_len = make_header(header, buffer->size(), code, false);
-  assert(header_len <= WS_HEADER_MAXLEN);
-  this->stream->write(header, header_len);
+  auto header = create_wsmsg(buffer->size(), code, false);
+  this->stream->write(header);
   /// write shared buffer
   this->stream->write(buffer);
 }
@@ -374,9 +377,8 @@ bool WebSocket::write_opcode(op_code code, const char* buffer, size_t datalen)
     return false;
   }
   /// write header
-  char header[WS_HEADER_MAXLEN];
-  int  header_len = make_header(header, datalen, code, clientside);
-  this->stream->write(header, header_len);
+  auto header = create_wsmsg(datalen, code, clientside);
+  this->stream->write(header);
   /// write buffer (if present)
   if (buffer != nullptr && datalen > 0)
       this->stream->write(buffer, datalen);


### PR DESCRIPTION
* make_header renamed to create_wsmsg
* Returns buffer_t with correct header length as size()
* No more raw buffers
