### PR TITLE
Removed '../run.sh' from Readmes.

### DIFF
--- a/examples/acorn/README.md
+++ b/examples/acorn/README.md
@@ -10,7 +10,7 @@ mkdir build
 cd build
 cmake ..
 make
-../run.sh acorn
+boot acorn
 ```
 
 ## Features

--- a/examples/scoped_profiler/README.md
+++ b/examples/scoped_profiler/README.md
@@ -21,7 +21,7 @@ mkdir build
 cd build
 cmake ..
 make
-../run.sh scoped_profiler_example
+boot scoped_profiler_example
 ```
 
 Make something happen in the OS and then use wget or curl to `GET /profile` to see statistics:

--- a/examples/snake/README.md
+++ b/examples/snake/README.md
@@ -7,7 +7,7 @@ mkdir build
 cd build
 cmake ..
 make
-../run.sh snake_example
+boot snake_example
 ```
 
 Use arrow keys to change the snakes direction. Press spacebar to restart the game.

--- a/examples/syslog/README.md
+++ b/examples/syslog/README.md
@@ -21,5 +21,5 @@ mkdir build
 cd build
 cmake ..
 make
-../run.sh syslog_plugin_example
+boot syslog_plugin_example
 ```

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -5,5 +5,5 @@ mkdir build
 cd build
 cmake ..
 make
-../run.sh tcp_example
+boot tcp_example
 ```


### PR DESCRIPTION
I think this is ok. I couldn't start the acorn example with ```../run.sh```.