### PR TITLE
Compiler: Separate script for check/set of clang version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ test/**/*.log
 CMakeFiles*
 CMakeCache*
 cmake_install.cmake
+
+# Name of installation folder
+IncludeOS_install

--- a/etc/build_chainloader.sh
+++ b/etc/build_chainloader.sh
@@ -23,6 +23,9 @@ fi
 $INCLUDEOS_SRC/etc/install_from_bundle.sh
 
 echo -e "\n\n>>> Building chainloader"
+# Set compiler version
+source $INCLUDEOS_SRC/etc/use_clang_version.sh
+echo -e "\n\n>>> Best guess for compatible compilers: $CXX / $CC"
 
 mkdir -p $CHAINLOAD_LOC/build
 pushd $CHAINLOAD_LOC/build

--- a/etc/install_from_bundle.sh
+++ b/etc/install_from_bundle.sh
@@ -19,33 +19,8 @@ set -e
 : ${num_jobs:="-j 4"}
 : ${ARCH:=x86_64}
 
-# Try to find suitable compiler
-cc_list="clang-7.0 clang-6.0 clang-5.0 clang-4.0 clang-3.9 clang"
-cxx_list="clang++-7.0 clang++-6.0 clang++-5.0 clang++-4.0 clang++-3.9 clang++"
-
-compiler=""
-guess_compiler() {
-    for compiler in $*
-    do
-	if command -v $compiler; then
-		break
-	fi
-    done
-}
-
-
-if [ -z "$CC" ]
-then
-	guess_compiler "$cc_list"
-	export CC=$compiler
-fi
-
-if [ -z "$CXX" ]
-then
-	guess_compiler "$cxx_list"
-	export CXX=$compiler
-fi
-
+# Set compiler version
+source $INCLUDEOS_SRC/etc/use_clang_version.sh
 echo -e "\n\n>>> Best guess for compatible compilers: $CXX / $CC"
 
 # Build IncludeOS

--- a/etc/use_clang_version.sh
+++ b/etc/use_clang_version.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# env variables
+: ${INCLUDEOS_SRC:=$HOME/IncludeOS}
+: ${INCLUDEOS_PREFIX:=/usr/local}
+: ${CC:=""}
+: ${CXX:=""}
+
+###########################################################
+# Compiler information:
+############################################################
+# This information can be changed to add/remove suport for a compiler version
+CLANG_VERSION_MIN_REQUIRED="5.0"
+cc_list="clang-7.0 clang-6.0 clang-5.0 clang"
+cxx_list="clang++-7.0 clang++-6.0 clang++-5.0 clang++"
+
+############################################################
+# Support functions:
+############################################################
+# newer_than_minimum takes a specific compiler vesion and checks if it is compatible
+# returns error if it is not compatible
+newer_than_minimum() {
+  local check=${1?You must specify which compiler to check}
+  local CLANG_VERSION=${check: -3}
+  if [[ $CLANG_VERSION < $CLANG_VERSION_MIN_REQUIRED ]]; then
+    return 1
+  fi
+  return 0
+}
+
+check_installed() {
+  local clang=${1?Clang version needs to be set}
+  if [[ $(command -v $clang) ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# guess_compiler takes a list of compilers and returns the first one that is installed
+check_if_in_list() {
+  for compiler in $*; do
+    if check_installed $compiler; then
+      compiler_to_use=$compiler
+      return 0
+    fi
+  done
+  return 1
+}
+
+# containes checks if an item $1 is in the list supplied $2
+contains() {
+  for item in $2; do
+    if [ "$1" == "$item" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+############################################################
+# Main:
+############################################################
+# If CC and CXX is set then a check is performed to see if it compatible
+#
+
+if [ "$CC" != "" ]; then
+  if ! newer_than_minimum "$CC"; then
+    echo Your clang version: $CC is older than minimum required: $CLANG_VERSION_MIN_REQUIRED
+  fi
+  if ! contains "$CC" "$cc_list"; then
+    echo Your clang version: $CC is not in the approved list: "$cc_list"
+  fi
+else
+  check_if_in_list "$cc_list"
+  if [ $? -eq 1 ]; then
+    echo "None of the compatible CC's were installed: $cc_list"
+  else
+    echo Set CC=$compiler_to_use
+    export CC=$compiler_to_use
+  fi
+fi
+
+if [ "$CXX" != "" ]; then
+  if ! newer_than_minimum "$CXX"; then
+    echo Your clang version: $CXX is older than minimum required: $CLANG_VERSION_MIN_REQUIRED
+  fi
+  if ! contains "$CXX" "$cxx_list"; then
+    echo Your clang version: $CXX is not in the approved list: "$cxx_list"
+  fi
+else
+  check_if_in_list "$cxx_list"
+  if [ $? -eq 1 ]; then
+    echo "None of the compatible CC's were installed: $cxx_list"
+  else
+    echo Set CXX=$compiler_to_use
+    export CXX=$compiler_to_use
+  fi
+fi

--- a/install.sh
+++ b/install.sh
@@ -254,10 +254,12 @@ fi
 # INSTALL FINISHED:
 ############################################################
 
+# Set compiler version
+source $INCLUDEOS_SRC/etc/use_clang_version.sh
 printf "\n\n>>> IncludeOS installation Done!\n"
 printf "    %s\n" "To use IncludeOS set env variables for cmake to know your compiler, e.g.:"\
-	   '    export CC="clang-5.0"'\
-	   '    export CXX="clang++-5.0"'\
+	   '    export CC="'$CC'"'\
+	   '    export CXX="'$CXX'"'\
 	   ""\
 	   "Test your installation with ./test.sh"
 


### PR DESCRIPTION
Moved code from `install_from_bundle.sh` to separate script so that it can be called multiple places.

When trying to build latest dev in a docker container I noticed that the chainloader was not built using clang as the rest of the installation process was. Every step now sets the compiler explicitly before getting called so that we know the correct compiler will be used. 

This is still not perfect:
- Installing dependencies still has a separate check for which version to install, this also differs between ubuntu and mac. 
- Do we need both `CLANG_VERSION_MIN_REQUIRED` and the lists of compatible compilers?

