### PR TITLE
Test dhcpd: Add flushing of arp cache for addresses used in test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -11,7 +11,7 @@ The following IP addresses are used by the services in the test folder. Make sur
 - bufstore: No IP
 - configure: 10.0.0.60, 10.0.0.61, 10.0.0.62
 - dhclient: Time_sensitive, leave for now
-- dhcpd: 10.0.0.1, 10.0.0.10, 10.0.0.11, 10.0.0.12 - Is 10.0.0.1 a problem?
+- dhcpd: 10.0.0.9, 10.0.0.10, 10.0.0.11, 10.0.0.12
 - dhcpd_dhclient_linux: leave for now
 - dns: 10.0.0.48
 - gateway: 10.0.1.1, 10.0.1.10, 10.0.2.1, 10.0.2.10

--- a/test/net/integration/dhcpd/service.cpp
+++ b/test/net/integration/dhcpd/service.cpp
@@ -30,7 +30,7 @@ void Service::start(const std::string&)
   // Server
 
   auto& inet = Inet::ifconfig<0>(
-    { 10,0,0,1 },     // IP
+    { 10,0,0,9 },     // IP
     { 255,255,255,0 },  // Netmask
     { 10,0,0,1 },       // Gateway
     { 8,8,8,8 });       // DNS

--- a/test/net/integration/dhcpd/setup.sh
+++ b/test/net/integration/dhcpd/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo arp -d 10.0.0.10 2>&1 > /dev/null
+sudo arp -d 10.0.0.11 2>&1 > /dev/null
+sudo arp -d 10.0.0.12 2>&1 > /dev/null


### PR DESCRIPTION
An attempt to increase the stability of this test. Locally on my mac the arp cache was causing all sorts of problems. 