### PR TITLE
Net: Adding dhcpd test to time senstive.

### DIFF
--- a/test/net/integration/dhcpd/vm.json
+++ b/test/net/integration/dhcpd/vm.json
@@ -4,5 +4,6 @@
           {"device" : "virtio", "mac" : "c0:01:0a:00:00:2f"},
           {"device" : "virtio", "mac" : "c0:01:0a:00:00:20"},
           {"device" : "virtio", "mac" : "c0:01:0a:00:00:23"}],
-  "mem" : 128
+  "mem" : 128,
+  "time_sensitive" : "True"
 }


### PR DESCRIPTION
Without time sensitive, the test often times out or fails.