### PR TITLE
Fixed unittest on mac + isotime issue

### DIFF
--- a/api/net/buffer_store.hpp
+++ b/api/net/buffer_store.hpp
@@ -93,7 +93,7 @@ namespace net
     size_t               bufsize_;
     uint8_t*             pool_;
     std::vector<uint8_t*> available_;
-    BufferStore*         next_;
+    std::unique_ptr<BufferStore> next_;
     int                  index;
 #ifndef INCLUDEOS_SINGLE_THREADED
     // has strict alignment reqs, so put at end

--- a/api/util/isotime.hpp
+++ b/api/util/isotime.hpp
@@ -36,8 +36,8 @@ struct isotime
    */
   static std::string to_datetime_string(time_t ts)
   {
-    char buf[sizeof("2017-04-10T13:337:00Z")];
-    const auto res = std::strftime(buf, sizeof(buf)-1, "%FT%TZ", gmtime(&ts));
+    char buf[sizeof("2017-04-10T13:37:00Z")];
+    const auto res = std::strftime(buf, sizeof(buf), "%FT%TZ", gmtime(&ts));
     return {buf, res};
   }
 

--- a/api/util/isotime.hpp
+++ b/api/util/isotime.hpp
@@ -28,15 +28,17 @@ struct isotime
    * @brief      Returns a ISO 8601 UTC datetime string.
    *             Example: 2017-04-10T13:37:00Z
    *
+   * @note       Invalid time (too big for the format) will result in a empty string.
+   *
    * @param[in]  ts    A timestamp
    *
    * @return     An ISO datetime string, formatted as "YYYY-MM-DDThh:mm:ssZ"
    */
   static std::string to_datetime_string(time_t ts)
   {
-    char buf[sizeof "2017-04-10T13:37:00Z"];
-    strftime(buf, sizeof buf, "%FT%TZ", gmtime(&ts));
-    return buf;
+    char buf[sizeof("2017-04-10T13:337:00Z")];
+    const auto res = std::strftime(buf, sizeof(buf)-1, "%FT%TZ", gmtime(&ts));
+    return {buf, res};
   }
 
   /**

--- a/src/net/buffer_store.cpp
+++ b/src/net/buffer_store.cpp
@@ -15,12 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !defined(__MACH__)
-#include <malloc.h>
-#else
-#include <cstddef>
-extern void *memalign(size_t, size_t);
-#endif
+#include <cstdlib>
 #include <net/buffer_store.hpp>
 #include <kernel/syscalls.hpp>
 #include <common>
@@ -64,7 +59,7 @@ namespace net {
     assert(bufsize != 0);
     const size_t DATA_SIZE  = poolsize_;
 
-    this->pool_ = (uint8_t*) memalign(PAGE_SIZE, DATA_SIZE);
+    this->pool_ = (uint8_t*) aligned_alloc(PAGE_SIZE, DATA_SIZE);
     assert(this->pool_);
 
     available_.reserve(num);
@@ -79,7 +74,7 @@ namespace net {
   }
 
   BufferStore::~BufferStore() {
-    delete this->next_;
+    this->next_ = nullptr;
     free(this->pool_);
   }
 
@@ -89,7 +84,7 @@ namespace net {
 #ifdef ENABLE_BUFFERSTORE_CHAIN
     auto* parent = this;
     while (parent->next_ != nullptr) {
-        parent = parent->next_;
+        parent = parent->next_.get();
         avail += parent->available_.size();
     }
 #endif
@@ -101,7 +96,7 @@ namespace net {
 #ifdef ENABLE_BUFFERSTORE_CHAIN
     auto* parent = this;
     while (parent->next_ != nullptr) {
-        parent = parent->next_;
+        parent = parent->next_.get();
         total += parent->local_buffers();
     }
 #endif
@@ -113,13 +108,13 @@ namespace net {
 #ifdef ENABLE_BUFFERSTORE_CHAIN
     BufferStore* parent = this;
     while (parent->next_ != nullptr) {
-        parent = parent->next_;
+        parent = parent->next_.get();
         if (!parent->available_.empty()) return parent;
     }
     BSD_BUF("<BufferStore> Allocating %lu new buffers (%lu total)\n",
             local_buffers(), total_buffers() + local_buffers());
-    parent->next_ = new BufferStore(local_buffers(), bufsize());
-    return parent->next_;
+    parent->next_ = std::make_unique<BufferStore>(local_buffers(), bufsize());
+    return parent->next_.get();
 #else
     return nullptr;
 #endif
@@ -170,14 +165,14 @@ namespace net {
 #endif
 #ifdef ENABLE_BUFFERSTORE_CHAIN
     // try to release buffer on linked bufferstore
-    BufferStore* ptr = next_;
+    BufferStore* ptr = next_.get();
     while (ptr != nullptr) {
       if (ptr->is_from_this_pool(buff)) {
         BSD_RELEASE("released on other bufferstore\n");
         ptr->release_directly(buff);
         return;
       }
-      ptr = ptr->next_;
+      ptr = ptr->next_.get();
     }
 #endif
     throw std::runtime_error("Packet did not belong");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,7 @@ execute_process(COMMAND brew "--prefix" "llvm@5" OUTPUT_VARIABLE BREW_LLVM)
 string(STRIP ${BREW_LLVM} BREW_LLVM)
 set(BREW_LIBCXX_INC ${BREW_LLVM}/lib)
 message(STATUS "Brew libc++ location: " ${BREW_LIBCXX_INC})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L${BREW_LIBCXX_INC} -Wl")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L${BREW_LIBCXX_INC} -Wno-unused-command-line-argument")
 endif()
 
 if(NOT DEFINED ${INCLUDEOS_ROOT})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,15 @@ endif()
 
 set(CMAKE_CXX_FLAGS "-g -O0 -march=native -std=c++17 -Wall -Wextra -Wno-unused-function -D__id_t_defined -DUNITTESTS -DURI_THROW_ON_ERROR ${NO_INFO} ${NO_DEBUG} -DGSL_THROW_ON_CONTRACT_VIOLATION -Dlest_FEATURE_AUTO_REGISTER=1 -DHAVE_LEST_MAIN")
 
+if (APPLE)
+message(STATUS "Including brew bundled libc++")
+execute_process(COMMAND brew "--prefix" "llvm@5" OUTPUT_VARIABLE BREW_LLVM)
+string(STRIP ${BREW_LLVM} BREW_LLVM)
+set(BREW_LIBCXX_INC ${BREW_LLVM}/lib)
+message(STATUS "Brew libc++ location: " ${BREW_LIBCXX_INC})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L${BREW_LIBCXX_INC} -Wl")
+endif()
+
 if(NOT DEFINED ${INCLUDEOS_ROOT})
   set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 endif()
@@ -42,6 +51,7 @@ set(SRC ${INCLUDEOS_ROOT}/src)
 set(TEST ${INCLUDEOS_ROOT}/test)
 
 include_directories(
+  ${TEST}/lest_util
   ${INCLUDEOS_ROOT}/api
   ${INCLUDEOS_ROOT}/src/
   ${INCLUDEOS_ROOT}/src/include
@@ -49,7 +59,6 @@ include_directories(
   ${INCLUDEOS_ROOT}/mod/GSL
   ${INCLUDEOS_ROOT}/mod/uzlib/src
   ${TEST}/lest/include
-  ${TEST}/lest_util
 )
 
 set(LEST_UTIL

--- a/test/lest_util/stdlib.h
+++ b/test/lest_util/stdlib.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <stddef.h>
+#ifdef __MACH__
+void* aligned_alloc(size_t alignment, size_t size);
+#endif
+
+#include_next <stdlib.h>

--- a/test/util/unit/isotime.cpp
+++ b/test/util/unit/isotime.cpp
@@ -35,5 +35,16 @@ CASE("A timestamp can be converted into a ISO UTC datetime string")
 
   EXPECT(str == "1970-01-01T05:00:00Z");
 
-  // Not gonna bother more due to leap seconds and calendars etc...
+  uint64_t big_number = 253402297200L;
+
+  str = isotime::to_datetime_string(big_number);
+
+  EXPECT(str == "9999-12-31T23:00:00Z");
+
+  uint64_t bigger_number = big_number + 2*60*60;
+
+  str = isotime::to_datetime_string(bigger_number);
+
+  // buffer is not big enough for more than 21 chars
+  EXPECT(str == "");
 }


### PR DESCRIPTION
Building unittest on mac now uses brew bundled libc++. The user still has to export correct CC/CXX for it to build (Apple do not support c++17 on native Sierra 10.12.6).

isotime now checks the return value from strftime and return empty string if something is wrong. #1721

Bufferstore now using aligned_alloc instead of memalign (supposedly better and less mocking for mac unittest). Also replaced `next_` with unique_ptr due to some weird missing stuff on mac. The problem didnt go away but the error was cleaner. 
What fixed the problem was using brew bundled libc++. 