### PR TITLE
Makes the website homepage much more readable

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -2,9 +2,9 @@
 
 body {
   padding:50px;
-  font:14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color:#777;
-  font-weight:300;
+  font:16px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  /* Display a fallback font-face while the Lato font loads */
+  font-display: fallback;
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
![screenshot_20171009_162605](https://user-images.githubusercontent.com/2380692/31359252-d4f4523a-ad0e-11e7-8986-eb8fe1802df7.png)

The font on the current website is a little hard to read. I hope you agree that this improves it a bit?

Please note that the `font-display: fallback` is only implemented in recent versions of Chrome and Firefox, but it only effects how the page looks in the brief (50-100ms) time during the page loads. 