### PR TITLE
Clocks interface, nanosecond API, KVM clocks

### DIFF
--- a/api/arch.hpp
+++ b/api/arch.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cassert>
+#include <ctime>
 
 extern void __arch_init();
 extern void __arch_poweroff();
@@ -39,7 +40,7 @@ inline void __arch_hw_barrier() noexcept;
 inline void __sw_barrier() noexcept;
 
 extern uint64_t __arch_system_time() noexcept;
-extern uint64_t __arch_wall_clock() noexcept;
+extern timespec __arch_wall_clock() noexcept;
 inline uint64_t __arch_cpu_cycles() noexcept;
 
 

--- a/api/arch.hpp
+++ b/api/arch.hpp
@@ -37,7 +37,9 @@ extern void __arch_preempt_forever(void(*)());
 
 inline void __arch_hw_barrier() noexcept;
 inline void __sw_barrier() noexcept;
-extern int64_t  __arch_time_now() noexcept;
+
+extern uint64_t __arch_system_time() noexcept;
+extern uint64_t __arch_wall_clock() noexcept;
 inline uint64_t __arch_cpu_cycles() noexcept;
 
 

--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -236,6 +236,8 @@ public:
   /** Initialize common subsystems, call Service::start */
   static void post_start();
 
+  static void install_cpu_frequency(MHz);
+
 private:
   /** Process multiboot info. Called by 'start' if multibooted **/
   static void multiboot(uint32_t boot_addr);
@@ -256,7 +258,6 @@ private:
   static bool m_block_drivers_ready;
   static MHz cpu_mhz_;
 
-  static RTC::timestamp_t booted_at_;
   static uintptr_t liveupdate_loc_;
   static std::string version_str_;
   static std::string arch_str_;
@@ -293,6 +294,15 @@ inline OS::Span_mods OS::modules()
         static_cast<int>(bootinfo_->mods_count) };
   }
   return nullptr;
+}
+
+inline RTC::timestamp_t OS::boot_timestamp()
+{
+  return RTC::boot_timestamp();
+}
+inline RTC::timestamp_t OS::uptime()
+{
+  return RTC::time_since_boot();
 }
 
 #endif //< KERNEL_OS_HPP

--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -79,8 +79,8 @@ public:
   static uint64_t nanos_asleep() noexcept;
 
 
-  static MHz cpu_freq() noexcept
-  { return cpu_mhz_; }
+  static auto cpu_freq() noexcept
+  { return cpu_khz_; }
 
   /**
    * Reboot operating system
@@ -256,7 +256,7 @@ private:
   static bool boot_sequence_passed_;
   static bool m_is_live_updated;
   static bool m_block_drivers_ready;
-  static MHz cpu_mhz_;
+  static KHz cpu_khz_;
 
   static uintptr_t liveupdate_loc_;
   static std::string version_str_;

--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -63,8 +63,8 @@ public:
   static uint64_t cycles_since_boot() {
     return __arch_cpu_cycles();
   }
-  /** micro seconds since boot */
-  static int64_t micros_since_boot() noexcept;
+  /** Nanoseconds since boot */
+  static uint64_t nanos_since_boot() noexcept;
 
   /** Timestamp for when OS was booted */
   static RTC::timestamp_t boot_timestamp();
@@ -75,8 +75,8 @@ public:
   /** Time spent sleeping (halt) in cycles */
   static uint64_t cycles_asleep() noexcept;
 
-  /** Time spent sleeping (halt) in micros */
-  static uint64_t micros_asleep() noexcept;
+  /** Time spent sleeping (halt) in nanoseconds */
+  static uint64_t nanos_asleep() noexcept;
 
 
   static MHz cpu_freq() noexcept

--- a/api/kernel/rtc.hpp
+++ b/api/kernel/rtc.hpp
@@ -28,8 +28,14 @@ class RTC
 public:
   using timestamp_t = uint64_t;
 
+  /// a 64-bit nanosecond timestamp of the current time
+  static timestamp_t nanos_now() {
+    return __arch_system_time();
+  }
   /// returns a 64-bit unix timestamp of the current time
-  static timestamp_t now() { return __arch_system_time(); }
+  static timestamp_t now() {
+    return nanos_now() / 1000000000ull;
+  }
 
   /// returns a 64-bit unix timestamp for when the OS was booted
   static timestamp_t boot_timestamp() {

--- a/api/kernel/rtc.hpp
+++ b/api/kernel/rtc.hpp
@@ -34,7 +34,7 @@ public:
   }
   /// returns a 64-bit unix timestamp of the current time
   static timestamp_t now() {
-    return nanos_now() / 1000000000ull;
+    return __arch_wall_clock().tv_sec;
   }
 
   /// returns a 64-bit unix timestamp for when the OS was booted

--- a/api/kernel/rtc.hpp
+++ b/api/kernel/rtc.hpp
@@ -26,10 +26,10 @@
 class RTC
 {
 public:
-  using timestamp_t = int64_t;
+  using timestamp_t = uint64_t;
 
   /// returns a 64-bit unix timestamp of the current time
-  static timestamp_t now() { return __arch_time_now(); }
+  static timestamp_t now() { return __arch_system_time(); }
 
   /// returns a 64-bit unix timestamp for when the OS was booted
   static timestamp_t boot_timestamp() {

--- a/api/kernel/timers.hpp
+++ b/api/kernel/timers.hpp
@@ -29,7 +29,7 @@ class Timers
 {
 public:
   using id_t       = int32_t;
-  using duration_t = std::chrono::microseconds;
+  using duration_t = std::chrono::nanoseconds;
   using handler_t  = delegate<void(id_t)>;
 
   static constexpr id_t UNUSED_ID = -1;

--- a/api/profile
+++ b/api/profile
@@ -118,7 +118,7 @@ class ScopedProfiler
    *  --------------------------------------------------------------------------------
    *
    */
-  static std::string get_statistics();
+  static std::string get_statistics(bool sorted = true);
 
  private:
   uint64_t tick_start;
@@ -132,6 +132,7 @@ class ScopedProfiler
     std::string function_name;
     unsigned    num_samples;
     uint64_t    cycles_average;
+    uint64_t    nanos_start;
   };
 
 

--- a/examples/IRCd/CMakeLists.txt
+++ b/examples/IRCd/CMakeLists.txt
@@ -40,7 +40,7 @@ set(LOCAL_INCLUDES "")
 set(DRIVERS
   virtionet
   vmxnet3
-  boot_logger
+  #boot_logger
   )
 
 set (PLUGINS

--- a/examples/IRCd/CMakeLists.txt
+++ b/examples/IRCd/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LOCAL_INCLUDES "")
 set(DRIVERS
   virtionet
   vmxnet3
+  boot_logger
   )
 
 set (PLUGINS

--- a/examples/IRCd/service.cpp
+++ b/examples/IRCd/service.cpp
@@ -139,4 +139,7 @@ void Service::ready()
 #endif
 
   Timers::periodic(seconds(1), seconds(PERIOD_SECS), print_stats);
+
+  // profiler statistics
+  printf("%s\n", ScopedProfiler::get_statistics(false).c_str());
 }

--- a/examples/IRCd/service.cpp
+++ b/examples/IRCd/service.cpp
@@ -28,7 +28,7 @@ void Service::start()
 {
   // run a small self-test to verify parser is sane
   extern void selftest(); selftest();
-  
+
   ircd = IrcServer::from_config();
 
   ircd->set_motd([] () -> const std::string& {
@@ -55,6 +55,7 @@ void Service::start()
 }
 
 #include <ctime>
+#include <sys/time.h>
 std::string now()
 {
   auto  tnow = time(0);
@@ -138,4 +139,10 @@ void Service::ready()
 
   using namespace std::chrono;
   Timers::periodic(seconds(1), seconds(PERIOD_SECS), print_stats);
+  Timers::periodic(seconds(1), seconds(1),
+    [] (int) {
+      struct timeval tv;
+      gettimeofday(&tv, nullptr);
+      printf("Time: %ld secs %ld nanos\n", tv.tv_sec, tv.tv_usec);
+    });
 }

--- a/examples/IRCd/service.cpp
+++ b/examples/IRCd/service.cpp
@@ -18,11 +18,13 @@
 #include <os>
 #include <profile>
 #include <timers>
+#include <sys/time.h>
 #define USE_STACK_SAMPLING
 #define PERIOD_SECS    4
 
 #include "ircd/ircd.hpp"
 static std::unique_ptr<IrcServer> ircd = nullptr;
+using namespace std::chrono;
 
 void Service::start()
 {
@@ -55,7 +57,6 @@ void Service::start()
 }
 
 #include <ctime>
-#include <sys/time.h>
 std::string now()
 {
   auto  tnow = time(0);
@@ -137,12 +138,5 @@ void Service::ready()
   //StackSampler::set_mode(StackSampler::MODE_CALLER);
 #endif
 
-  using namespace std::chrono;
   Timers::periodic(seconds(1), seconds(PERIOD_SECS), print_stats);
-  Timers::periodic(seconds(1), seconds(1),
-    [] (int) {
-      struct timeval tv;
-      gettimeofday(&tv, nullptr);
-      printf("Time: %ld secs %ld nanos\n", tv.tv_sec, tv.tv_usec);
-    });
 }

--- a/examples/IRCd/vm.json
+++ b/examples/IRCd/vm.json
@@ -1,5 +1,5 @@
 {
   "image" : "IRCd",
-  "net" : [{"device" : "vmxnet3"}],
+  "net" : [{"device" : "virtio"}],
   "mem" : 1024
 }

--- a/examples/STREAM/service.cpp
+++ b/examples/STREAM/service.cpp
@@ -20,7 +20,7 @@
 
 double mysecond()
 {
-  return OS::micros_since_boot() / 1000000.f;
+  return OS::nanos_since_boot() / 1.0e9;
 }
 
 void Service::start()

--- a/examples/TCP_perf/service.cpp
+++ b/examples/TCP_perf/service.cpp
@@ -64,13 +64,13 @@ void start_measure()
   packets_tx  = Statman::get().get_by_name("eth0.ethernet.packets_tx").get_uint64();
   printf("<Settings> DACK: %lli ms WSIZE: %u WS: %u CALC_WIN: %u TS: %s\n",
     dack.count(), winsize, wscale, winsize << wscale, timestamps ? "ON" : "OFF");
-  ts          = OS::micros_since_boot();
+  ts          = OS::nanos_since_boot();
   activity_before.reset();
 }
 
 void stop_measure()
 {
-  auto diff   = OS::micros_since_boot() - ts;
+  auto diff   = OS::nanos_since_boot() - ts;
   activity_after.reset();
 
   StackSampler::print(15);
@@ -79,7 +79,7 @@ void stop_measure()
   packets_rx  = Statman::get().get_by_name("eth0.ethernet.packets_rx").get_uint64() - packets_rx;
   packets_tx  = Statman::get().get_by_name("eth0.ethernet.packets_tx").get_uint64() - packets_tx;
   printf("Packets RX [%llu] TX [%llu]\n", packets_rx, packets_tx);
-  double durs   = ((double)diff) / 1000 / 1000;
+  double durs   = (double) diff / 1000000000ULL;
   double mbits  = (received/(1024*1024)*8) / durs;
   printf("Duration: %.2fs - Payload: %lld/%u MB - %.2f MBit/s\n",
           durs, received/(1024*1024), SIZE/(1024*1024), mbits);

--- a/linux/src/arch.cpp
+++ b/linux/src/arch.cpp
@@ -17,7 +17,7 @@ bool OS::is_panicking() noexcept
 
 void __arch_subscribe_irq(uint8_t) {}
 
-int64_t __arch_time_now() noexcept {
+uint64_t __arch_system_time() noexcept {
   return time(0);
 }
 

--- a/linux/src/os.cpp
+++ b/linux/src/os.cpp
@@ -4,11 +4,11 @@
 #include <kernel/timers.hpp>
 #include <sys/time.h>
 #include <sched.h>
-int64_t OS::micros_since_boot() noexcept
+int64_t OS::nanos_since_boot() noexcept
 {
-  struct timeval tv;
-  gettimeofday(&tv,NULL);
-  return tv.tv_sec*(uint64_t)1000000+tv.tv_usec;
+  struct timespec tv;
+  clock_gettime(&tv,NULL);
+  return tv.tv_sec*(uint64_t)1000000000ull+tv.tv_nsec;
 }
 
 void OS::event_loop()
@@ -103,14 +103,14 @@ extern "C" void alarm_handler(int sig)
 {
   (void) sig;
 }
-static void begin_timer(std::chrono::microseconds usec)
+static void begin_timer(std::chrono::nanoseconds usec)
 {
   using namespace std::chrono;
   auto secs = duration_cast<seconds> (usec);
 
   struct itimerspec it;
   it.it_value.tv_sec  = secs.count();
-  it.it_value.tv_nsec = 1000 * (usec.count() - secs.count() * 1000000);
+  it.it_value.tv_nsec = usec.count() - secs.count() * 1000000000ull;
   timer_settime(timer_id, 0, &it, nullptr);
 }
 

--- a/linux/src/os.cpp
+++ b/linux/src/os.cpp
@@ -4,10 +4,11 @@
 #include <kernel/timers.hpp>
 #include <sys/time.h>
 #include <sched.h>
-int64_t OS::nanos_since_boot() noexcept
+#include <ctime>
+uint64_t OS::nanos_since_boot() noexcept
 {
   struct timespec tv;
-  clock_gettime(&tv,NULL);
+  clock_gettime(CLOCK_REALTIME, &tv);
   return tv.tv_sec*(uint64_t)1000000000ull+tv.tv_nsec;
 }
 
@@ -69,9 +70,6 @@ uintptr_t OS::heap_usage() noexcept {
 #include <kernel/rtc.hpp>
 #include <time.h>
 RTC::timestamp_t RTC::booted_at = time(0);
-RTC::timestamp_t OS::boot_timestamp() {
-  return RTC::boot_timestamp();
-}
 
 #include <smp>
 int SMP::cpu_id() noexcept {

--- a/src/drivers/disk_logger.cpp
+++ b/src/drivers/disk_logger.cpp
@@ -59,7 +59,7 @@ static void disk_logger_write(const char* data, size_t len)
     header.timestamp = RTC::now();
   }
   else {
-    header.timestamp = OS::micros_since_boot() / 1000000;
+    header.timestamp = OS::nanos_since_boot() / 1000000000ull;
   }
   __builtin_memcpy(logbuffer->data(), &header, sizeof(log_structure));
 

--- a/src/kernel/cpuid.cpp
+++ b/src/kernel/cpuid.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <array>
 #include <unordered_map>
+#include <kprint>
 
 namespace std
 {
@@ -280,18 +281,18 @@ bool CPUID::is_amd_cpu() noexcept
 {
   auto result = cpuid(0, 0);
   return
-     memcmp(reinterpret_cast<char*>(&result.EBX), "htuA", 4) == 0
-  && memcmp(reinterpret_cast<char*>(&result.EDX), "itne", 4) == 0
-  && memcmp(reinterpret_cast<char*>(&result.ECX), "DMAc", 4) == 0;
+     memcmp((char*) &result.EBX, "Auth", 4) == 0
+  && memcmp((char*) &result.EDX, "enti", 4) == 0
+  && memcmp((char*) &result.ECX, "cAMD", 4) == 0;
 }
 
 bool CPUID::is_intel_cpu() noexcept
 {
   auto result = cpuid(0, 0);
   return
-     memcmp(reinterpret_cast<char*>(&result.EBX), "Genu", 4) == 0
-  && memcmp(reinterpret_cast<char*>(&result.EDX), "ineI", 4) == 0
-  && memcmp(reinterpret_cast<char*>(&result.ECX), "ntel", 4) == 0;
+     memcmp((char*) &result.EBX, "Genu", 4) == 0
+  && memcmp((char*) &result.EDX, "ineI", 4) == 0
+  && memcmp((char*) &result.ECX, "ntel", 4) == 0;
 }
 
 bool CPUID::has_feature(Feature f)

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -48,7 +48,7 @@ bool  OS::power_   = true;
 bool  OS::boot_sequence_passed_ = false;
 bool  OS::m_is_live_updated     = false;
 bool  OS::m_block_drivers_ready = false;
-MHz   OS::cpu_mhz_ {-1};
+KHz   OS::cpu_khz_ {-1};
 uintptr_t OS::liveupdate_loc_   = 0;
 uintptr_t OS::memory_end_ = 0;
 uintptr_t OS::heap_max_ = (uintptr_t) -1;

--- a/src/kernel/rtc.cpp
+++ b/src/kernel/rtc.cpp
@@ -5,5 +5,5 @@ RTC::timestamp_t RTC::booted_at;
 void RTC::init()
 {
   // set boot timestamp
-  booted_at = __arch_time_now();
+  booted_at = now();
 }

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -250,10 +250,9 @@ int clock_gettime(clockid_t clk_id, struct timespec* tp) {
   return -1;
 }
 int gettimeofday(struct timeval* p, void*) {
-  uint64_t ts = RTC::nanos_now();
-  printf("gettimeofday called: %lu\n", ts);
-  p->tv_sec  = ts / 1000000000ull;
-  p->tv_usec = (ts % 1000000000ull) / 1000;
+  auto tval = __arch_wall_clock();
+  p->tv_sec  = tval.tv_sec;
+  p->tv_usec = tval.tv_nsec / 1000;
   return 0;
 }
 

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -98,13 +98,6 @@ int wait(int*) {
   return -1;
 }
 
-int gettimeofday(struct timeval* p, void*) {
-  uint64_t ts = RTC::now();
-  p->tv_sec  = ts / 1000000000ull;
-  p->tv_usec = (ts % 1000000000ull) / 1000;
-  return 0;
-}
-
 int kill(pid_t pid, int sig) THROW {
   SMP::global_lock();
   printf("!!! Kill PID: %i, SIG: %i - %s ", pid, sig, strsignal(sig));
@@ -247,11 +240,21 @@ typedef int clockid_t;
 // Basic second-resolution implementation - using CMOS directly for now.
 int clock_gettime(clockid_t clk_id, struct timespec* tp) {
   if (clk_id == CLOCK_REALTIME) {
-    tp->tv_sec = RTC::now();
-    tp->tv_nsec = 0;
+    uint64_t ts = RTC::nanos_now();
+    printf("clock_gettime called: %lu\n", ts);
+    tp->tv_sec  = ts / 1000000000ull;
+    tp->tv_nsec = ts % 1000000000ull;
     return 0;
   }
+  printf("hmm clock_gettime called, -1\n");
   return -1;
+}
+int gettimeofday(struct timeval* p, void*) {
+  uint64_t ts = RTC::nanos_now();
+  printf("gettimeofday called: %lu\n", ts);
+  p->tv_sec  = ts / 1000000000ull;
+  p->tv_usec = (ts % 1000000000ull) / 1000;
+  return 0;
 }
 
 extern "C" void _init_syscalls();

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -99,8 +99,9 @@ int wait(int*) {
 }
 
 int gettimeofday(struct timeval* p, void*) {
-  p->tv_sec  = RTC::now();
-  p->tv_usec = 0;
+  uint64_t ts = RTC::now();
+  p->tv_sec  = ts / 1000000000ull;
+  p->tv_usec = (ts % 1000000000ull) / 1000;
   return 0;
 }
 

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -23,7 +23,6 @@
 #include <sys/errno.h>
 #include <sys/stat.h>
 #include <kernel/os.hpp>
-#include <kernel/rtc.hpp>
 
 #include <statman>
 #include <kprint>
@@ -237,13 +236,10 @@ typedef int clockid_t;
 #define CLOCK_REALTIME 0
 #endif
 #endif
-// Basic second-resolution implementation - using CMOS directly for now.
+
 int clock_gettime(clockid_t clk_id, struct timespec* tp) {
   if (clk_id == CLOCK_REALTIME) {
-    uint64_t ts = RTC::nanos_now();
-    printf("clock_gettime called: %lu\n", ts);
-    tp->tv_sec  = ts / 1000000000ull;
-    tp->tv_nsec = ts % 1000000000ull;
+    *tp = __arch_wall_clock();
     return 0;
   }
   printf("hmm clock_gettime called, -1\n");

--- a/src/kernel/timers.cpp
+++ b/src/kernel/timers.cpp
@@ -2,6 +2,7 @@
 
 #include <kernel/os.hpp>
 #include <kernel/events.hpp>
+#include <kernel/rtc.hpp>
 #include <service>
 #include <smp>
 #include <statman>
@@ -16,7 +17,7 @@ typedef Timers::handler_t  handler_t;
 
 static inline auto now() noexcept
 {
-  return nanoseconds(OS::nanos_since_boot());
+  return nanoseconds(RTC::nanos_now());
 }
 
 /// internal timer ///

--- a/src/kernel/timers.cpp
+++ b/src/kernel/timers.cpp
@@ -14,9 +14,9 @@ typedef Timers::handler_t  handler_t;
 
 /// time functions ///
 
-static inline std::chrono::microseconds now() noexcept
+static inline auto now() noexcept
 {
-  return microseconds(OS::micros_since_boot());
+  return nanoseconds(OS::nanos_since_boot());
 }
 
 /// internal timer ///

--- a/src/net/tcp/tcp.cpp
+++ b/src/net/tcp/tcp.cpp
@@ -22,7 +22,7 @@
 #include <net/tcp/tcp.hpp>
 #include <net/inet_common.hpp> // checksum
 #include <statman>
-#include <os> // micros_since_boot (get_ts_value)
+#include <os> // nanos_since_boot (get_ts_value)
 
 using namespace std;
 using namespace net;
@@ -365,7 +365,7 @@ seq_t TCP::generate_iss() {
 
 uint32_t TCP::get_ts_value() const
 {
-  return ((OS::micros_since_boot() >> 10) & 0xffffffff);
+  return ((OS::nanos_since_boot() / 1000000000ull) & 0xffffffff);
 }
 
 void TCP::drop(const tcp::Packet&) {

--- a/src/platform/kvm/bsd_pvclock.hpp
+++ b/src/platform/kvm/bsd_pvclock.hpp
@@ -1,0 +1,80 @@
+/*-
+ * Copyright (c) 2009 Adrian Chadd
+ * Copyright (c) 2012 Spectra Logic Corporation
+ * Copyright (c) 2014 Bryan Venteicher
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+* Scale a 64-bit delta by scaling and multiplying by a 32-bit fraction,
+* yielding a 64-bit result.
+*/
+static inline uint64_t
+pvclock_scale_delta(uint64_t delta, uint32_t mul_frac, int shift)
+{
+	uint64_t product;
+
+	if (shift < 0)
+		delta >>= -shift;
+	else
+		delta <<= shift;
+
+#if defined(__i386__)
+	{
+		uint32_t tmp1, tmp2;
+
+		/**
+		 * For i386, the formula looks like:
+		 *
+		 *   lower = (mul_frac * (delta & UINT_MAX)) >> 32
+		 *   upper = mul_frac * (delta >> 32)
+		 *   product = lower + upper
+		 */
+		__asm__ (
+			"mul  %5       ; "
+			"mov  %4,%%eax ; "
+			"mov  %%edx,%4 ; "
+			"mul  %5       ; "
+			"xor  %5,%5    ; "
+			"add  %4,%%eax ; "
+			"adc  %5,%%edx ; "
+			: "=A" (product), "=r" (tmp1), "=r" (tmp2)
+			: "a" ((uint32_t)delta), "1" ((uint32_t)(delta >> 32)),
+			  "2" (mul_frac) );
+	}
+#elif defined(__amd64__)
+	{
+		unsigned long tmp;
+
+		__asm__ (
+			"mulq %[mul_frac] ; shrd $32, %[hi], %[lo]"
+			: [lo]"=a" (product), [hi]"=d" (tmp)
+			: "0" (delta), [mul_frac]"rm"((uint64_t)mul_frac));
+	}
+#else
+#error "pvclock: unsupported x86 architecture?"
+#endif
+
+	return (product);
+}

--- a/src/platform/kvm/kvmclock.cpp
+++ b/src/platform/kvm/kvmclock.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <info>
 #include <smp>
+
 #define MSR_KVM_WALL_CLOCK_NEW  0x4b564d00
 #define MSR_KVM_SYSTEM_TIME_NEW 0x4b564d01
 using namespace x86;
@@ -20,76 +21,64 @@ struct alignas(4096) pvclock_vcpu_time_info {
 }__attribute__((packed));
 static SMP_ARRAY<pvclock_vcpu_time_info> vcpu_time;
 
-struct pvclock_wall_clock {
+struct alignas(4096) pvclock_wall_clock {
 	uint32_t version;
 	uint32_t sec;
 	uint32_t nsec;
-}__attribute__((__packed__));
+}__attribute__((packed));
 static pvclock_wall_clock kvm_wall_clock;
 
 void KVM_clock::init()
 {
-  //auto wall_addr = (uintptr_t) &wall_clock;
-  //CPU::write_msr(MSR_KVM_WALL_CLOCK_NEW, wall_addr);
+  auto wall_addr = (uintptr_t) &kvm_wall_clock;
+  CPU::write_msr(MSR_KVM_WALL_CLOCK_NEW, wall_addr);
   auto vcpu_addr = (uintptr_t) &PER_CPU(vcpu_time);
   CPU::write_msr(MSR_KVM_SYSTEM_TIME_NEW, vcpu_addr | 1);
-
-
-  INFO("KVM", "KVM clocks initialized");
-
 }
 
-uint64_t KVM_clock::get_tsc_khz()
+KHz KVM_clock::get_tsc_khz()
 {
-  u64 pv_tsc_khz = 1000000ULL << 32;
+  uint64_t khz = 1000000ULL << 32;
+  khz /= PER_CPU(vcpu_time).tsc_to_system_mul;
 
-  do_div(pv_tsc_khz, src->tsc_to_system_mul);
-  if (src->tsc_shift < 0)
-  	pv_tsc_khz <<= -src->tsc_shift;
+  if (PER_CPU(vcpu_time).tsc_shift < 0)
+  	khz <<= -PER_CPU(vcpu_time).tsc_shift;
   else
-  	pv_tsc_khz >>= src->tsc_shift;
-  return pv_tsc_khz;
+    khz >>=  PER_CPU(vcpu_time).tsc_shift;
+  return KHz(khz);
 }
 
+#include "bsd_pvclock.hpp"
 uint64_t KVM_clock::system_time()
 {
   auto& vcpu = PER_CPU(vcpu_time);
-  printf("VCPU timestamp: %lu  vs  %lu\n",
-        vcpu.tsc_timestamp, __arch_cpu_cycles());
-  printf("TSC to system: %lu  shift: %hhd\n",
-        vcpu.tsc_to_system_mul, vcpu.tsc_shift);
   uint32_t version = 0;
   uint64_t time_ns = 0;
   do
   {
     version = vcpu.version;
     asm("mfence" ::: "memory");
-    time_ns = (__arch_cpu_cycles() - vcpu.tsc_timestamp);
-    if (vcpu.tsc_shift >= 0) {
-      time_ns <<= vcpu.tsc_shift;
-    } else {
-      time_ns >>= -vcpu.tsc_shift;
-    }
-    time_ns = (time_ns * vcpu.tsc_to_system_mul) >> 32;
+    // nanosecond offset based on TSC
+    uint64_t delta = (__arch_cpu_cycles() - vcpu.tsc_timestamp);
+    time_ns = pvclock_scale_delta(delta, vcpu.tsc_to_system_mul, vcpu.tsc_shift);
+    // base system time
     time_ns += vcpu.system_time;
     asm("mfence" ::: "memory");
   }
   while ((vcpu.version & 0x1) || (version != vcpu.version));
-
-  printf("KVM_clock nanos: %lu\n", time_ns);
   return time_ns;
 }
 
-uint64_t KVM_clock::wall_clock()
+timespec KVM_clock::wall_clock()
 {
   uint32_t version = 0;
-  uint64_t tval = 0;
+  timespec tval;
 	do
   {
 		version = kvm_wall_clock.version;
 		asm("mfence" ::: "memory");
-		tval = kvm_wall_clock.sec * 1000000000ull;
-		tval += kvm_wall_clock.nsec;
+		tval.tv_sec  = kvm_wall_clock.sec;
+		tval.tv_nsec = kvm_wall_clock.nsec;
 		asm("mfence" ::: "memory");
 	}
   while ((kvm_wall_clock.version & 1)

--- a/src/platform/kvm/kvmclock.cpp
+++ b/src/platform/kvm/kvmclock.cpp
@@ -1,0 +1,78 @@
+#include "kvmclock.hpp"
+#include "../x86_pc/cpu.hpp"
+#include <cstdio>
+#include <info>
+#include <smp>
+#define MSR_KVM_WALL_CLOCK_NEW  0x4b564d00
+#define MSR_KVM_SYSTEM_TIME_NEW 0x4b564d01
+using namespace x86;
+
+struct alignas(4096) pvclock_vcpu_time_info {
+	uint32_t version;
+	uint32_t pad0;
+	uint64_t tsc_timestamp;
+	uint64_t system_time;
+	uint32_t tsc_to_system_mul;
+	signed char tsc_shift;
+	unsigned char flags;
+	unsigned char pad[2];
+}__attribute__((packed));
+static SMP_ARRAY<pvclock_vcpu_time_info> vcpu_time;
+
+struct pvclock_wall_clock {
+	uint32_t version;
+	uint32_t sec;
+	uint32_t nsec;
+}__attribute__((__packed__));
+static pvclock_wall_clock kvm_wall_clock;
+
+void KVM_clock::init()
+{
+  //auto wall_addr = (uintptr_t) &wall_clock;
+  //CPU::write_msr(MSR_KVM_WALL_CLOCK_NEW, wall_addr);
+  auto vcpu_addr = (uintptr_t) &PER_CPU(vcpu_time);
+  CPU::write_msr(MSR_KVM_SYSTEM_TIME_NEW, vcpu_addr | 1);
+  INFO("KVM", "KVM clocks initialized");
+}
+
+uint64_t KVM_clock::system_time()
+{
+  auto& vcpu = PER_CPU(vcpu_time);
+  uint32_t version = 0;
+  uint64_t time_ns = 0;
+  do
+  {
+    version = vcpu.version;
+    asm("mfence" ::: "memory");
+    time_ns = (__arch_cpu_cycles() - vcpu.tsc_timestamp);
+    if (vcpu.tsc_shift >= 0) {
+      time_ns <<= vcpu.tsc_shift;
+    } else {
+      time_ns >>= -vcpu.tsc_shift;
+    }
+    time_ns = (time_ns * vcpu.tsc_to_system_mul) >> 32;
+    time_ns += vcpu.system_time;
+    asm("mfence" ::: "memory");
+  }
+  while ((vcpu.version & 0x1) || (version != vcpu.version));
+
+  return time_ns;
+}
+
+uint64_t KVM_clock::wall_clock()
+{
+  uint32_t version = 0;
+  uint64_t tval = 0;
+	do
+  {
+		version = kvm_wall_clock.version;
+		asm("mfence" ::: "memory");
+		tval = kvm_wall_clock.sec * 1000000000ull;
+		tval += kvm_wall_clock.nsec;
+		asm("mfence" ::: "memory");
+	}
+  while ((kvm_wall_clock.version & 1)
+      || (kvm_wall_clock.version != version));
+
+  return tval;
+}

--- a/src/platform/kvm/kvmclock.hpp
+++ b/src/platform/kvm/kvmclock.hpp
@@ -1,11 +1,12 @@
 #pragma once
 #include <cstdint>
+#include <sys/time.h>
+#include <hertz>
 
 struct KVM_clock
 {
   static void init();
   static uint64_t system_time();
-  static uint64_t wall_clock();
-
-  static uint64_t get_tsc_khz();
+  static timespec wall_clock();
+  static KHz      get_tsc_khz();
 };

--- a/src/platform/kvm/kvmclock.hpp
+++ b/src/platform/kvm/kvmclock.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+
+struct KVM_clock
+{
+  static void init();
+  static uint64_t system_time();
+  static uint64_t wall_clock();
+};

--- a/src/platform/kvm/kvmclock.hpp
+++ b/src/platform/kvm/kvmclock.hpp
@@ -6,4 +6,6 @@ struct KVM_clock
   static void init();
   static uint64_t system_time();
   static uint64_t wall_clock();
+
+  static uint64_t get_tsc_khz();
 };

--- a/src/platform/x86_linux/os.cpp
+++ b/src/platform/x86_linux/os.cpp
@@ -51,7 +51,7 @@ struct alignas(SMP_ALIGN) OS_CPU {
 };
 static SMP_ARRAY<OS_CPU> os_per_cpu;
 
-int64_t OS::micros_since_boot() noexcept {
+uint64_t OS::nanos_since_boot() noexcept {
   return cycles_since_boot() / cpu_freq().count();
 }
 
@@ -68,7 +68,7 @@ RTC::timestamp_t OS::uptime()
 uint64_t OS::cycles_asleep() noexcept {
   return PER_CPU(os_per_cpu).cycles_hlt;
 }
-uint64_t OS::micros_asleep() noexcept {
+uint64_t OS::nanos_asleep() noexcept {
   return PER_CPU(os_per_cpu).cycles_hlt / cpu_freq().count();
 }
 

--- a/src/platform/x86_linux/os.cpp
+++ b/src/platform/x86_linux/os.cpp
@@ -55,16 +55,6 @@ uint64_t OS::nanos_since_boot() noexcept {
   return cycles_since_boot() / cpu_freq().count();
 }
 
-RTC::timestamp_t OS::boot_timestamp()
-{
-  return RTC::boot_timestamp();
-}
-
-RTC::timestamp_t OS::uptime()
-{
-  return RTC::time_since_boot();
-}
-
 uint64_t OS::cycles_asleep() noexcept {
   return PER_CPU(os_per_cpu).cycles_hlt;
 }

--- a/src/platform/x86_nano/platform.cpp
+++ b/src/platform/x86_nano/platform.cpp
@@ -20,8 +20,11 @@ void __platform_init()
 }
 
 // not supported!
-int64_t __arch_time_now() noexcept {
+uint64_t __arch_system_time() noexcept {
   return 0;
+}
+timespec __arch_wall_clock() noexcept {
+  return {0, 0};
 }
 // not supported!
 void OS::block() {}

--- a/src/platform/x86_pc/apic_timer.cpp
+++ b/src/platform/x86_pc/apic_timer.cpp
@@ -120,10 +120,10 @@ namespace x86
     return ticks_per_micro != 0;
   }
 
-  void APIC_Timer::oneshot(std::chrono::microseconds micros) noexcept
+  void APIC_Timer::oneshot(std::chrono::nanoseconds nanos) noexcept
   {
     // prevent overflow
-    uint64_t ticks = micros.count() * ticks_per_micro;
+    uint64_t ticks = nanos.count() / 1000 * ticks_per_micro;
     if (ticks > 0xFFFFFFFF) ticks = 0xFFFFFFFF;
 
     // set initial counter

--- a/src/platform/x86_pc/apic_timer.cpp
+++ b/src/platform/x86_pc/apic_timer.cpp
@@ -97,8 +97,8 @@ namespace x86
       // stop APIC timer
       APIC::get().timer_interrupt(false);
 
-      //printf("* APIC timer: ticks %ums: %u\t 1mi: %u\n",
-      //       CALIBRATION_MS, diff, ticks_per_micro);
+      printf("* APIC timer: ticks %ums: %u\t 1mi: %u\n",
+             CALIBRATION_MS, diff, ticks_per_micro);
       start_timers();
 
       // with SMP, signal everyone else too (IRQ 1)

--- a/src/platform/x86_pc/apic_timer.cpp
+++ b/src/platform/x86_pc/apic_timer.cpp
@@ -97,8 +97,8 @@ namespace x86
       // stop APIC timer
       APIC::get().timer_interrupt(false);
 
-      printf("* APIC timer: ticks %ums: %u\t 1mi: %u\n",
-             CALIBRATION_MS, diff, ticks_per_micro);
+      //printf("* APIC timer: ticks %ums: %u\t 1mi: %u\n",
+      //       CALIBRATION_MS, diff, ticks_per_micro);
       start_timers();
 
       // with SMP, signal everyone else too (IRQ 1)

--- a/src/platform/x86_pc/apic_timer.hpp
+++ b/src/platform/x86_pc/apic_timer.hpp
@@ -32,7 +32,7 @@ struct APIC_Timer
 
   static bool ready() noexcept;
 
-  static void oneshot(std::chrono::microseconds) noexcept;
+  static void oneshot(std::chrono::nanoseconds) noexcept;
   static void stop() noexcept;
 };
 

--- a/src/platform/x86_pc/clocks.hpp
+++ b/src/platform/x86_pc/clocks.hpp
@@ -16,10 +16,13 @@
 // limitations under the License.
 
 #pragma once
+#include <sys/time.h>
+#include <hertz>
 
 namespace x86
 {
   struct Clocks {
     static void init();
+    static KHz  get_khz();
   };
 }

--- a/src/platform/x86_pc/cmos_clock.cpp
+++ b/src/platform/x86_pc/cmos_clock.cpp
@@ -23,7 +23,7 @@
 
 namespace x86
 {
-  static int64_t  current_time;
+  static uint64_t current_time;
   static uint64_t current_ticks;
 
   void CMOS_clock::init()
@@ -41,11 +41,15 @@ namespace x86
       });
   }
 
-  int64_t CMOS_clock::system_time()
+  uint64_t CMOS_clock::system_time()
   {
     auto ticks = OS::cycles_since_boot() - current_ticks;
-    auto diff  = ticks / Hz(MHz(OS::cpu_freq())).count();
+    auto diff  = (double) ticks / Hz(MHz(OS::cpu_freq())).count();
 
-    return current_time + diff;
+    return (current_time + diff) * 1000000000ull;
+  }
+  uint64_t CMOS_clock::wall_clock()
+  {
+    return system_time();
   }
 }

--- a/src/platform/x86_pc/cmos_clock.hpp
+++ b/src/platform/x86_pc/cmos_clock.hpp
@@ -25,6 +25,7 @@ namespace x86
   {
     static void init();
     static uint64_t system_time();
-    static uint64_t wall_clock();
+    static timespec wall_clock();
+    static KHz      get_tsc_khz();
   };
 }

--- a/src/platform/x86_pc/cmos_clock.hpp
+++ b/src/platform/x86_pc/cmos_clock.hpp
@@ -24,6 +24,7 @@ namespace x86
   struct CMOS_clock
   {
     static void init();
-    static int64_t system_time();
+    static uint64_t system_time();
+    static uint64_t wall_clock();
   };
 }

--- a/src/platform/x86_pc/os.cpp
+++ b/src/platform/x86_pc/os.cpp
@@ -56,16 +56,6 @@ uint64_t OS::nanos_since_boot() noexcept {
   return cycles_since_boot() / cpu_freq().count();
 }
 
-RTC::timestamp_t OS::boot_timestamp()
-{
-  return RTC::boot_timestamp();
-}
-
-RTC::timestamp_t OS::uptime()
-{
-  return RTC::time_since_boot();
-}
-
 uint64_t OS::cycles_asleep() noexcept {
   return PER_CPU(os_per_cpu).cycles_hlt;
 }

--- a/src/platform/x86_pc/os.cpp
+++ b/src/platform/x86_pc/os.cpp
@@ -52,7 +52,7 @@ struct alignas(SMP_ALIGN) OS_CPU {
 };
 static SMP_ARRAY<OS_CPU> os_per_cpu;
 
-int64_t OS::micros_since_boot() noexcept {
+uint64_t OS::nanos_since_boot() noexcept {
   return cycles_since_boot() / cpu_freq().count();
 }
 
@@ -69,7 +69,7 @@ RTC::timestamp_t OS::uptime()
 uint64_t OS::cycles_asleep() noexcept {
   return PER_CPU(os_per_cpu).cycles_hlt;
 }
-uint64_t OS::micros_asleep() noexcept {
+uint64_t OS::nanos_asleep() noexcept {
   return PER_CPU(os_per_cpu).cycles_hlt / cpu_freq().count();
 }
 

--- a/src/platform/x86_pc/os.cpp
+++ b/src/platform/x86_pc/os.cpp
@@ -53,7 +53,7 @@ struct alignas(SMP_ALIGN) OS_CPU {
 static SMP_ARRAY<OS_CPU> os_per_cpu;
 
 uint64_t OS::nanos_since_boot() noexcept {
-  return cycles_since_boot() / cpu_freq().count();
+  return __arch_system_time();
 }
 
 uint64_t OS::cycles_asleep() noexcept {

--- a/src/platform/x86_pc/pit.cpp
+++ b/src/platform/x86_pc/pit.cpp
@@ -20,6 +20,7 @@
 #include <hw/ioport.hpp>
 #include <kernel/os.hpp>
 #include <kernel/events.hpp>
+#include <kernel/rtc.hpp>
 //#undef NO_DEBUG
 #define DEBUG
 #define DEBUG2
@@ -73,7 +74,7 @@ namespace x86
 
   static inline auto now() noexcept
   {
-    return duration_cast<nanoseconds> (nanoseconds(OS::nanos_since_boot()));
+    return duration_cast<nanoseconds> (nanoseconds(RTC::nanos_now()));
   }
 
   void PIT::oneshot(milliseconds timeval, timeout_handler handler)
@@ -87,7 +88,7 @@ namespace x86
     if (forever) {
       get().forev_handler = handler;
     } else {
-      get().expiration    = now() + timeval;
+      get().expiration    = now() + duration_cast<nanoseconds>(timeval);
       get().handler       = handler;
     }
   }

--- a/src/platform/x86_pc/pit.cpp
+++ b/src/platform/x86_pc/pit.cpp
@@ -71,9 +71,9 @@ namespace x86
     return freq;
   }
 
-  static inline milliseconds now() noexcept
+  static inline auto now() noexcept
   {
-    return duration_cast<milliseconds> (microseconds(OS::micros_since_boot()));
+    return duration_cast<nanoseconds> (nanoseconds(OS::nanos_since_boot()));
   }
 
   void PIT::oneshot(milliseconds timeval, timeout_handler handler)

--- a/src/platform/x86_pc/pit.hpp
+++ b/src/platform/x86_pc/pit.hpp
@@ -85,9 +85,9 @@ namespace x86
     Mode     current_mode_ = NONE;
 
     // Timer handler & expiration timestamp
-    timeout_handler           handler = nullptr;
-    timeout_handler           forev_handler = nullptr;
-    std::chrono::milliseconds expiration;
+    timeout_handler          handler = nullptr;
+    timeout_handler          forev_handler = nullptr;
+    std::chrono::nanoseconds expiration;
 
     // Access mode bits are bits 4- and 5 in the Mode register
     enum AccessMode { LATCH_COUNT = 0x0, LO_ONLY=0x10, HI_ONLY=0x20, LO_HI=0x30 };

--- a/src/platform/x86_pc/platform.cpp
+++ b/src/platform/x86_pc/platform.cpp
@@ -21,7 +21,6 @@
 #include "clocks.hpp"
 #include "gdt.hpp"
 #include "idt.hpp"
-#include "pit.hpp"
 #include "smp.hpp"
 #include <kernel/events.hpp>
 #include <kernel/pci_manager.hpp>
@@ -31,7 +30,6 @@
 #include <info>
 #define MYINFO(X,...) INFO("x86", X, ##__VA_ARGS__)
 
-extern "C" uint16_t _cpu_sampling_freq_divider_;
 extern "C" char* get_cpu_esp();
 extern "C" void* get_cpu_ebp();
 #define _SENTINEL_VALUE_   0x123456789ABCDEF
@@ -101,26 +99,19 @@ void __platform_init()
   MYINFO("Enabling interrupts");
   asm volatile("sti");
 
-  // Estimate CPU frequency
-  MYINFO("Estimating CPU-frequency");
-  INFO2("|");
-  INFO2("+--(%d samples, %f sec. interval)", 18,
-        (x86::PIT::FREQUENCY / _cpu_sampling_freq_divider_).count());
-  INFO2("|");
+  // Setup kernel clocks
+  MYINFO("Setting up kernel clock sources");
+  Clocks::init();
 
   if (OS::cpu_freq().count() <= 0.0) {
-    OS::cpu_mhz_ = MHz(PIT::get().estimate_CPU_frequency());
+    OS::cpu_khz_ = Clocks::get_khz();
   }
-  INFO2("+--> %f MHz", OS::cpu_freq().count());
+  INFO2("+--> %f MHz", OS::cpu_freq().count() / 1000.0);
 
   // Note: CPU freq must be known before we can start timer system
   // Initialize APIC timers and timer systems
   // Deferred call to Service::ready() when calibration is complete
   APIC_Timer::calibrate();
-
-  // Setup kernel clocks
-  MYINFO("Setting up kernel clock sources");
-  Clocks::init();
 
   // Initialize storage devices
   PCI_manager::init(PCI::STORAGE);

--- a/src/platform/x86_pc/softreset.cpp
+++ b/src/platform/x86_pc/softreset.cpp
@@ -15,7 +15,7 @@ struct softreset_t
   uint32_t  checksum;
   uint64_t  liveupdate_loc;
   uint64_t  high_mem;
-  MHz       cpu_freq;
+  KHz       cpu_freq;
   uint32_t  apic_ticks;
   uint64_t  extra;
   uint32_t  extra_len;
@@ -47,7 +47,7 @@ void OS::resume_softreset(intptr_t addr)
   /// restore known values
   OS::liveupdate_loc_ = data->liveupdate_loc;
   OS::memory_end_     = data->high_mem;
-  OS::cpu_mhz_        = data->cpu_freq;
+  OS::cpu_khz_        = data->cpu_freq;
   x86::apic_timer_set_ticks(data->apic_ticks);
   OS::m_is_live_updated = true;
 

--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -35,8 +35,6 @@ extern uintptr_t _ELF_END_;
 #define PROFILE(name) /* name */
 #endif
 
-RTC::timestamp_t OS::booted_at_ {0};
-
 void solo5_poweroff()
 {
   __asm__ __volatile__("cli; hlt");
@@ -53,11 +51,6 @@ uint64_t __arch_wall_clock() noexcept
   return solo5_clock_wall();
 }
 
-RTC::timestamp_t OS::boot_timestamp()
-{
-  return booted_at_;
-}
-
 // actually uses nanoseconds (but its just a number)
 uint64_t OS::cycles_asleep() noexcept {
   return os_cycles_hlt;
@@ -66,13 +59,8 @@ uint64_t OS::nanos_asleep() noexcept {
   return os_cycles_hlt;
 }
 
-// uptime in nanoseconds
-RTC::timestamp_t OS::uptime()
-{
-  return solo5_clock_monotonic() - booted_at_;
-}
 uint64_t OS::nanos_since_boot() noexcept {
-  return uptime();
+  return solo5_clock_monotonic();
 }
 
 void OS::default_stdout(const char* str, const size_t len)

--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -44,7 +44,11 @@ void solo5_poweroff()
 }
 
 // returns wall clock time in nanoseconds since the UNIX epoch
-int64_t __arch_time_now() noexcept
+uint64_t __arch_system_time() noexcept
+{
+  return solo5_clock_wall();
+}
+uint64_t __arch_wall_clock() noexcept
 {
   return solo5_clock_wall();
 }
@@ -58,8 +62,8 @@ RTC::timestamp_t OS::boot_timestamp()
 uint64_t OS::cycles_asleep() noexcept {
   return os_cycles_hlt;
 }
-uint64_t OS::micros_asleep() noexcept {
-  return os_cycles_hlt / 1000;
+uint64_t OS::nanos_asleep() noexcept {
+  return os_cycles_hlt;
 }
 
 // uptime in nanoseconds
@@ -67,8 +71,8 @@ RTC::timestamp_t OS::uptime()
 {
   return solo5_clock_monotonic() - booted_at_;
 }
-int64_t OS::micros_since_boot() noexcept {
-  return uptime() / 1000;
+uint64_t OS::nanos_since_boot() noexcept {
+  return uptime();
 }
 
 void OS::default_stdout(const char* str, const size_t len)
@@ -141,7 +145,7 @@ void OS::start(char* _cmdline, uintptr_t mem_size)
   // We don't need a start or stop function in solo5.
   Timers::init(
     // timer start function
-    [] (std::chrono::microseconds) {},
+    [] (auto) {},
     // timer stop function
     [] () {});
 

--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -46,9 +46,13 @@ uint64_t __arch_system_time() noexcept
 {
   return solo5_clock_wall();
 }
-uint64_t __arch_wall_clock() noexcept
+timespec __arch_wall_clock() noexcept
 {
-  return solo5_clock_wall();
+  uint64_t stamp = solo5_clock_wall();
+  timespec result;
+  result.tv_sec = stamp / 1000000000ul;
+  result.tv_nsec = stamp % 1000000000ul;
+  return result;
 }
 
 // actually uses nanoseconds (but its just a number)
@@ -125,7 +129,7 @@ void OS::start(char* _cmdline, uintptr_t mem_size)
   extern void __platform_init();
   __platform_init();
 
-  MYINFO("Booted at monotonic_ns=%lld walltime_ns=%lld",
+  MYINFO("Booted at monotonic_ns=%ld walltime_ns=%ld",
          solo5_clock_monotonic(), solo5_clock_wall());
 
   Solo5_manager::init();

--- a/test/kernel/integration/LiveUpdate/test_boot.cpp
+++ b/test/kernel/integration/LiveUpdate/test_boot.cpp
@@ -7,7 +7,7 @@ static buffer_t bloberino;
 
 static void boot_save(Storage& storage, const buffer_t* blob)
 {
-  timestamps.push_back(OS::micros_since_boot());
+  timestamps.push_back(OS::nanos_since_boot());
   storage.add_vector(0, timestamps);
   assert(blob != nullptr);
   storage.add_buffer(2, *blob);
@@ -17,7 +17,7 @@ static void boot_resume_all(Restore& thing)
   timestamps = thing.as_vector<int64_t>(); thing.go_next();
   // calculate time spent
   auto t1 = timestamps.back();
-  auto t2 = OS::micros_since_boot();
+  auto t2 = OS::nanos_since_boot();
   // set final time
   timestamps.back() = t2 - t1;
   // retrieve old blob
@@ -36,8 +36,8 @@ LiveUpdate::storage_func begin_test_boot()
       std::sort(timestamps.begin(), timestamps.end());
       auto median = timestamps[timestamps.size()/2];
       // show information
-      printf("Median boot time over %lu samples: %ld micros\n",
-              timestamps.size(), median);
+      printf("Median boot time over %lu samples: %.2f millis\n",
+              timestamps.size(), median / 1000000.0);
       /*
       for (auto& stamp : timestamps) {
         printf("%lld\n", stamp);

--- a/test/kernel/integration/timers/timers.cpp
+++ b/test/kernel/integration/timers/timers.cpp
@@ -29,15 +29,14 @@ static int repeat2 = 0;
 void test_timers()
 {
   INFO("Timers", "Testing one-shot timers");
-  // RTC is using a timer to calibrate itself over large periods of time
-  assert(Timers::active() == 1);
+  assert(Timers::active() == 0);
 
   // 30 sec. - Test End
   Timers::oneshot(30s, [] (auto) {
       printf("One-shots fired: %i \n", one_shots);
       CHECKSERT(one_shots == 5, "5 one-shot-timers fired");
       CHECKSERT(repeat1 == 25 and repeat2 == 10, "1s. timer fired 25 times, 2s. timer fired 10 times");
-      CHECKSERT(Timers::active() == 1, "This was the last active timer (except RTC)");
+      CHECKSERT(Timers::active() == 0, "No more active timers");
       INFO("Timers", "SUCCESS");
     });
 
@@ -103,9 +102,8 @@ void test_timers()
 
       // Make sure this timer iterator is valid
       Timers::stop(timer1s);
-      // The current timer does not count towards the total active,
-      // but RTC uses a timer to calibrate itself over time
-      CHECKSERT(Timers::active() == 2, "There are still 2 timers left");
+      // The current timer does not count towards the total active
+      CHECKSERT(Timers::active() == 1, "Only the last finish timer is left");
 
       Timers::oneshot(1s,
       [] (auto) {

--- a/test/kernel/integration/timers/timers.cpp
+++ b/test/kernel/integration/timers/timers.cpp
@@ -29,14 +29,15 @@ static int repeat2 = 0;
 void test_timers()
 {
   INFO("Timers", "Testing one-shot timers");
-  assert(Timers::active() == 0);
+  static int BASE_TIMERS;
+  BASE_TIMERS = Timers::active();
 
   // 30 sec. - Test End
   Timers::oneshot(30s, [] (auto) {
       printf("One-shots fired: %i \n", one_shots);
       CHECKSERT(one_shots == 5, "5 one-shot-timers fired");
       CHECKSERT(repeat1 == 25 and repeat2 == 10, "1s. timer fired 25 times, 2s. timer fired 10 times");
-      CHECKSERT(Timers::active() == 0, "No more active timers");
+      CHECKSERT(Timers::active() == BASE_TIMERS+0, "No more active timers");
       INFO("Timers", "SUCCESS");
     });
 
@@ -103,7 +104,7 @@ void test_timers()
       // Make sure this timer iterator is valid
       Timers::stop(timer1s);
       // The current timer does not count towards the total active
-      CHECKSERT(Timers::active() == 1, "Only the last finish timer is left");
+      CHECKSERT(Timers::active() == BASE_TIMERS+1, "Only the last finish timer is left");
 
       Timers::oneshot(1s,
       [] (auto) {

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -65,7 +65,7 @@ void OS::start(unsigned, unsigned) {}
 void OS::default_stdout(const char*, size_t) {}
 void OS::event_loop() {}
 void OS::block() {}
-int64_t OS::micros_since_boot() noexcept {
+uint64_t OS::nanos_since_boot() noexcept {
   return 0;
 }
 void OS::resume_softreset(intptr_t) {}
@@ -141,8 +141,12 @@ void __arch_subscribe_irq(uint8_t) {}
 void __arch_enable_legacy_irq(uint8_t) {}
 void __arch_disable_legacy_irq(uint8_t) {}
 
-int64_t __arch_time_now() noexcept {
+uint64_t __arch_system_time() noexcept {
   return 0;
+}
+#include <sys/time.h>
+timespec __arch_wall_clock() noexcept {
+  return timespec{0, 0};
 }
 
 /// smp ///


### PR DESCRIPTION
- Nanosecond precision on all interfaces
- Instant boot on qemu, vbox, GCE, Xen etc.
- Looks exactly like Linux and other OSes (directly with gettimeofday and clock_gettime)
- Uses host platform time
- Fallback to old CMOS / mhz calibration when necessary
