### PR TITLE
solo5: add missing __arch_time_now to solo5 platform

### DIFF
--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -43,6 +43,12 @@ void solo5_poweroff()
   for(;;);
 }
 
+// returns wall clock time in nanoseconds since the UNIX epoch
+int64_t __arch_time_now() noexcept
+{
+  return solo5_clock_wall();
+}
+
 RTC::timestamp_t OS::boot_timestamp()
 {
   return booted_at_;


### PR DESCRIPTION
Adding missing `__arch_time_now` implementation to solo5. This was broken after 5b90cfc277c3284c9d2b6c65f605e5bc7282eff9. Will work on something for #1521 

Question: the returned time should be in nanoseconds right?

Tested with test_ukvm.sh on an ubuntu:16.04 container.