### PR TITLE
cleanup: use another std::equal function to remove verbose code

### DIFF
--- a/src/net/http/header.cpp
+++ b/src/net/http/header.cpp
@@ -110,10 +110,8 @@ Header::Const_iterator Header::find(util::csview field) const noexcept {
   //-----------------------------------
   return
     std::find_if(fields_.cbegin(), fields_.cend(), [&field](const auto _) {
-      return (_.first.length() == field.length())
-        and std::equal(_.first.data(), _.first.data() + _.first.length(), field.data(), [](const auto a, const auto b) {
-          return std::tolower(a) == std::tolower(b);
-        });
+      return std::equal(_.first.cbegin(), _.first.cend(), field.cbegin(), field.cend(),
+        [](const auto a, const auto b) { return std::tolower(a) == std::tolower(b); });
     });
 }
 


### PR DESCRIPTION
#1590 Just a small change to fix the issue opened by myself.

However, I am not sure why `field` is capture by reference in the lambda function here,

`std::find_if(fields_.cbegin(), fields_.cend(), [&field](const auto _) {`

So I didn't make a change to this line.

The `field` is a const string_view, and is pass by value to `find` function.

BTW, can someone explain how unit test is organized in this repo? There is a `lest_util` folder. Am I supposed to use it?