### PR TITLE
"system_log" logging interface + plugin implementation

### DIFF
--- a/api/fs/memdisk.hpp
+++ b/api/fs/memdisk.hpp
@@ -28,6 +28,11 @@ namespace fs {
   public:
     static constexpr size_t SECTOR_SIZE = 512;
 
+    static MemDisk& get() noexcept {
+      static MemDisk memdisk;
+      return memdisk;
+    }
+
     std::string device_name() const override {
       return "memdisk" + std::to_string(id());
     }

--- a/api/memdisk
+++ b/api/memdisk
@@ -28,20 +28,18 @@ namespace fs
   // new singleton interface for the memdisk
   inline Disk& memdisk()
   {
-    static MemDisk device;
-    static Disk    disk {device};
+    static Disk    disk {MemDisk::get()};
     return disk;
   }
   // new_shared_memdisk() very likely contains FAT
   inline Disk_ptr shared_memdisk()
   {
-    static MemDisk device;
     static std::weak_ptr<Disk> disk;
 
     if(auto ptr = disk.lock())
       return ptr;
 
-    auto ptr = std::make_shared<Disk>(device);
+    auto ptr = std::make_shared<Disk>(MemDisk::get());
     disk = ptr;
     return ptr;
   }

--- a/api/net/ws/websocket.hpp
+++ b/api/net/ws/websocket.hpp
@@ -258,6 +258,11 @@ public:
     return stream->get_cpuid();
   }
 
+  // 0 == unlimited
+  void set_max_message_size(uint32_t sz) noexcept {
+    max_msg_size = sz;
+  }
+
   WebSocket(net::Stream_ptr, bool);
   WebSocket(WebSocket&&);
   ~WebSocket();
@@ -266,6 +271,7 @@ private:
   net::Stream_ptr stream;
   Timer ping_timer{{this, &WebSocket::pong_timeout}};
   Message_ptr message;
+  uint32_t max_msg_size;
   bool clientside;
 
   WebSocket(const WebSocket&) = delete;

--- a/api/system_log
+++ b/api/system_log
@@ -11,6 +11,6 @@ public:
   // retrieve a copy of the memory-stored system log
   static std::vector<char> copy();
 
-  // invoke OS::print on the system log
-  static void print_all();
+  // platform will initialize (create new or restore)
+  static void initialize();
 };

--- a/api/system_log
+++ b/api/system_log
@@ -5,11 +5,21 @@
 class SystemLog
 {
 public:
+  enum Flags {
+    PANIC   = 0x1,
+    REBOOT  = 0x2
+  };
+
   // append @bytes to the system log
   static void write(const char*, size_t);
 
   // retrieve a copy of the memory-stored system log
   static std::vector<char> copy();
+
+  // set and get global bits
+  static uint32_t get_flags();
+  static void     set_flags(uint32_t flags);
+  static void     clear_flags();
 
   // platform will initialize (create new or restore)
   static void initialize();

--- a/api/system_log
+++ b/api/system_log
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <vector>
+
+class SystemLog
+{
+public:
+  // append @bytes to the system log
+  static void write(const char*, size_t);
+
+  // retrieve a copy of the memory-stored system log
+  static std::vector<char> copy();
+
+  // invoke OS::print on the system log
+  static void print_all();
+};

--- a/api/system_log
+++ b/api/system_log
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <kernel/os.hpp>
 #include <vector>
 
 class SystemLog
@@ -16,6 +17,9 @@ public:
   // retrieve a copy of the memory-stored system log
   static std::vector<char> copy();
 
+  // send whole system log to stdout @function
+  static void print_to(OS::print_func function);
+
   // set and get global bits
   static uint32_t get_flags();
   static void     set_flags(uint32_t flags);
@@ -24,3 +28,10 @@ public:
   // platform will initialize (create new or restore)
   static void initialize();
 };
+
+
+inline void SystemLog::print_to(OS::print_func funcptr)
+{
+  auto copy = SystemLog::copy();
+  if (not copy.empty()) funcptr(copy.data(), copy.size());
+}

--- a/cmake/nacl.cmake
+++ b/cmake/nacl.cmake
@@ -18,7 +18,7 @@ ExternalProject_Add(nacl_bin
 set(NACL_DIR ${INCLUDEOS_ROOT}/NaCl)
 set(NACL_EXE ${NACL_DIR}/NaCl.py)
 set(NACL_SRC
-  ${NACL_DIR}/cpp_template.py
+  ${NACL_DIR}/cpp_transpile_function.py
   ${NACL_DIR}/cpp_template.mustache
   ${NACL_DIR}/cpp_resolve_values.py
   ${NACL_DIR}/shared_constants.py

--- a/cmake/post.service.cmake
+++ b/cmake/post.service.cmake
@@ -95,6 +95,11 @@ endif()
 # DRIVERS / PLUGINS - support for parent cmake list specification
 #
 
+# Add default stdout driver if option is ON
+if (default_stdout)
+  set(DRIVERS ${DRIVERS} default_stdout)
+endif()
+
 # Add extra drivers defined from command line
 set(DRIVERS ${DRIVERS} ${EXTRA_DRIVERS})
 if(DRIVERS)

--- a/cmake/pre.service.cmake
+++ b/cmake/pre.service.cmake
@@ -16,6 +16,8 @@ if (NOT DEFINED PLATFORM)
 endif()
 
 # configure options
+option(default_stdout "Use the OS default stdout (serial)" ON)
+
 option(debug "Build with debugging symbols (OBS: increases binary size)" OFF)
 option(minimal "Build for minimal size" OFF)
 option(stripped "Strip symbols to further reduce size" OFF)

--- a/etc/boot
+++ b/etc/boot
@@ -64,6 +64,9 @@ parser.add_argument("-j", "--config", dest="config", type = str, metavar = "PATH
 parser.add_argument('vm_location', action="store", type = str, default=".",
                     help="Location of the IncludeOS service binary, image or source")
 
+parser.add_argument("--with-solo5", dest="solo5", action="store_true",
+                    help="Run includeOS on solo5 kernel with ukvm-bin as monitor")
+
 parser.add_argument('vmargs', nargs='*', help="Arguments to pass on to the VM start / main")
 
 args = parser.parse_args()
@@ -150,7 +153,17 @@ if args.config:
     config = os.path.abspath(args.config)
     if VERB: print INFO, "Using config file", config
 
-vm = vmrunner.vm(config = config)
+hyper_name = "qemu"
+if args.solo5:
+    hyper_name = "ukvm"
+    os.environ['PLATFORM'] = "x86_solo5"
+    qkvm_bin = INCLUDEOS_PREFIX + "/includeos/x86_64/lib/ukvm-bin"
+
+    subprocess.call(['touch', INCLUDEOS_PREFIX + 'dummy.disk'])
+    subprocess.call(['chmod', '+x', qkvm_bin])
+    subprocess.call(['sudo', INCLUDEOS_PREFIX + "/includeos/scripts/ukvm-ifup.sh" ])
+
+vm = vmrunner.vm(config = config, hyper_name = hyper_name)
 
 # Don't listen to events needed by testrunner
 vm.on_success(lambda(x): None, do_exit = False)

--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -7,7 +7,9 @@
 ############################################################
 
 BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip g++-multilib gcc"
-[ ! -z "$CC" ] && { CLANG_VERSION=${CC: -3}; } || CLANG_VERSION="5.0"
+CLANG_VERSION_MIN_REQUIRED="5.0"
+[ ! -z "$CC" ] && { CLANG_VERSION=${CC: -3}; } || CLANG_VERSION=$CLANG_VERSION_MIN_REQUIRED
+[[ $CLANG_VERSION < $CLANG_VERSION_MIN_REQUIRED ]] && CLANG_VERSION=$CLANG_VERSION_MIN_REQUIRED
 TEST_DEPENDENCIES="g++"
 PYTHON_DEPENDENCIES="jsonschema psutil junit-xml filemagic"
 INSTALLED_PIP=0

--- a/examples/TCP_perf/CMakeLists.txt
+++ b/examples/TCP_perf/CMakeLists.txt
@@ -26,6 +26,7 @@ else()
   set(DRIVERS
     virtionet
     vmxnet3
+    e1000
   )
 endif()
 

--- a/examples/TCP_perf/receive.sh
+++ b/examples/TCP_perf/receive.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-ncat 10.0.0.42 1337 --recv-only > bla.txt
+for i in `seq 1 4`;
+do
+    ncat 10.0.0.42 1337 --recv-only > bla.txt
+done

--- a/examples/TCP_perf/service.cpp
+++ b/examples/TCP_perf/service.cpp
@@ -20,6 +20,7 @@
 #include <statman>
 #include <profile>
 #include <cstdio>
+#define ENABLE_JUMBO_FRAMES
 
 using namespace net::tcp;
 
@@ -156,3 +157,14 @@ void Service::ready()
     });
   });
 }
+
+#ifdef ENABLE_JUMBO_FRAMES
+#include <hw/nic.hpp>
+namespace hw {
+  uint16_t Nic::MTU_detection_override(int idx, const uint16_t default_MTU)
+  {
+    if (idx == 0) return 9000;
+    return default_MTU;
+  }
+}
+#endif

--- a/examples/TCP_perf/vm.json
+++ b/examples/TCP_perf/vm.json
@@ -1,4 +1,4 @@
 {
-  "net" : [{"device" : "virtio"}],
+  "net" : [{"device" : "vmxnet3"}],
   "mem"   : 1280
 }

--- a/examples/demo_service/CMakeLists.txt
+++ b/examples/demo_service/CMakeLists.txt
@@ -30,15 +30,14 @@ if ("$ENV{PLATFORM}" STREQUAL "x86_solo5")
 else()
   set(DRIVERS
       virtionet     # Virtio networking
-      # virtioblk   # Virtio block device
+      vmxnet3
+      boot_logger   # Display boot information
 
       # Use "boot --drivers ." to see other drivers
     )
 endif()
 
 set(PLUGINS
-    autoconf  # configuration from config.json
-
     # Use "boot --plugins ." to see other plugins
   )
 

--- a/lib/uplink/config.cpp
+++ b/lib/uplink/config.cpp
@@ -96,6 +96,11 @@ namespace uplink {
       config_.serialize_ct = cfg["serialize_ct"].GetBool();
     }
 
+    if(cfg.HasMember("tag"))
+    {
+      config_.tag = cfg["tag"].GetString();
+    }
+
     return config_;
   }
 

--- a/lib/uplink/config.hpp
+++ b/lib/uplink/config.hpp
@@ -30,6 +30,7 @@ namespace uplink {
     net::Inet<net::IP4>* inet;
     std::string url;
     std::string token;
+    std::string tag;
     bool        reboot        = true;
     bool        ws_logging    = true;
     bool        serialize_ct  = false;

--- a/lib/uplink/register_plugin.cpp
+++ b/lib/uplink/register_plugin.cpp
@@ -23,13 +23,6 @@ namespace uplink {
 
 static std::unique_ptr<WS_uplink> uplink{nullptr};
 
-
-  void on_panic(const char* why){
-    if (uplink)
-      uplink->panic(why);
-  }
-
-
 void setup_uplink()
 {
   MYINFO("Setting up WS uplink");
@@ -38,8 +31,6 @@ void setup_uplink()
     auto config = Config::read();
 
     uplink = std::make_unique<WS_uplink>(std::move(config));
-
-    OS::on_panic(uplink::on_panic);
 
   }catch(const std::exception& e) {
     MYINFO("Uplink initialization failed: %s ", e.what());

--- a/lib/uplink/uplink_log.cpp
+++ b/lib/uplink/uplink_log.cpp
@@ -20,7 +20,7 @@
 
 // Initialize the log at OS start (global constructor)
 // and hook it up to OS stdout.
-struct Autoreg_log {
+static struct Autoreg_log {
   Autoreg_log() {
     auto& log = uplink::Log::get();
     OS::add_stdout({log, &uplink::Log::log});

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -62,6 +62,8 @@ namespace uplink {
     liu::LiveUpdate::register_partition("uplink", {this, &WS_uplink::store});
 
     CHECK(config_.reboot, "Reboot on panic");
+    if(config_.reboot)
+      OS::set_panic_action(OS::Panic_action::reboot);
 
     CHECK(config_.serialize_ct, "Serialize Conntrack");
     if(config_.serialize_ct)

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -37,6 +37,7 @@
 #include <statman>
 #include <config>
 #include "log.hpp"
+#include <system_log>
 
 namespace uplink {
   constexpr std::chrono::seconds WS_uplink::heartbeat_interval;
@@ -212,6 +213,14 @@ namespace uplink {
     heart_retries_left = heartbeat_retries;
     last_ping = RTC::now();
     heartbeat_timer.start(std::chrono::seconds(10));
+
+    if(SystemLog::get_flags() & SystemLog::PANIC)
+    {
+      MYINFO("Found panic in system log");
+      auto log = SystemLog::copy();
+      SystemLog::clear_flags();
+      send_message(Transport_code::PANIC, log.data(), log.size());
+    }
   }
 
   void WS_uplink::handle_ws_close(uint16_t code)
@@ -525,16 +534,6 @@ namespace uplink {
       logbuf_.clear();
       logbuf_.shrink_to_fit();
     }
-  }
-
-  void WS_uplink::panic(const char* why){
-    MYINFO("WS_uplink sending panic\n");
-    Log::get().flush();
-    send_message(Transport_code::PANIC, why, strlen(why));
-    ws_->close();
-    inet_.nic().flush();
-
-    if(config_.reboot) OS::reboot();
   }
 
   void WS_uplink::send_stats()

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -409,6 +409,12 @@ namespace uplink {
       writer.String(binary_hash_);
     }
 
+    if(not tag_.empty())
+    {
+      writer.Key("tag");
+      writer.String(tag_);
+    }
+
     if(update_time_taken > 0)
     {
       writer.Key("update_time_taken");

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -307,7 +307,7 @@ namespace uplink {
     }
   }
 
-  void WS_uplink::update(const std::vector<char>& buffer)
+  void WS_uplink::update(std::vector<char> buffer)
   {
     static SHA1 checksum;
     checksum.update(buffer);
@@ -317,21 +317,26 @@ namespace uplink {
     auto trans = Transport{Header{Transport_code::UPDATE, static_cast<uint32_t>(update_hash_.size())}};
     trans.load_cargo(update_hash_.data(), update_hash_.size());
     ws_->write(trans.data().data(), trans.data().size());
+
+    // make sure to flush the driver rings so there is room for the next packets
+    inet_.nic().flush();
+    // can't wait for defered log flush due to liveupdating
+    uplink::Log::get().flush();
+    // close the websocket (and tcp) gracefully
     ws_->close();
+    // make sure both the log and the close is flushed before updating
+    inet_.nic().flush();
 
     // do the update
-    Timers::oneshot(std::chrono::milliseconds(10),
-    [this, copy = buffer] (int) {
-      try {
-        liu::LiveUpdate::exec(copy);
-      }
-      catch (std::exception& e) {
-        INFO2("LiveUpdate::exec() failed: %s\n", e.what());
-        liu::LiveUpdate::restore_environment();
-        // establish new connection
-        this->auth();
-      }
-    });
+    try {
+      liu::LiveUpdate::exec(std::move(buffer));
+    }
+    catch (std::exception& e) {
+      INFO2("LiveUpdate::exec() failed: %s\n", e.what());
+      liu::LiveUpdate::restore_environment();
+      // establish new connection
+      this->auth();
+    }
   }
 
   template <typename Writer, typename Stack_ptr>
@@ -474,7 +479,11 @@ namespace uplink {
     ws_->write(transport.data().data(), transport.data().size());
   }
 
-  void WS_uplink::send_message(Transport_code code, const char* data, size_t len) {
+  void WS_uplink::send_message(Transport_code code, const char* data, size_t len)
+  {
+    if(UNLIKELY(not is_online()))
+      return;
+
     auto transport = Transport{Header{code, static_cast<uint32_t>(len)}};
 
     transport.load_cargo(data, len);

--- a/lib/uplink/ws_uplink.hpp
+++ b/lib/uplink/ws_uplink.hpp
@@ -74,6 +74,7 @@ private:
   net::WebSocket_ptr            ws_;
   std::string                   id_;
   std::string                   token_;
+  std::string                   tag_;
   /** Hash for the current running binary
    * (restored during update, none if never updated) */
   std::string                   binary_hash_;

--- a/lib/uplink/ws_uplink.hpp
+++ b/lib/uplink/ws_uplink.hpp
@@ -66,8 +66,6 @@ public:
   bool is_online() const
   { return ws_ != nullptr and ws_->is_alive(); }
 
-  void panic(const char* why);
-
 private:
   Config config_;
 

--- a/lib/uplink/ws_uplink.hpp
+++ b/lib/uplink/ws_uplink.hpp
@@ -55,7 +55,7 @@ public:
 
   void send_uplink();
 
-  void update(const std::vector<char>& buffer);
+  void update(std::vector<char> buffer);
 
   void send_error(const std::string& err);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ set(OS_OBJECTS
   kernel/vga.cpp kernel/context.cpp kernel/context_asm.asm
   kernel/fiber.cpp kernel/tls.cpp kernel/profile.cpp kernel/scoped_profiler.cpp
   kernel/terminal.cpp kernel/timers.cpp kernel/rtc.cpp kernel/rng.cpp
-  kernel/rdrand.cpp kernel/solo5_manager.cpp
+  kernel/system_log.cpp kernel/rdrand.cpp kernel/solo5_manager.cpp
   util/memstream.c util/async.cpp util/statman.cpp util/logger.cpp util/sha1.cpp
   util/syslog_facility.cpp util/syslogd.cpp util/uri.cpp util/percent_encoding.cpp
   util/tar.cpp util/path_to_regex.cpp util/config.cpp util/autoconf.cpp

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -5,6 +5,9 @@
 #
 # ...There are probably nicer solutions, so please PR if you know them.
 
+# make LiveUpdate visible to drivers
+include_directories(${INCLUDEOS_ROOT}/lib/LiveUpdate)
+
 add_library(disable_paging STATIC disable_paging.cpp)
 add_dependencies(disable_paging PrecompiledLibraries)
 

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -8,6 +8,10 @@
 # make LiveUpdate visible to drivers
 include_directories(${INCLUDEOS_ROOT}/lib/LiveUpdate)
 
+# Simple stuff
+add_library(boot_logger STATIC bootlog.cpp)
+add_library(default_stdout STATIC "default_stdout.cpp")
+
 add_library(disable_paging STATIC disable_paging.cpp)
 add_dependencies(disable_paging PrecompiledLibraries)
 
@@ -39,9 +43,6 @@ add_dependencies(ip4_reassembly PrecompiledLibraries)
 add_library(heap_debugging STATIC heap_debugging.cpp)
 add_dependencies(heap_debugging PrecompiledLibraries)
 
-add_library(boot_logger STATIC bootlog.cpp)
-add_dependencies(boot_logger PrecompiledLibraries)
-
 add_library(disk_logger STATIC "disk_logger.cpp")
 add_dependencies(disk_logger PrecompiledLibraries)
 
@@ -60,6 +61,7 @@ add_dependencies(vga_emergency PrecompiledLibraries)
 set(CMAKE_INSTALL_MESSAGE LAZY) # to avoid spam
 
 install(TARGETS
+    default_stdout
     disable_paging
     ide_readwrite ide_readonly ide_writeonly
     virtionet virtioblk

--- a/src/drivers/default_stdout.cpp
+++ b/src/drivers/default_stdout.cpp
@@ -1,0 +1,19 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// add OS default stdout handler
+bool os_default_stdout = true;

--- a/src/drivers/e1000.hpp
+++ b/src/drivers/e1000.hpp
@@ -27,8 +27,9 @@ public:
   using Link          = net::Link_layer<net::Ethernet>;
   using Link_protocol = Link::Protocol;
   static const int DRIVER_OFFSET = 2;
-  static const int NUM_TX_DESC   = 256;
-  static const int NUM_RX_DESC   = 256;
+  static const int NUM_TX_DESC   = 64;
+  static const int NUM_TX_QUEUE  = 64;
+  static const int NUM_RX_DESC   = 64;
 
   static std::unique_ptr<Nic> new_instance(hw::PCI_Device& d, const uint16_t MTU)
   { return std::make_unique<e1000>(d, MTU); }
@@ -65,7 +66,8 @@ public:
 
   /** Space available in the transmit queue, in packets */
   size_t transmit_queue_available() override {
-    return 1;
+    if (sendq_size >= NUM_TX_QUEUE) return 0;
+    return free_transmit_descr() + NUM_TX_QUEUE - sendq_size;
   }
 
   void flush() override;
@@ -154,5 +156,6 @@ private:
 
   // sendq as packet chain
   net::Packet_ptr  sendq = nullptr;
+  size_t           sendq_size = 0;
   net::BufferStore bufstore_;
 };

--- a/src/drivers/vga_emergency.cpp
+++ b/src/drivers/vga_emergency.cpp
@@ -3,7 +3,7 @@
 #include <ringbuffer>
 #include <hw/ps2.hpp>
 
-static RingBuffer emerg_buffer(1 << 17);
+static FixedRingBuffer<1 << 17> emerg_buffer;
 static bool procedure_entered = false;
 static const char* read_position = nullptr;
 static const char* read_minpos = nullptr;

--- a/src/fs/fat.cpp
+++ b/src/fs/fat.cpp
@@ -196,7 +196,6 @@ namespace fs
     for (int i = 0; i < 16; i++) {
 
       if (UNLIKELY(root[i].shortname[0] == 0x0)) {
-        //printf("end of dir\n");
         found_last = true;
         // end of directory
         break;
@@ -217,6 +216,9 @@ namespace fs
             int  final_count = 0;
 
             int  total = L->long_index();
+            // ignore names we can't complete inside of one sector
+            if (i + total >= 16) return false;
+
             // go to the last entry and work backwards
             i += total-1;
             L += total-1;

--- a/src/include/tcp_fd.hpp
+++ b/src/include/tcp_fd.hpp
@@ -73,8 +73,7 @@ private:
 struct TCP_FD_Conn
 {
   TCP_FD_Conn(net::tcp::Connection_ptr c)
-    : conn(c), readq(16384)
-  {}
+    : conn(c) {}
 
   void recv_to_ringbuffer(net::tcp::buffer_t);
   void set_default_read();
@@ -87,7 +86,7 @@ struct TCP_FD_Conn
   std::string to_string() const { return conn->to_string(); }
 
   net::tcp::Connection_ptr conn;
-  RingBuffer readq;
+  FixedRingBuffer<16384> readq;
 };
 
 struct TCP_FD_Listen

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -28,6 +28,7 @@
 #include <cstdio>
 #include <cinttypes>
 #include <util/fixed_vector.hpp>
+#include <system_log>
 
 //#define ENABLE_PROFILERS
 #ifdef ENABLE_PROFILERS
@@ -114,6 +115,9 @@ void OS::post_start()
     auto size = OS::heap_max() / 4;
     OS::liveupdate_loc_ = (OS::heap_max() - size) & 0xFFFFFFF0;
   }
+  // Initialize the system log if plugin is present.
+  // Dependent on the liveupdate location being set
+  SystemLog::initialize();
 
   MYINFO("Initializing RNG");
   PROFILE("RNG init");

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -151,6 +151,8 @@ void OS::add_stdout(OS::print_func func)
 }
 __attribute__((weak))
 bool os_enable_boot_logging = false;
+__attribute__((weak))
+bool os_default_stdout = false;
 void OS::print(const char* str, const size_t len)
 {
   for (auto& callback : os_print_handlers) {

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -23,6 +23,7 @@
 #include <sys/errno.h>
 #include <sys/stat.h>
 #include <kernel/os.hpp>
+#include <system_log>
 
 #include <statman>
 #include <kprint>
@@ -166,6 +167,9 @@ asm("panic_begin:");
   const int current_cpu = SMP::cpu_id();
 
   SMP::global_lock();
+
+  // Tell the System log that we have paniced
+  SystemLog::set_flags(SystemLog::PANIC);
 
   /// display informacion ...
   fprintf(stderr, "\n%s\nCPU: %d, Reason: %s\n",

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <kernel/os.hpp>
 
+#include <system_log>
 #include <statman>
 #include <kprint>
 #include <info>
@@ -165,8 +166,11 @@ asm("panic_begin:");
   cpu_enable_panicking();
   const int current_cpu = SMP::cpu_id();
 
-  /// display informacion ...
   SMP::global_lock();
+  // dump entire log (?)
+  SystemLog::print_all();
+
+  /// display informacion ...
   fprintf(stderr, "\n%s\nCPU: %d, Reason: %s\n",
           panic_signature, current_cpu, why);
 

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -24,7 +24,6 @@
 #include <sys/stat.h>
 #include <kernel/os.hpp>
 
-#include <system_log>
 #include <statman>
 #include <kprint>
 #include <info>
@@ -167,8 +166,6 @@ asm("panic_begin:");
   const int current_cpu = SMP::cpu_id();
 
   SMP::global_lock();
-  // dump entire log (?)
-  SystemLog::print_all();
 
   /// display informacion ...
   fprintf(stderr, "\n%s\nCPU: %d, Reason: %s\n",

--- a/src/kernel/system_log.cpp
+++ b/src/kernel/system_log.cpp
@@ -1,0 +1,18 @@
+#include <system_log>
+#include <kernel/os.hpp>
+
+__attribute__((weak))
+void SystemLog::write(const char* buffer, size_t length) {
+  OS::print(buffer, length);
+}
+
+__attribute__((weak))
+std::vector<char> SystemLog::copy() {
+  return {/* override me */};
+}
+
+__attribute__((weak))
+void SystemLog::print_all()
+{
+  /* override me */
+}

--- a/src/kernel/system_log.cpp
+++ b/src/kernel/system_log.cpp
@@ -10,6 +10,12 @@ __attribute__((weak))
 std::vector<char> SystemLog::copy() {
   return {/* override me */};
 }
+__attribute__((weak))
+uint32_t SystemLog::get_flags() { return 0; }
+__attribute__((weak))
+void     SystemLog::set_flags(uint32_t) {}
+__attribute__((weak))
+void     SystemLog::clear_flags() {}
 
 __attribute__((weak))
 void SystemLog::initialize()

--- a/src/kernel/system_log.cpp
+++ b/src/kernel/system_log.cpp
@@ -12,7 +12,7 @@ std::vector<char> SystemLog::copy() {
 }
 
 __attribute__((weak))
-void SystemLog::print_all()
+void SystemLog::initialize()
 {
   /* override me */
 }

--- a/src/net/ip4/udp.cpp
+++ b/src/net/ip4/udp.cpp
@@ -205,6 +205,11 @@ namespace net {
     {
       WriteBuffer& buffer = sendq.front();
 
+      // If nothing is remaining, it probably means we're currently
+      // processing this buffer
+      if (UNLIKELY(buffer.remaining() == 0))
+        return;
+
       // create and transmit packet from writebuffer
       buffer.write();
       num--;
@@ -265,6 +270,9 @@ namespace net {
           remaining(),
           remaining() / udp.max_datagram_size() + (remaining() % udp.max_datagram_size() ? 1 : 0));
 
+    // Only call write() (above) when there's something remaining
+    Expects(remaining());
+
     while (remaining()) {
       // the max bytes we can write in one operation
       size_t total = remaining();
@@ -275,6 +283,7 @@ namespace net {
       if (!p) break;
 
       auto p2 = static_unique_ptr_cast<PacketUDP>(std::move(p));
+
       // Initialize UDP packet
       p2->init(l_port, d_port);
       p2->set_ip_src(l_addr);
@@ -294,9 +303,12 @@ namespace net {
       this->offset += total;
     }
 
-    Expects(chain_head->ip_protocol() == Protocol::UDP);
-    // ship the packet
-    udp.transmit(std::move(chain_head));
+    // Only transmit if a chain actually was produced
+    if (chain_head) {
+      Expects(chain_head->ip_protocol() == Protocol::UDP);
+      // ship the packet
+      udp.transmit(std::move(chain_head));
+    }
   }
 
 } //< namespace net

--- a/src/platform/x86_pc/acpi.cpp
+++ b/src/platform/x86_pc/acpi.cpp
@@ -175,6 +175,13 @@ namespace x86 {
       // create SDT pointer from 32-bit address
       // NOTE: don't touch!
       auto* sdt = (SDTHeader*) (uintptr_t) (*(uint32_t*) addr);
+
+      addr += 4; total--;
+
+      // some entries seems to be null depending on hypervisor
+      if(sdt == nullptr)
+        continue;
+
       // find out which SDT it is
       switch (sdt->sigint()) {
       case APIC_t:
@@ -192,8 +199,6 @@ namespace x86 {
       default:
         debug("Signature: %.*s (u=%u)\n", 4, sdt->Signature, sdt->sigint());
       }
-
-      addr += 4; total--;
     }
     debug("Finished walking SDTs\n");
   }

--- a/src/platform/x86_pc/os.cpp
+++ b/src/platform/x86_pc/os.cpp
@@ -46,6 +46,8 @@ extern uintptr_t _ELF_START_;
 extern uintptr_t _TEXT_START_;
 extern uintptr_t _LOAD_START_;
 extern uintptr_t _ELF_END_;
+// in kernel/os.cpp
+extern bool os_default_stdout;
 
 struct alignas(SMP_ALIGN) OS_CPU {
   uint64_t cycles_hlt = 0;
@@ -83,8 +85,11 @@ void OS::default_stdout(const char* str, const size_t len)
 void OS::start(uint32_t boot_magic, uint32_t boot_addr)
 {
   OS::cmdline = Service::binary_name();
+
   // Initialize stdout handlers
-  OS::add_stdout(&OS::default_stdout);
+  if(os_default_stdout) {
+    OS::add_stdout(&OS::default_stdout);
+  }
 
   PROFILE("OS::start");
   // Print a fancy header

--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -24,6 +24,8 @@ extern uintptr_t _ELF_START_;
 extern uintptr_t _TEXT_START_;
 extern uintptr_t _LOAD_START_;
 extern uintptr_t _ELF_END_;
+// in kernel/os.cpp
+extern bool os_default_stdout;
 
 #define MYINFO(X,...) INFO("Kernel", X, ##__VA_ARGS__)
 
@@ -70,7 +72,9 @@ void OS::default_stdout(const char* str, const size_t len)
 void OS::start(char* _cmdline, uintptr_t mem_size)
 {
   // Initialize stdout handlers
-  OS::add_stdout(&OS::default_stdout);
+  if(os_default_stdout) {
+    OS::add_stdout(&OS::default_stdout);
+  }
 
   PROFILE("");
   // Print a fancy header

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -1,6 +1,13 @@
 #
 # Build and install plugins as libraries
 #
+
+# make LiveUpdate visible to plugins
+include_directories(${INCLUDEOS_ROOT}/lib/LiveUpdate)
+
+add_library(system_log STATIC "system_log.cpp")
+add_dependencies(system_log PrecompiledLibraries)
+
 add_library(syslogd STATIC syslogd.cpp)
 add_dependencies(syslogd PrecompiledLibraries)
 
@@ -29,6 +36,7 @@ add_dependencies(nacl PrecompiledLibraries)
 set(CMAKE_INSTALL_MESSAGE LAZY) # to avoid spam
 
 install(TARGETS
+    system_log
     syslogd
     unik
     example

--- a/src/plugins/system_log.cpp
+++ b/src/plugins/system_log.cpp
@@ -95,7 +95,8 @@ void SystemLog::initialize()
     new (mrb) MemoryRingBuffer(get_ringbuffer_loc(),
                     state[0], state[1], state[2], state[3]);
 
-    INFO2("Restored @ %p (%i kB)", mrb->data(), mrb->capacity() / 1024);
+    INFO2("Restored @ %p (%i kB) Flags: 0x%x",
+      mrb->data(), mrb->capacity() / 1024, buffer.flags);
   }
   Ensures(mrb != nullptr);
   Expects(buffer.capacity == mrb->capacity());

--- a/src/plugins/system_log.cpp
+++ b/src/plugins/system_log.cpp
@@ -1,0 +1,82 @@
+#include <system_log>
+#include <kernel/os.hpp>
+#include <ringbuffer>
+#include <liveupdate.hpp>
+#include <kprint>
+
+static FixedRingBuffer<32768> temp_mrb;
+#define MRB_LOG_SIZE (1 << 17)
+static MemoryRingBuffer* mrb = nullptr;
+static inline RingBuffer* get_mrb()
+{
+  if (mrb != nullptr) return mrb;
+  return &temp_mrb;
+}
+
+void SystemLog::write(const char* buffer, size_t length)
+{
+  size_t free = get_mrb()->free_space();
+  if (free < length) {
+    get_mrb()->discard(length - free);
+  }
+  get_mrb()->write(buffer, length);
+  // we will want to display the panic, always
+  if (OS::is_panicking()) {
+    OS::print(buffer, length);
+  }
+}
+std::vector<char> SystemLog::copy()
+{
+  const auto* buffer = get_mrb()->sequentialize();
+  return {buffer, buffer + get_mrb()->size()};
+}
+void SystemLog::print_all()
+{
+  const auto* buffer = get_mrb()->sequentialize();
+  OS::print(buffer, get_mrb()->size());
+}
+
+static void resume_system_log(liu::Restore& store)
+{
+  mrb = store.as_type<MemoryRingBuffer*> ();
+  store.go_next();
+}
+static void store_system_log(liu::Storage& store, const liu::buffer_t*)
+{
+  store.add<RingBuffer*> (0, get_mrb());
+}
+
+// start dumping the log
+extern "C"
+void panic_perform_inspection_procedure()
+{
+  static bool procedure_entered = false;
+  if (procedure_entered) return;
+  procedure_entered = true;
+
+  SystemLog::print_all();
+}
+
+static void register_system_log()
+{
+  if (liu::LiveUpdate::partition_exists("system_log"))
+  {
+    liu::LiveUpdate::resume("system_log", resume_system_log);
+  }
+  else
+  {
+    // create new MRB
+    char* loc = (char*) OS::liveupdate_storage_area() - MRB_LOG_SIZE;
+    mrb = (MemoryRingBuffer*) (loc - sizeof(MemoryRingBuffer));
+    new (mrb) MemoryRingBuffer(loc, MRB_LOG_SIZE);
+    // copy from temp RB
+    mrb->write(temp_mrb.sequentialize(), temp_mrb.size());
+  }
+  liu::LiveUpdate::register_partition("system_log", store_system_log);
+}
+
+__attribute__((constructor))
+static void system_log_gconstr()
+{
+  OS::register_plugin(register_system_log, "System log plugin");
+}

--- a/src/posix/unistd.cpp
+++ b/src/posix/unistd.cpp
@@ -24,7 +24,6 @@
 #include <file_fd.hpp>
 #include <errno.h>
 #include <posix_strace.hpp>
-#include <system_log>
 
 static const int RNG_FD = 4;
 
@@ -104,7 +103,7 @@ int read(int fd, void* buf, size_t len)
 int write(int fd, const void* ptr, size_t len)
 {
   if (fd < 4) {
-    SystemLog::write((const char*) ptr, len);
+    OS::print((const char*) ptr, len);
     return len;
   }
   PRINT("write(%d, %p, %lu)\n", fd, ptr, len);

--- a/src/posix/unistd.cpp
+++ b/src/posix/unistd.cpp
@@ -24,6 +24,7 @@
 #include <file_fd.hpp>
 #include <errno.h>
 #include <posix_strace.hpp>
+#include <system_log>
 
 static const int RNG_FD = 4;
 
@@ -103,7 +104,7 @@ int read(int fd, void* buf, size_t len)
 int write(int fd, const void* ptr, size_t len)
 {
   if (fd < 4) {
-    OS::print((const char*) ptr, len);
+    SystemLog::write((const char*) ptr, len);
     return len;
   }
   PRINT("write(%d, %p, %lu)\n", fd, ptr, len);

--- a/test/kernel/integration/LiveUpdate/CMakeLists.txt
+++ b/test/kernel/integration/LiveUpdate/CMakeLists.txt
@@ -30,5 +30,8 @@ set(LIBRARIES
   libliveupdate.a
   )
 
+# disable serial output
+set(default_stdout OFF)
+
 # include service build script
 include($ENV{INCLUDEOS_PREFIX}/includeos/post.service.cmake)

--- a/test/kernel/integration/LiveUpdate/CMakeLists.txt
+++ b/test/kernel/integration/LiveUpdate/CMakeLists.txt
@@ -18,10 +18,12 @@ set(SOURCES
 
 # DRIVERS / PLUGINS:
 set(DRIVERS
-  virtionet
+    virtionet
   )
 
-set(PLUGINS )
+set(PLUGINS
+    system_log
+  )
 
 # STATIC LIBRARIES:
 set(LIBRARIES

--- a/test/kernel/integration/LiveUpdate/manual.sh
+++ b/test/kernel/integration/LiveUpdate/manual.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cat > /dev/tcp/10.0.0.49/666 < build/service

--- a/test/kernel/integration/LiveUpdate/service.cpp
+++ b/test/kernel/integration/LiveUpdate/service.cpp
@@ -25,6 +25,8 @@ extern storage_func_t begin_test_boot();
 
 void Service::start()
 {
+  OS::set_panic_action(OS::Panic_action::halt);
+
   auto func = begin_test_boot();
 
   if (OS::is_live_updated() == false)
@@ -32,7 +34,9 @@ void Service::start()
     auto& inet = net::Super_stack::get<net::IP4>(0);
     inet.network_config({10,0,0,49}, {255,255,255,0}, {10,0,0,1});
     setup_liveupdate_server(inet, 666, func);
+
     // signal test.py that the server is up
-    printf("Ready to receive binary blob\n");
+    const char* sig = "Ready to receive binary blob\n";
+    OS::print(sig, strlen(sig));
   }
 }

--- a/test/kernel/integration/LiveUpdate/service.cpp
+++ b/test/kernel/integration/LiveUpdate/service.cpp
@@ -37,6 +37,6 @@ void Service::start()
 
     // signal test.py that the server is up
     const char* sig = "Ready to receive binary blob\n";
-    OS::print(sig, strlen(sig));
+    OS::default_stdout(sig, strlen(sig));
   }
 }

--- a/test/kernel/integration/LiveUpdate/test_boot.cpp
+++ b/test/kernel/integration/LiveUpdate/test_boot.cpp
@@ -2,6 +2,7 @@
 #include <kernel/syscalls.hpp>
 #include <liveupdate>
 #include <timers>
+#include <system_log>
 using namespace liu;
 
 static std::vector<uint64_t> timestamps;
@@ -53,6 +54,7 @@ LiveUpdate::storage_func begin_test_boot()
       using namespace std::chrono;
       Timers::oneshot(5ms,[] (int) {
         printf("SUCCESS\n");
+        SystemLog::print_all();
       });
       return nullptr;
     }

--- a/test/kernel/integration/LiveUpdate/test_boot.cpp
+++ b/test/kernel/integration/LiveUpdate/test_boot.cpp
@@ -54,7 +54,7 @@ LiveUpdate::storage_func begin_test_boot()
       using namespace std::chrono;
       Timers::oneshot(5ms,[] (int) {
         printf("SUCCESS\n");
-        SystemLog::print_all();
+        SystemLog::print_to(OS::default_stdout);
       });
       return nullptr;
     }

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -89,9 +89,8 @@ void paging_test_init(){
 void OS::multiboot(unsigned) {}
 
 #include <system_log>
-void SystemLog::print_all() {
-  printf("SystemLog::print_all();\n");
-}
+void SystemLog::initialize() {}
+void SystemLog::set_flags(uint32_t) {}
 
 /// Kernel ///
 char _binary_apic_boot_bin_end;

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -87,22 +87,26 @@ void paging_test_init(){
 }
 
 void OS::multiboot(unsigned) {}
-extern "C" {
+
+#include <system_log>
+void SystemLog::print_all() {
+  printf("SystemLog::print_all();\n");
+}
 
 /// Kernel ///
+char _binary_apic_boot_bin_end;
+char _binary_apic_boot_bin_start;
+char _ELF_START_;
+char _ELF_END_;
+uintptr_t _MULTIBOOT_START_;
+uintptr_t _LOAD_START_;
+uintptr_t _LOAD_END_;
+uintptr_t _BSS_END_;
+uintptr_t _TEXT_START_;
+uintptr_t _TEXT_END_;
+uintptr_t _EXEC_END_;
 
-  char _binary_apic_boot_bin_end;
-  char _binary_apic_boot_bin_start;
-  char _ELF_START_;
-  char _ELF_END_;
-  uintptr_t _MULTIBOOT_START_;
-  uintptr_t _LOAD_START_;
-  uintptr_t _LOAD_END_;
-  uintptr_t _BSS_END_;
-  uintptr_t _TEXT_START_;
-  uintptr_t _TEXT_END_;
-  uintptr_t _EXEC_END_;
-
+extern "C" {
   uintptr_t get_cpu_esp() {
     return 0xdeadbeef;
   }
@@ -139,8 +143,6 @@ extern "C" {
     static char __printbuf[4096];
     snprintf(__printbuf, sizeof(__printbuf), "%s", cstr);
   }
-
-
 } // ~ extern "C"
 
 /// platform ///

--- a/test/util/unit/ringbuffer.cpp
+++ b/test/util/unit/ringbuffer.cpp
@@ -20,7 +20,7 @@
 
 CASE("A new ringbuffer is empty")
 {
-  RingBuffer rb(1);
+  HeapRingBuffer rb(1);
   EXPECT(rb.capacity() == 1);
 
   EXPECT(rb.free_space() == 1);
@@ -31,7 +31,7 @@ CASE("A new ringbuffer is empty")
 }
 CASE("Adding bytes to ringbuffer")
 {
-  RingBuffer rb(2);
+  HeapRingBuffer rb(2);
 
   int written = rb.write("1", 1);
   EXPECT(written == 1);
@@ -55,7 +55,7 @@ CASE("Adding bytes to ringbuffer")
 }
 CASE("Reading bytes to ringbuffer")
 {
-  RingBuffer rb(2);
+  HeapRingBuffer rb(2);
   int written;
 
   written = rb.write("1", 1);
@@ -90,7 +90,7 @@ CASE("Read Pt.2")
   const char* buffer = "ABCDEFGH";
   const int len = strlen(buffer);
 
-  RingBuffer rb(len);
+  HeapRingBuffer rb(len);
   // advance one position internally
   rb.write("A", 1);
   rb.discard(1);
@@ -104,7 +104,7 @@ CASE("Read Pt.2")
 }
 CASE("We can discard data")
 {
-  RingBuffer rb(10);
+  HeapRingBuffer rb(10);
   int written;
 
   written = rb.write("12345", 5);
@@ -132,7 +132,7 @@ CASE("We can discard data")
 }
 CASE("Discard pt.2")
 {
-  RingBuffer rb(10);
+  HeapRingBuffer rb(10);
   int written;
   written = rb.write("1234567890", 10);
   EXPECT(written == 10);
@@ -174,17 +174,17 @@ CASE("Discard pt.2")
 CASE("Test sequentialize Pt.1")
 {
   {
-    RingBuffer rb(1);
+    HeapRingBuffer rb(1);
     rb.write("A", 1);
     EXPECT(strncmp(rb.sequentialize(), "A", 1) == 0);
   }
   {
-    RingBuffer rb(2);
+    HeapRingBuffer rb(2);
     rb.write("AB", 2);
     EXPECT(strncmp(rb.sequentialize(), "AB", 2) == 0);
   }
   {
-    RingBuffer rb(2);
+    HeapRingBuffer rb(2);
     rb.write("A", 1);
     rb.discard(1);
     rb.write("AB", 2);
@@ -195,7 +195,7 @@ CASE("Test sequentialize Pt.2")
 {
   const char* buffer = "ABCDEFGH";
   const int len = strlen(buffer);
-  RingBuffer rb(len);
+  HeapRingBuffer rb(len);
 
   for (int i = 0; i < len; i++)
   {

--- a/test_ukvm.sh
+++ b/test_ukvm.sh
@@ -12,26 +12,6 @@ fi
 
 pushd examples/demo_service
 mkdir -p build
-pushd build
-PLATFORM=x86_solo5 cmake ..
-make
+boot --with-solo5 .
 popd
-popd
-
-echo -e "Build complete \n"
-echo -e "Starting VM with ukvm/solo5. "
-
-# The default ukvm-bin needs a disk, even if it's a dummy 0 byte one.
-# If you want ukvm-bin with just the net module, you need to re-build it.
-touch dummy.disk
-
-# Create a tap100 device
-sudo ./etc/scripts/ukvm-ifup.sh
-
-# XXX: fix this during installation
-chmod +x ./build_x86_64/precompiled/src/solo5_repo/ukvm/ukvm-bin
-
-# XXX: should be using the installation directory instead
-sudo ./build_x86_64/precompiled/src/solo5_repo/ukvm/ukvm-bin --disk=dummy.disk --net=tap100 ./examples/demo_service/build/IncludeOS_example
-
 trap - EXIT

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -180,6 +180,136 @@ class hypervisor(object):
     def image_name(self):
         abstract()
 
+    def start_process(self, cmdlist):
+
+        if cmdlist[0] == "sudo": # and have_sudo():
+            print color.WARNING("Running with sudo")
+            self._sudo = True
+
+        # Start a subprocess
+        self._proc = subprocess.Popen(cmdlist,
+                                      stdout = subprocess.PIPE,
+                                      stderr = subprocess.PIPE,
+                                      stdin = subprocess.PIPE)
+
+        return self._proc
+
+
+# Ukvm Hypervisor interface
+class ukvm(hypervisor):
+
+    def __init__(self, config):
+        # config is not yet used for ukvm
+        super(ukvm, self).__init__(config)
+        self._proc = None
+        self._stopped = False
+        self._sudo = False
+        self._image_name = self._config if "image" in self._config else self.name() + " vm"
+
+        # Pretty printing
+        self.info = Logger(color.INFO("<" + type(self).__name__ + ">"))
+
+    def name(self):
+        return "Ukvm"
+
+    def image_name(self):
+        return self._image_name
+
+    def drive_arg(self):
+        return ["--disk=" + INCLUDEOS_HOME + "dummy.disk"]
+
+    def net_arg(self):
+        return ["--net=tap100"]
+
+    def get_final_output(self):
+        return self._proc.communicate()
+
+    def boot(self, multiboot, kernel_args = "", image_name = None):
+        self._stopped = False
+
+        qkvm_bin = INCLUDEOS_HOME + "/includeos/x86_64/lib/ukvm-bin"
+
+        # Use provided image name if set, otherwise raise an execption
+        if not image_name:
+            raise Exception("No image name provided as param")
+
+        self._image_name = image_name
+
+        command = ["sudo", qkvm_bin]
+        command += self.drive_arg()
+        command += self.net_arg()
+        command += [self._image_name]
+
+        try:
+            self.start_process(command)
+            self.info("Started process PID ",self._proc.pid)
+        except Exception as e:
+            raise e
+
+    def stop(self):
+
+        signal = "-SIGTERM"
+
+        # Don't try to kill twice
+        if self._stopped:
+            self.wait()
+            return self
+        else:
+            self._stopped = True
+
+        if self._proc and self._proc.poll() == None :
+
+            if not self._sudo:
+                info ("Stopping child process (no sudo required)")
+                self._proc.terminate()
+            else:
+                # Find and terminate all child processes, since parent is "sudo"
+                parent = psutil.Process(self._proc.pid)
+                children = parent.children()
+
+                info ("Stopping", self._image_name, "PID",self._proc.pid, "with", signal)
+
+                for child in children:
+                    info (" + child process ", child.pid)
+
+                    # The process might have gotten an exit status by now so check again to avoid negative exit
+                    if (not self._proc.poll()):
+                        subprocess.call(["sudo", "kill", signal, str(child.pid)])
+
+            # Wait for termination (avoids the need to reset the terminal etc.)
+            self.wait()
+
+        return self
+
+    def wait(self):
+        if (self._proc): self._proc.wait()
+        return self
+
+    def read_until_EOT(self):
+        chars = ""
+
+        while (not self._proc.poll()):
+            char = self._proc.stdout.read(1)
+            if char == chr(4):
+                return chars
+            chars += char
+
+        return chars
+
+
+    def readline(self):
+        if self._proc.poll():
+            raise Exception("Process completed")
+        return self._proc.stdout.readline()
+
+
+    def writeline(self, line):
+        if self._proc.poll():
+            raise Exception("Process completed")
+        return self._proc.stdin.write(line + "\n")
+
+    def poll(self):
+        return self._proc.poll()
 
 # Qemu Hypervisor interface
 class qemu(hypervisor):
@@ -259,21 +389,6 @@ class qemu(hypervisor):
     # Note: if the command failed, we can't know until we have exit status,
     # but we can't wait since we expect no exit. Checking for program start error
     # is therefore deferred to the callee
-    def start_process(self, cmdlist):
-
-        if cmdlist[0] == "sudo": # and have_sudo():
-            print color.WARNING("Running with sudo")
-            self._sudo = True
-
-        # Start a subprocess
-        self._proc = subprocess.Popen(cmdlist,
-                                      stdout = subprocess.PIPE,
-                                      stderr = subprocess.PIPE,
-                                      stdin = subprocess.PIPE)
-        self.info("Started process PID ",self._proc.pid)
-
-        return self._proc
-
 
     def get_final_output(self):
         return self._proc.communicate()
@@ -410,6 +525,7 @@ class qemu(hypervisor):
 
         try:
             self.start_process(command)
+            self.info("Started process PID ",self._proc.pid)
         except Exception as e:
             print self.INFO,"Starting subprocess threw exception:", e
             raise e
@@ -482,7 +598,7 @@ class qemu(hypervisor):
 # VM class
 class vm:
 
-    def __init__(self, config = None, hyper = qemu):
+    def __init__(self, config = None, hyper_name = "qemu"):
 
         self._exit_status = None
         self._exit_msg = ""
@@ -495,6 +611,11 @@ class vm:
         self._on_output = {
             panic_signature : self._on_panic,
             "SUCCESS" : self._on_success }
+
+        if hyper_name == "ukvm":
+            hyper = ukvm
+        else:
+            hyper = qemu
 
         # Initialize hypervisor with config
         assert(issubclass(hyper, hypervisor))


### PR DESCRIPTION
* `stdout` behavior is by default directly to OS::print, as expected
* When system_log plugin enabled stdout is routed to the system log
* System log by default only prints during panic()
* System log interface in `api/system_log`
* RB is preserved during LiveUpdate, zero overhead
* LiveUpdate test median time: 30ms before, 27.81ms after