### PR TITLE
etc: ensure (already installed) clang is at least 5.0

### DIFF
--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -7,7 +7,9 @@
 ############################################################
 
 BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip g++-multilib gcc"
-[ ! -z "$CC" ] && { CLANG_VERSION=${CC: -3}; } || CLANG_VERSION="5.0"
+CLANG_VERSION_MIN_REQUIRED="5.0"
+[ ! -z "$CC" ] && { CLANG_VERSION=${CC: -3}; } || CLANG_VERSION=$CLANG_VERSION_MIN_REQUIRED
+[[ $CLANG_VERSION < $CLANG_VERSION_MIN_REQUIRED ]] && CLANG_VERSION=$CLANG_VERSION_MIN_REQUIRED
 TEST_DEPENDENCIES="g++"
 PYTHON_DEPENDENCIES="jsonschema psutil junit-xml filemagic"
 INSTALLED_PIP=0


### PR DESCRIPTION
With "export CC=/usr/bin/clang-3.8" and actually installed clang-3.8,
we failed to request at least 5.0 version.

The "export CC=" line was added as install.sh suggested, so I
guess it is quite common case.

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>