### PR TITLE
Fix the breakage of booting solo5 using '--with-solo5' option

### DIFF
--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -224,7 +224,7 @@ class ukvm(hypervisor):
     def get_final_output(self):
         return self._proc.communicate()
 
-    def boot(self, multiboot, kernel_args = "", image_name = None):
+    def boot(self, multiboot, debug=False, kernel_args = "", image_name = None):
         self._stopped = False
 
         qkvm_bin = INCLUDEOS_HOME + "/includeos/x86_64/lib/ukvm-bin"


### PR DESCRIPTION
When I tried to run IncludeOS with solo5 with `boot --with-solo5 .`  I got the following error

```
Traceback (most recent call last):
  File "/home/osboxes/includeos//includeos/vmrunner/vmrunner.py", line 855, in boot
    self._hyper.boot(multiboot, debug, "booted with vmrunner", "udp_perf")
TypeError: boot() takes at most 4 arguments (5 given)
```

Looks like this because of a recent change (#1708) where the `debug` parameter was added to Qemu but not to ukvm.  I simply added the debug parameter and its a NO-OP for now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hioa-cs/includeos/1726)
<!-- Reviewable:end -->
