### PR TITLE
Allow booting of solo5/ukvm with the boot command

### DIFF
--- a/etc/boot
+++ b/etc/boot
@@ -57,6 +57,9 @@ parser.add_argument("-j", "--config", dest="config", type = str, metavar = "PATH
 parser.add_argument('vm_location', action="store", type = str,
                     help="Location of the IncludeOS service binary, image or source")
 
+parser.add_argument("--with-solo5", dest="solo5", action="store_true",
+                    help="Run includeOS on solo5 kernel with ukvm-bin as monitor")
+
 parser.add_argument('vmargs', nargs='*', help="Arguments to pass on to the VM start / main")
 
 args = parser.parse_args()
@@ -115,7 +118,17 @@ if args.config:
     config = os.path.abspath(args.config)
     if VERB: print INFO, "Using config file", config
 
-vm = vmrunner.vm(config = config)
+hyper_name = "qemu"
+if args.solo5:
+    hyper_name = "ukvm"
+    os.environ['PLATFORM'] = "x86_solo5"
+    qkvm_bin = INCLUDEOS_PREFIX + "/includeos/x86_64/lib/ukvm-bin"
+
+    subprocess.call(['touch', INCLUDEOS_PREFIX + 'dummy.disk'])
+    subprocess.call(['chmod', '+x', qkvm_bin])
+    subprocess.call(['sudo', INCLUDEOS_PREFIX + "/includeos/scripts/ukvm-ifup.sh" ])
+
+vm = vmrunner.vm(config = config, hyper_name = hyper_name)
 
 # Don't listen to events needed by testrunner
 vm.on_success(lambda(x): None, do_exit = False)

--- a/test_ukvm.sh
+++ b/test_ukvm.sh
@@ -12,26 +12,6 @@ fi
 
 pushd examples/demo_service
 mkdir -p build
-pushd build
-PLATFORM=x86_solo5 cmake ..
-make
+boot --with-solo5 .
 popd
-popd
-
-echo -e "Build complete \n"
-echo -e "Starting VM with ukvm/solo5. "
-
-# The default ukvm-bin needs a disk, even if it's a dummy 0 byte one.
-# If you want ukvm-bin with just the net module, you need to re-build it.
-touch dummy.disk
-
-# Create a tap100 device
-sudo ./etc/scripts/ukvm-ifup.sh
-
-# XXX: fix this during installation
-chmod +x ./build_x86_64/precompiled/src/solo5_repo/ukvm/ukvm-bin
-
-# XXX: should be using the installation directory instead
-sudo ./build_x86_64/precompiled/src/solo5_repo/ukvm/ukvm-bin --disk=dummy.disk --net=tap100 ./examples/demo_service/build/IncludeOS_example
-
 trap - EXIT

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -179,6 +179,136 @@ class hypervisor(object):
     def image_name(self):
         abstract()
 
+    def start_process(self, cmdlist):
+
+        if cmdlist[0] == "sudo": # and have_sudo():
+            print color.WARNING("Running with sudo")
+            self._sudo = True
+
+        # Start a subprocess
+        self._proc = subprocess.Popen(cmdlist,
+                                      stdout = subprocess.PIPE,
+                                      stderr = subprocess.PIPE,
+                                      stdin = subprocess.PIPE)
+
+        return self._proc
+
+
+# Ukvm Hypervisor interface
+class ukvm(hypervisor):
+
+    def __init__(self, config):
+        # config is not yet used for ukvm
+        super(ukvm, self).__init__(config)
+        self._proc = None
+        self._stopped = False
+        self._sudo = False
+        self._image_name = self._config if "image" in self._config else self.name() + " vm"
+
+        # Pretty printing
+        self.info = Logger(color.INFO("<" + type(self).__name__ + ">"))
+
+    def name(self):
+        return "Ukvm"
+
+    def image_name(self):
+        return self._image_name
+
+    def drive_arg(self):
+        return ["--disk=" + INCLUDEOS_HOME + "dummy.disk"]
+
+    def net_arg(self):
+        return ["--net=tap100"]
+
+    def get_final_output(self):
+        return self._proc.communicate()
+
+    def boot(self, multiboot, kernel_args = "", image_name = None):
+        self._stopped = False
+
+        qkvm_bin = INCLUDEOS_HOME + "/includeos/x86_64/lib/ukvm-bin"
+
+        # Use provided image name if set, otherwise raise an execption
+        if not image_name:
+            raise Exception("No image name provided as param")
+
+        self._image_name = image_name
+
+        command = ["sudo", qkvm_bin]
+        command += self.drive_arg()
+        command += self.net_arg()
+        command += [self._image_name]
+
+        try:
+            self.start_process(command)
+            self.info("Started process PID ",self._proc.pid)
+        except Exception as e:
+            raise e
+
+    def stop(self):
+
+        signal = "-SIGTERM"
+
+        # Don't try to kill twice
+        if self._stopped:
+            self.wait()
+            return self
+        else:
+            self._stopped = True
+
+        if self._proc and self._proc.poll() == None :
+
+            if not self._sudo:
+                info ("Stopping child process (no sudo required)")
+                self._proc.terminate()
+            else:
+                # Find and terminate all child processes, since parent is "sudo"
+                parent = psutil.Process(self._proc.pid)
+                children = parent.children()
+
+                info ("Stopping", self._image_name, "PID",self._proc.pid, "with", signal)
+
+                for child in children:
+                    info (" + child process ", child.pid)
+
+                    # The process might have gotten an exit status by now so check again to avoid negative exit
+                    if (not self._proc.poll()):
+                        subprocess.call(["sudo", "kill", signal, str(child.pid)])
+
+            # Wait for termination (avoids the need to reset the terminal etc.)
+            self.wait()
+
+        return self
+
+    def wait(self):
+        if (self._proc): self._proc.wait()
+        return self
+
+    def read_until_EOT(self):
+        chars = ""
+
+        while (not self._proc.poll()):
+            char = self._proc.stdout.read(1)
+            if char == chr(4):
+                return chars
+            chars += char
+
+        return chars
+
+
+    def readline(self):
+        if self._proc.poll():
+            raise Exception("Process completed")
+        return self._proc.stdout.readline()
+
+
+    def writeline(self, line):
+        if self._proc.poll():
+            raise Exception("Process completed")
+        return self._proc.stdin.write(line + "\n")
+
+    def poll(self):
+        return self._proc.poll()
 
 # Qemu Hypervisor interface
 class qemu(hypervisor):
@@ -258,21 +388,6 @@ class qemu(hypervisor):
     # Note: if the command failed, we can't know until we have exit status,
     # but we can't wait since we expect no exit. Checking for program start error
     # is therefore deferred to the callee
-    def start_process(self, cmdlist):
-
-        if cmdlist[0] == "sudo": # and have_sudo():
-            print color.WARNING("Running with sudo")
-            self._sudo = True
-
-        # Start a subprocess
-        self._proc = subprocess.Popen(cmdlist,
-                                      stdout = subprocess.PIPE,
-                                      stderr = subprocess.PIPE,
-                                      stdin = subprocess.PIPE)
-        self.info("Started process PID ",self._proc.pid)
-
-        return self._proc
-
 
     def get_final_output(self):
         return self._proc.communicate()
@@ -399,6 +514,7 @@ class qemu(hypervisor):
 
         try:
             self.start_process(command)
+            self.info("Started process PID ",self._proc.pid)
         except Exception as e:
             print self.INFO,"Starting subprocess threw exception:", e
             raise e
@@ -471,7 +587,7 @@ class qemu(hypervisor):
 # VM class
 class vm:
 
-    def __init__(self, config = None, hyper = qemu):
+    def __init__(self, config = None, hyper_name = "qemu"):
 
         self._exit_status = None
         self._exit_msg = ""
@@ -484,6 +600,11 @@ class vm:
         self._on_output = {
             "\\x15\\x07\\t\*\*\*\* PANIC \*\*\*\*" : self._on_panic,
             "SUCCESS" : self._on_success }
+
+        if hyper_name == "ukvm":
+            hyper = ukvm
+        else:
+            hyper = qemu
 
         # Initialize hypervisor with config
         assert(issubclass(hyper, hypervisor))


### PR DESCRIPTION
Changes done:

- The IncludeOS can now be booted on solo5 as follows
`boot --with-solo5 .`
- Changed test_ukvm.sh to reflect this change.
- vm.json file is not required for solo5 currently but can be used if required in the future.
-  Created a new class ukvm under hypervisor
- Moved start_process() function to the parent class(hypervisor). Similarly, stop(), wait() and other functions could be moved to the parent class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hioa-cs/includeos/1706)
<!-- Reviewable:end -->
