### PR TITLE
Fix GCC 5.4 compiler error (to master)

### DIFF
--- a/examples/snake/snake.hpp
+++ b/examples/snake/snake.hpp
@@ -176,7 +176,7 @@ void Snake::game_loop()
 
 	Timers::oneshot(
 		std::chrono::milliseconds(_head_dir.x() == 0 ? 120 : 70),
-		[this](auto) { game_loop(); }
+		[this](auto) { this->game_loop(); }
 	);
 }
 


### PR DESCRIPTION
Fixes the following error reported in https://github.com/hioa-cs/IncludeOS/issues/1605:
```
IncludeOS/examples/snake/snake.hpp:179:27: error: cannot call member function ‘void Snake::game_loop()’ without object
   [this](auto) { game_loop(); }
```

I'm already aware that I'm not supposed to build IncludeOS with GCC. Still, I think it's beneficial to limit dependence to a specific compiler.