### PR TITLE
net: Clear headers in a more standard way 

### DIFF
--- a/api/net/ip4/packet_ip4.hpp
+++ b/api/net/ip4/packet_ip4.hpp
@@ -223,7 +223,7 @@ namespace net {
     void init(Protocol proto = Protocol::HOPOPT) noexcept {
       Expects(size() == 0);
       auto& hdr = ip_header();
-      std::memset(&ip_header(), 0, sizeof(ip4::Header));
+      hdr = {};
       hdr.version_ihl    = 0x45;
       //hdr.ds_ecn         = 0;
       //hdr.id             = 0;

--- a/api/net/ip6/packet_ip6.hpp
+++ b/api/net/ip6/packet_ip6.hpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -156,7 +156,7 @@ namespace net
     void init(Protocol proto = Protocol::HOPOPT) noexcept {
       Expects(size() == 0);
       auto& hdr = ip6_header();
-      std::memset(&ip6_header(), 0, IP6_HEADER_LEN);
+      hdr = {};
       hdr.ver_tc_fl = 0x0060;
       hdr.next_header    = static_cast<uint8_t>(proto);
       hdr.payload_length = 0x0;

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,0 +1,30 @@
+## Userspace Linux platform
+
+### Installation
+
+* Get a modern compiler
+    * gcc 7.3 or gcc 8.0
+    * clang-6 or clang-7 from SVN trunk
+* Install the CMake project
+    * mkdir -p build && cd build
+    * cmake ..
+    * make -j32 install
+* Install Botan from source, if you need it
+    * git clone ...
+    * ./configure --disable-shared
+    * make -j32
+    * sudo make install
+
+### Options
+
+* Use EXTRA_LIBS in CMake project to add your own libraries
+* CMake options:
+    * Some options require enabling it in both the Linux platform CMake project and the service code CMake project for it to fully work.
+    * CUSTOM_BOTAN: Use your local Botan for Botan TLS (enable both)
+    * ENABLE_LTO: Enable ThinLTO. Only works with clang. (enable both)
+    * GPROF: Enable profiling with gprof (enable both)
+    * SANITIZE: Enable asan and ub sanitizers (enable both)
+
+### Testing it
+
+Run one of the Linux platform tests in /test/linux. If you get the error `RTNETLINK answers: File exists`, flush the interace with `sudo ip addr flush dev bridge43`. Where bridge43 is the interface name.

--- a/src/service_name.cpp
+++ b/src/service_name.cpp
@@ -20,10 +20,12 @@
 extern "C" __attribute__((noreturn))
 void panic(const char* reason);
 
+#ifndef __linux__
 extern "C" __attribute__((noreturn))
 void abort(){
   panic("Abort called");
 }
+#endif
 
 const char* service_name__ = SERVICE_NAME;
 const char* service_binary_name__ = SERVICE;


### PR DESCRIPTION
This PR contains a change that replaces memset with copy assignment when initializing Packet headers. It's a more standard approach.

Also, build linux platform with GCC and add README.