### PR TITLE
WebSocket buffer extraction

### DIFF
--- a/api/fs/disk.hpp
+++ b/api/fs/disk.hpp
@@ -88,7 +88,7 @@ namespace fs
 
     // Returns a reference to an initialized filesystem
     // If no filesystem is initialized it will throw an error
-    File_system& fs() noexcept
+    File_system& fs()
     {
       if(UNLIKELY(not fs_ready()))
       {

--- a/api/net/ws/header.hpp
+++ b/api/net/ws/header.hpp
@@ -130,18 +130,13 @@ namespace net {
     char* data() noexcept {
       return &vla[data_offset()];
     }
-    void masking_algorithm()
+    void masking_algorithm(char* ptr)
     {
-      char* ptr  = data();
       const char* mask = keymask();
       for (size_t i = 0; i < data_length(); i++)
       {
         ptr[i] = ptr[i] xor mask[i & 3];
       }
-    }
-
-    size_t reported_length() const noexcept {
-      return header_length() + data_length();
     }
 
     char vla[0];

--- a/api/net/ws/websocket.hpp
+++ b/api/net/ws/websocket.hpp
@@ -42,72 +42,70 @@ public:
     using Data_it  = Data::iterator;
     using Data_cit = Data::const_iterator;
 
-  public:
-    Message(const char* data, size_t len)
-      : data_{data, data + len}
-    {
-      data_.reserve(header().reported_length());
+    auto as_shared_vector() const {
+      return std::make_shared<std::vector<uint8_t>> (cbegin(), cend());
+    }
+    auto extract_shared_vector() {
+      return std::make_shared<std::vector<uint8_t>> (std::move(data_));
     }
 
-    Message(ws_header&& header)
-    {
-      data_.reserve(header.reported_length());
-      const char* hdr = reinterpret_cast<const char*>(&header);
-      data_.insert(data_.begin(), hdr, hdr + header.header_length());
-    }
+    std::string as_text() const
+    { return std::string(data(), size()); }
 
-    const ws_header& header() const noexcept
-    { return *(reinterpret_cast<const ws_header*>(data_.data())); }
-
-    op_code opcode() const noexcept
-    { return header().opcode(); }
-
-    auto size() const noexcept
-    { return header().data_length(); }
+    size_t size() const noexcept
+    { return data_.size(); }
 
     Data_it begin() noexcept
-    { return data_.begin() + header().header_length(); }
+    { return data_.begin(); }
 
     Data_it end() noexcept
     { return data_.end(); }
 
     Data_cit cbegin() const noexcept
-    { return data_.begin() + header().header_length(); }
+    { return data_.begin(); }
 
     Data_cit cend() const noexcept
     { return data_.end(); }
 
-    std::string as_text() const
-    { return std::string((const char*) data(), size()); }
-
-    auto as_shared_vector() const {
-      return std::make_shared<std::vector<uint8_t>> (cbegin(), cend());
-    }
-
     const char* data() const noexcept
-    { return (const char*) data_.data() + header().header_length(); }
+    { return (const char*) data_.data(); }
 
     char* data() noexcept
-    { return (char*) data_.data() + header().header_length(); }
+    { return (char*) data_.data(); }
 
-    size_t add(const char* data, size_t len)
+    Message(const uint8_t* data, size_t len)
     {
-      size_t insert_size = std::min(data_.capacity() - data_.size(), len);
-      data_.insert(data_.end(), data, data + insert_size);
-      return insert_size;
+      this->append(data, len);
     }
 
+    size_t append(const uint8_t* data, size_t len);
+
     bool is_complete() const noexcept
-    { return header().data_length() == (data_.size() - header().header_length()); }
+    { return header_complete() && data_.size() == header().data_length(); }
+
+    const ws_header& header() const noexcept
+    { return *(ws_header*) header_.data(); }
+
+    op_code opcode() const noexcept
+    { return header().opcode(); }
 
     void unmask() noexcept
-    { if (_header().is_masked()) _header().masking_algorithm(); }
+    {
+      if (header().is_masked())
+          writable_header().masking_algorithm(this->data());
+    }
 
   private:
     Data data_;
+    std::array<uint8_t, 15> header_;
+    uint8_t header_length = 0;
 
-    ws_header& _header()
-    { return *(reinterpret_cast<ws_header*>(data_.data())); }
+    inline bool header_complete() const noexcept {
+      return header_length >= 2 && header_length >= header().header_length();
+    }
+
+    ws_header& writable_header()
+    { return *(ws_header*) header_.data(); }
 
   }; // < class Message
 
@@ -245,7 +243,7 @@ private:
   bool write_opcode(op_code code, const char*, size_t);
   void failure(const std::string&);
   void tcp_closed();
-  size_t create_message(char*, size_t len);
+  size_t create_message(const uint8_t*, size_t len);
   void finalize_message();
   void reset();
 };

--- a/examples/websocket/service.cpp
+++ b/examples/websocket/service.cpp
@@ -35,9 +35,10 @@ void handle_ws(net::WebSocket_ptr ws)
   ws->write("Welcome");
   ws->write(ws->to_string());
   // Setup echo reply
-  ws->on_read = [ws = ws.get()](auto msg) {
+  ws->on_read = [ws = ws.get()] (auto msg) {
     printf("WS Recv: %s\n", msg->as_text().c_str());
-    ws->write(msg->as_shared_vector());
+    // Extracting the data from the message is performant
+    ws->write(msg->extract_shared_vector());
   };
 
   websockets[idx] = std::move(ws);

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -254,7 +254,8 @@ namespace uplink {
 
     ws_->close();
     // do the update
-    Timers::oneshot(std::chrono::milliseconds(10), [this, buffer] (auto) {
+    Timers::oneshot(std::chrono::milliseconds(10),
+    [buffer] (auto) {
       liu::LiveUpdate::exec(buffer);
     });
   }


### PR DESCRIPTION
... made possible by buffering header to its own array, and the data to a vector

Also supports partial WS header to some degree, but must receive the first two bytes in one message

Adds Message::extract_shared_vector(), although it could just be called extract data
