### PR TITLE
Test: More readable stderr output in testrunner

### DIFF
--- a/test/kernel/integration/grub/setup.sh
+++ b/test/kernel/integration/grub/setup.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-sudo apt install -qy grub-pc xorriso
-
+sudo apt-get -q install -qy grub-pc xorriso

--- a/vmrunner/prettify.py
+++ b/vmrunner/prettify.py
@@ -91,7 +91,7 @@ class color:
 
     @staticmethod
     def DATA(string):
-        return color.C_GRAY + string + color.C_ENDC + "\n"
+        return string + "\n"
 
     @staticmethod
     def HEADER(string):


### PR DESCRIPTION
Gone are the days of light gray on white background. 
By just using standard `print` most terminals invert the output to black/white based on their own color scheme. 