### PR TITLE
net/icmp6: silencing the output from ipv6 command

### DIFF
--- a/test/net/integration/icmp6/setup.sh
+++ b/test/net/integration/icmp6/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
+sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 &> /dev/null


### PR DESCRIPTION
will output errors if there are any, otherwise quiet.