### PR TITLE
Changing IP addresses for dhcpd integration test

### DIFF
--- a/examples/LiveUpdate/service.cpp
+++ b/examples/LiveUpdate/service.cpp
@@ -53,7 +53,7 @@ static void save_state(liu::Storage& store, const liu::buffer_t*)
 static void resume_state(liu::Restore& thing)
 {
   printf("Resume state called\n");
-  auto& inet = net::Super_stack::get<net::IP4>(0);
+  auto& inet = net::Super_stack::get(0);
 
   while (not thing.is_marker())
   {

--- a/test/net/integration/README.md
+++ b/test/net/integration/README.md
@@ -7,3 +7,4 @@ The following IP addresses are used by the services in the test folder. Make sur
 - tcp: 10.0.0.44
 - udp: 10.0.0.45
 - websocket: 10.0.0.54
+- dhcpd: 10.0.0.1, 10.0.0.10, 10.0.0.20

--- a/test/net/integration/dhcpd/service.cpp
+++ b/test/net/integration/dhcpd/service.cpp
@@ -30,13 +30,13 @@ void Service::start(const std::string&)
   // Server
 
   auto& inet = Inet::ifconfig<0>(
-    { 10,0,100,1 },     // IP
+    { 10,0,0,1 },     // IP
     { 255,255,255,0 },  // Netmask
     { 10,0,0,1 },       // Gateway
     { 8,8,8,8 });       // DNS
 
-  IP4::addr pool_start{10,0,100,10};
-  IP4::addr pool_end{10,0,100,20};
+  IP4::addr pool_start{10,0,0,10};
+  IP4::addr pool_end{10,0,0,20};
   server = std::make_unique<DHCPD>(inet.udp(), pool_start, pool_end);
 
   // Client 1


### PR DESCRIPTION
Changing IP addresses due to failed integration tests on new test workers.
The earlier network mask was more open so a larger IP range worked.
After recent change to the network mask, the dhcpd integration tests failed.
Thus changing IP address to a smaller range for the network tests.
