### PR TITLE
Cherry-pick master: Uplink: Sending uplink with reboot option

### DIFF
--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -459,6 +459,9 @@ namespace uplink {
     writer.Key("token");
     writer.String(config_.token);
 
+    writer.Key("reboot");
+    writer.Bool(config_.reboot);
+
     writer.EndObject();
 
     std::string str = buf.GetString();


### PR DESCRIPTION
Simple addition that makes reboot option reports correctly in mothership. 