### PR TITLE
Grubify: Added missing sudo to script

### DIFF
--- a/etc/scripts/grubify.sh
+++ b/etc/scripts/grubify.sh
@@ -98,7 +98,7 @@ function create_disk {
 function mount_loopback {
 
   # Find first available loopback device
-  LOOP=$(losetup -f)
+  LOOP=$(sudo losetup -f)
 
   echo -e ">>> Associating $LOOP with $DISK"
   # NOTE: To list used loopback devices do


### PR DESCRIPTION
Only 1 of the 2 `losetup` commands had sudo before them. This created some issues in Rhel 7 when performing grubify commands. 