### PR TITLE
Fix compile error when using test_ukvm.sh

### DIFF
--- a/src/service_name.cpp
+++ b/src/service_name.cpp
@@ -20,8 +20,8 @@
 extern "C" __attribute__((noreturn))
 void panic(const char* reason);
 
-__attribute__((noreturn))
-extern "C" void abort(){
+extern "C" __attribute__((noreturn))
+void abort(){
   panic("Abort called");
 }
 


### PR DESCRIPTION
Moved `extern "C"` to correct location. Otherwise, when executing `./test_ukvm.sh` the following compile error is generated:
```
includeos/src/service_name.cpp:24:8: error: expected unqualified-id before string constant
 extern "C"
        ^
```