### PR TITLE
uplink: No longer delay liveupdate, but instead flush

### DIFF
--- a/api/net/ws/websocket.hpp
+++ b/api/net/ws/websocket.hpp
@@ -258,6 +258,11 @@ public:
     return stream->get_cpuid();
   }
 
+  // 0 == unlimited
+  void set_max_message_size(uint32_t sz) noexcept {
+    max_msg_size = sz;
+  }
+
   WebSocket(net::Stream_ptr, bool);
   WebSocket(WebSocket&&);
   ~WebSocket();
@@ -266,6 +271,7 @@ private:
   net::Stream_ptr stream;
   Timer ping_timer{{this, &WebSocket::pong_timeout}};
   Message_ptr message;
+  uint32_t max_msg_size;
   bool clientside;
 
   WebSocket(const WebSocket&) = delete;

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -479,7 +479,11 @@ namespace uplink {
     ws_->write(transport.data().data(), transport.data().size());
   }
 
-  void WS_uplink::send_message(Transport_code code, const char* data, size_t len) {
+  void WS_uplink::send_message(Transport_code code, const char* data, size_t len)
+  {
+    if(UNLIKELY(not is_online()))
+      return;
+
     auto transport = Transport{Header{code, static_cast<uint32_t>(len)}};
 
     transport.load_cargo(data, len);

--- a/lib/uplink/ws_uplink.hpp
+++ b/lib/uplink/ws_uplink.hpp
@@ -55,7 +55,7 @@ public:
 
   void send_uplink();
 
-  void update(const std::vector<char>& buffer);
+  void update(std::vector<char> buffer);
 
   void send_error(const std::string& err);
 


### PR DESCRIPTION
Bandaid for when timers are broken.