### PR TITLE
Emergency VGA logbuffer driver 

### DIFF
--- a/api/hw/ps2.hpp
+++ b/api/hw/ps2.hpp
@@ -58,8 +58,6 @@ namespace hw
       VK_COUNT
     };
 
-    static void init();
-
     static void set_virtualkey_handler(on_virtualkey_func func) {
       get().on_virtualkey = func;
     }
@@ -69,14 +67,19 @@ namespace hw
       return kbm;
     }
 
+    static void init();
+    static uint8_t get_kbd_irq();
+    static int     get_kbd_vkey();
+    static uint8_t get_mouse_irq();
+
   private:
     KBM();
     int  mouse_x;
     int  mouse_y;
     bool mouse_button[4];
 
-    int transform_ascii(int vk);
-    int transform_vk(uint8_t scancode);
+    static int transform_vk(uint8_t scancode);
+    static int transform_ascii(int vk);
     void handle_mouse(uint8_t scancode);
 
     on_virtualkey_func on_virtualkey;

--- a/cmake/cpu_feat.cmake
+++ b/cmake/cpu_feat.cmake
@@ -1,2 +1,2 @@
-set(CAPABS "-mavx -maes -mfma -mfpmath=sse")
-message(STATUS "Using extended CPU features: AVX, AES, FMA. CAPABS = ${CAPABS}")
+set(CAPABS "-march=native -mfpmath=sse")
+message(STATUS "Using native CPU features. CAPABS = ${CAPABS}")

--- a/examples/snake/service.cpp
+++ b/examples/snake/service.cpp
@@ -25,7 +25,6 @@ void begin_snake()
 {
   static Snake snake {TextmodeVGA::get()};
 
-  hw::KBM::init();
   hw::KBM::set_virtualkey_handler(
   [] (int key)
   {

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -45,6 +45,9 @@ add_dependencies(disklog_reader PrecompiledLibraries)
 add_library(vga_output STATIC vgaout.cpp)
 add_dependencies(vga_output PrecompiledLibraries)
 
+add_library(vga_emergency STATIC vga_emergency.cpp)
+add_dependencies(vga_emergency PrecompiledLibraries)
+
 install(TARGETS
     ide_readwrite ide_readonly ide_writeonly
     virtionet virtioblk
@@ -52,7 +55,7 @@ install(TARGETS
     ip4_reassembly
     heap_debugging
     boot_logger disk_logger disklog_reader
-    vga_output
+    vga_output vga_emergency
     DESTINATION includeos/${ARCH}/drivers)
 
 if(WITH_SOLO5)

--- a/src/drivers/vga_emergency.cpp
+++ b/src/drivers/vga_emergency.cpp
@@ -1,0 +1,97 @@
+#include <vga>
+#include <arch.hpp>
+#include <ringbuffer>
+#include <hw/ps2.hpp>
+
+static const int SUGGEST_READ_SIZE = 800;
+
+static RingBuffer emerg_buffer(1 << 17);
+static bool procedure_entered = false;
+static const char* read_position = nullptr;
+static const char* read_minpos = nullptr;
+static const char* read_maxpos = nullptr;
+static size_t read_size = 0;
+
+static void emergency_logging(const char* data, int length)
+{
+  int free = emerg_buffer.free_space();
+  if (free < length) {
+    emerg_buffer.discard(length - free);
+  }
+  emerg_buffer.write(data, length);
+}
+
+extern "C" void (*current_eoi_mechanism)();
+extern "C" void (*current_intr_handler)();
+extern "C"
+void keyboard_emergency_handler()
+{
+  auto& vga = TextmodeVGA::get();
+  vga.clear();
+
+  using namespace hw;
+  int key = KBM::get_kbd_vkey();
+  switch (key)
+  {
+  case KBM::VK_UP:
+      read_position = std::max(read_minpos, read_position - 100);
+      vga.write("UP!\n", 4);
+      break;
+  case KBM::VK_DOWN:
+      read_position = std::min(read_maxpos, read_position + 100);
+      vga.write("DN!\n", 4);
+      break;
+  }
+  // update
+  vga.write(read_position, read_size);
+
+  current_eoi_mechanism();
+}
+
+extern "C"
+void panic_perform_inspection_procedure()
+{
+  if (procedure_entered) return;
+  procedure_entered = true;
+
+  const char* EMERG_INFO =
+      "\n>>> VGA EMERGENCY MODE ENTERED! <<<\n"
+      "Use arrow keys to navigate logbuffer\n";
+
+  emerg_buffer.write(EMERG_INFO, strlen(EMERG_INFO));
+
+  // disable all IRQs
+  for (uint8_t i = 0; i < 128; i++)
+    __arch_unsubscribe_irq(i);
+
+  // enable interrupts again
+  asm("sti");
+
+  // enable keyboard and mouse
+  hw::KBM::init();
+
+  // make buffer sequential
+  auto* buffer = emerg_buffer.sequentialize();
+
+  // set position and size
+  read_size = std::min(emerg_buffer.size(), SUGGEST_READ_SIZE);
+  read_minpos = buffer;
+  read_maxpos = buffer + emerg_buffer.size() - read_size;
+
+  read_position = read_maxpos;
+
+  // print initial buffer
+  auto& vga = TextmodeVGA::get();
+  vga.clear();
+  vga.write(read_position, read_size);
+
+  const uint8_t kbd_irq = hw::KBM::get_kbd_irq();
+  __arch_subscribe_irq(kbd_irq);
+  current_intr_handler = keyboard_emergency_handler;
+}
+
+static __attribute__((constructor))
+void hest()
+{
+  OS::add_stdout(emergency_logging);
+}

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -203,8 +203,14 @@ void double_fault(const char* why)
   panic_epilogue(why);
 }
 
+extern "C" __attribute__ ((weak))
+void panic_perform_inspection_procedure() {}
+
 void panic_epilogue(const char* why)
 {
+  // action that restores some system functionality intended for inspection
+  panic_perform_inspection_procedure();
+
   // call custom on panic handler (if present)
   if (panic_handler) panic_handler(why);
 
@@ -215,7 +221,7 @@ void panic_epilogue(const char* why)
     SMP::global_unlock();
 
     // .. if we return from the panic handler, go to permanent sleep
-    while (1) asm("cli; hlt");
+    while (1) OS::halt();
   #else
     #warning "panic() handler not implemented for selected arch"
   #endif

--- a/src/platform/x86_nano/platform.cpp
+++ b/src/platform/x86_nano/platform.cpp
@@ -9,9 +9,10 @@ void (*current_intr_handler)() = nullptr;
 
 void __arch_poweroff()
 {
-  asm("cli; hlt;");
+  while (1) asm("cli; hlt;");
   __builtin_unreachable();
 }
+void OS::halt() { asm("hlt"); }
 
 void __platform_init()
 {

--- a/src/platform/x86_pc/apic.cpp
+++ b/src/platform/x86_pc/apic.cpp
@@ -119,13 +119,19 @@ namespace x86
       // NOTE: @bus_source is the IOAPIC number
       if (redir.irq_source == irq)
       {
-        INFO2("Enabled redirected IRQ %u -> %u on lapic %u",
-            redir.irq_source, redir.global_intr, get().get_id());
+        if (OS::is_panicking() == false)
+        {
+          INFO2("Enabled redirected IRQ %u -> %u on lapic %u",
+              redir.irq_source, redir.global_intr, get().get_id());
+        }
         IOAPIC::enable(redir.global_intr, irq, get().get_id());
         return;
       }
     }
-    INFO2("Enabled non-redirected IRQ %u on LAPIC %u", irq, get().get_id());
+    if (OS::is_panicking() == false)
+    {
+      INFO2("Enabled non-redirected IRQ %u on LAPIC %u", irq, get().get_id());
+    }
     IOAPIC::enable(irq, irq, get().get_id());
   }
   void APIC::disable_irq(uint8_t irq)

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -65,6 +65,7 @@ void OS::start(unsigned, unsigned) {}
 void OS::default_stdout(const char*, size_t) {}
 void OS::event_loop() {}
 void OS::block() {}
+void OS::halt() {}
 void OS::resume_softreset(intptr_t) {}
 bool OS::is_softreset_magic(uint32_t) {
   return true;

--- a/test/util/unit/ringbuffer.cpp
+++ b/test/util/unit/ringbuffer.cpp
@@ -18,99 +18,196 @@
 #include <common.cxx>
 #include <util/ringbuffer.hpp>
 
-
 CASE("A new ringbuffer is empty")
 {
   RingBuffer rb(1);
   EXPECT(rb.capacity() == 1);
-  
+
   EXPECT(rb.free_space() == 1);
   EXPECT(rb.used_space() == 0);
-  
+
   EXPECT(rb.full()  == false);
   EXPECT(rb.empty() == true);
 }
 CASE("Adding bytes to ringbuffer")
 {
   RingBuffer rb(2);
-  
+
   int written = rb.write("1", 1);
   EXPECT(written == 1);
-  
+
   EXPECT(rb.free_space() == 1);
   EXPECT(rb.used_space() == 1);
-  
+
   EXPECT(rb.full()  == false);
   EXPECT(rb.empty() == false);
-  
+
   written = rb.write("2", 1);
   EXPECT(written == 1);
-  
+
   EXPECT(rb.free_space() == 0);
   EXPECT(rb.used_space() == 2);
-  
+
   EXPECT(rb.full()  == true);
   EXPECT(rb.empty() == false);
-  
+
   EXPECT(rb.size() == rb.used_space());
 }
 CASE("Reading bytes to ringbuffer")
 {
   RingBuffer rb(2);
   int written;
-  
+
   written = rb.write("1", 1);
   EXPECT(written == 1);
   written = rb.write("2", 1);
   EXPECT(written == 1);
-  
+
   char buffer[1];
   int read;
-  
+
   read = rb.read(buffer, sizeof(buffer));
   EXPECT(read == 1);
   EXPECT(buffer[0] == '1');
-  
+
   EXPECT(rb.used_space() == 1);
   EXPECT(rb.free_space() == 1);
-  
+
   read = rb.read(buffer, sizeof(buffer));
   EXPECT(read == 1);
   EXPECT(buffer[0] == '2');
-  
+
   EXPECT(rb.used_space() == 0);
   EXPECT(rb.free_space() == 2);
-  
+
   EXPECT(rb.full()  == false);
   EXPECT(rb.empty() == true);
-  
+
   EXPECT(rb.size() == rb.used_space());
+}
+CASE("Read Pt.2")
+{
+  const char* buffer = "ABCDEFGH";
+  const int len = strlen(buffer);
+
+  RingBuffer rb(len);
+  // advance one position internally
+  rb.write("A", 1);
+  rb.discard(1);
+  EXPECT(rb.empty());
+  // write known buffer
+  rb.write(buffer, len);
+  // read it back
+  char readback[10];
+  EXPECT(rb.read(readback, sizeof(readback)) == len);
+  EXPECT(memcmp(readback, buffer, len) == 0);
 }
 CASE("We can discard data")
 {
   RingBuffer rb(10);
   int written;
-  
+
   written = rb.write("12345", 5);
   EXPECT(written == 5);
   written = rb.write("67890", 5);
   EXPECT(written == 5);
-  
+
   // discard half the data
   rb.discard(5);
-  
+
   EXPECT(rb.used_space() == 5);
   EXPECT(rb.free_space() == 5);
-  
+
   EXPECT(rb.full()  == false);
   EXPECT(rb.empty() == false);
-  
+
   // discard the rest
   rb.discard(5);
-  
+
   EXPECT(rb.used_space() == 0);
   EXPECT(rb.free_space() == rb.capacity());
-  
+
   EXPECT(rb.full()  == false);
   EXPECT(rb.empty() == true);
+}
+CASE("Discard pt.2")
+{
+  RingBuffer rb(10);
+  int written;
+  written = rb.write("1234567890", 10);
+  EXPECT(written == 10);
+
+  // discard 1, read 1, compare
+  char data[1];
+
+  rb.discard(1);
+  rb.read(data, sizeof(data));
+  EXPECT(data[0] == '2');
+  rb.write("12", 2);
+
+  rb.discard(1);
+  rb.read(data, sizeof(data));
+  EXPECT(data[0] == '4');
+  rb.write("34", 2);
+
+  rb.discard(1);
+  rb.read(data, sizeof(data));
+  EXPECT(data[0] == '6');
+  rb.write("56", 2);
+
+  rb.discard(1);
+  rb.read(data, sizeof(data));
+  EXPECT(data[0] == '8');
+  rb.write("78", 2);
+
+  rb.discard(1);
+  rb.read(data, sizeof(data));
+  EXPECT(data[0] == '0');
+  rb.write("90", 2);
+
+  EXPECT(rb.size() == 10);
+  char all_data[10];
+  rb.read(all_data, sizeof(all_data));
+  EXPECT(memcmp(all_data, "1234567890", 10) == 0);
+}
+
+CASE("Test sequentialize Pt.1")
+{
+  {
+    RingBuffer rb(1);
+    rb.write("A", 1);
+    EXPECT(strncmp(rb.sequentialize(), "A", 1) == 0);
+  }
+  {
+    RingBuffer rb(2);
+    rb.write("AB", 2);
+    EXPECT(strncmp(rb.sequentialize(), "AB", 2) == 0);
+  }
+  {
+    RingBuffer rb(2);
+    rb.write("A", 1);
+    rb.discard(1);
+    rb.write("AB", 2);
+    EXPECT(strncmp(rb.sequentialize(), "AB", 2) == 0);
+  }
+}
+CASE("Test sequentialize Pt.2")
+{
+  const char* buffer = "ABCDEFGH";
+  const int len = strlen(buffer);
+  RingBuffer rb(len);
+
+  for (int i = 0; i < len; i++)
+  {
+    // advance one position internally
+    rb.write("A", 1);
+    rb.discard(1);
+    EXPECT(rb.empty());
+    // write known buffer
+    rb.write(buffer, len);
+    // verify its sequential
+    const char* result = rb.sequentialize();
+    EXPECT(memcmp(result, buffer, len) == 0);
+    rb.discard(len);
+  }
 }


### PR DESCRIPTION
![screenshot from 2018-01-17 22-20-28](https://user-images.githubusercontent.com/3758947/35067583-acf0e572-fbd4-11e7-99e0-04748bcc3ba7.png)
New driver: vga_emergency
- Does not need the vga output driver to work and uses no heap
- Logs to 128k ringbuffer
- Re-activates interrupts on panic and enables keyboard handler
- Prints partial VGA buffer based on position in buffer
- Navigate up and down the OS log while in panic!
