### PR TITLE
uplink: removed unused variable

### DIFF
--- a/lib/uplink/ws_uplink.hpp
+++ b/lib/uplink/ws_uplink.hpp
@@ -74,7 +74,6 @@ private:
   net::WebSocket_ptr            ws_;
   std::string                   id_;
   std::string                   token_;
-  std::string                   tag_;
   /** Hash for the current running binary
    * (restored during update, none if never updated) */
   std::string                   binary_hash_;


### PR DESCRIPTION
The tag actually lives in config (see config.hpp)