### PR TITLE
mremap: Be honest about not being implemented

### DIFF
--- a/src/musl/mremap.cpp
+++ b/src/musl/mremap.cpp
@@ -3,5 +3,5 @@
 extern "C"
 long syscall_SYS_mremap() {
   STUB("mremap");
-  return 0;
+  return -ENOSYS;
 }


### PR DESCRIPTION
`mremap` used to return `SUCCESS` even though it's not implemented. This
results in issues for users calling `realloc`.

If we instead return `ENOSYS`, musl is able to detect that `mremap`
isn't implemented and fall back to `malloc`/`memcpy`:
https://git.musl-libc.org/cgit/musl/tree/src/malloc/malloc.c#n397

This was originally suggested by @fwsGonzo as a workaround for issues
@andeplane ran into. After having a look at musl, I think it makes sense
to do this officially too.

Note: There are a bunch of other syscalls who also return SUCCESS even
though they're stubbed out. Whether it makes sense to do the same to
them has to be evaluated case by case taking the effect on the rest of
the system into consideration.