### PR TITLE
solo5: point to solo5 latest

### DIFF
--- a/cmake/cross_compiled_libraries.txt
+++ b/cmake/cross_compiled_libraries.txt
@@ -33,7 +33,7 @@ ExternalProject_Add(solo5_repo
 	PREFIX precompiled
 	BUILD_IN_SOURCE 1
 	GIT_REPOSITORY https://github.com/solo5/solo5.git
-	GIT_TAG f8a277f83807333685742228ffef0d87270207cf
+	GIT_TAG 2765e0f5f090c0b27a8d62a48285842236e7d20f
 	CONFIGURE_COMMAND CC=gcc ./configure.sh
 	UPDATE_COMMAND ""
 	BUILD_COMMAND make


### PR DESCRIPTION
Point to latest solo5, so to get the fix for #1540 . Just in case, the added `include`s (in latest master) are here:
https://github.com/Solo5/solo5/blob/master/ukvm/ukvm_hv_kvm.c#L32
https://github.com/Solo5/solo5/blob/master/ukvm/ukvm_hv_kvm_x86_64.c#L34

Should I create a PR for master as well?

@fwsGonzo 