### PR TITLE
HTTP client_connection.cpp: Replacing Ensures(on_response_) with if statement

### DIFF
--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -129,7 +129,8 @@ namespace uplink {
     client_->post(http::URI{url},
       { {"Content-Type", "application/json"} },
       auth_data(),
-      {this, &WS_uplink::handle_auth_response});
+      {this, &WS_uplink::handle_auth_response},
+      http::Client::Options{15s});
   }
 
   void WS_uplink::handle_auth_response(http::Error err, http::Response_ptr res, http::Connection&)


### PR DESCRIPTION
To avoid panic if the request has timed out and the response is received after this