### PR TITLE
CONTRIBUTE.md: Fix link to contribution guidelines

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -2,6 +2,6 @@
 
 You're very welcome to [clone, edit and send pull-request](https://help.github.com/articles/using-pull-requests). 
 
-**Please read the contribution gudelines on the wiki: [Conributing to IncludeOS](https://github.com/hioa-cs/IncludeOS/wiki/Contributing-to-IncludeOS)**
+**Please read the contribution guidelines: [Contributing to IncludeOS](http://includeos.readthedocs.io/en/latest/Contributing-to-IncludeOS.html)**
 
 ## Thank you!


### PR DESCRIPTION
The old link was to a wiki that seems to no longer exist. In README.md,
I found a link to the contribution guidelines on readthedocs, so I
assume that's the one we want to use.