### PR TITLE
tcp: Remove on_packet_dropped, on_rtx_timeout

### DIFF
--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -136,30 +136,6 @@ public:
    */
   inline Connection&            on_write(WriteCallback callback);
 
-  /** Called with the packet that got dropped and the reason why. */
-  using PacketDroppedCallback   = delegate<void(const Packet&, Drop_reason)>;
-  /**
-   * @brief      Event when a connection has dropped a packet.
-   *             Useful for debugging/track counting.
-   *
-   * @param[in]  callback  The callback
-   *
-   * @return     This connection
-   */
-  inline Connection&            on_packet_dropped(PacketDroppedCallback callback);
-
-  /** Called with the number of simultaneous retransmit attempts and the current Round trip timeout in milliseconds. */
-  using RtxTimeoutCallback      = delegate<void(size_t no_attempts, std::chrono::milliseconds rto)>;
-  /**
-   * @brief      Event when the connections retransmit timer has expired.
-   *             Useful for debugging/track counting.
-   *
-   * @param[in]  callback  The callback
-   *
-   * @return     This connection
-   */
-  inline Connection&            on_rtx_timeout(RtxTimeoutCallback);
-
   /**
    * @brief      Only change the on_read callback without touching the buffer.
    *             Only useful in special cases. Assumes on_read has been called.
@@ -169,7 +145,6 @@ public:
    * @return     This connection
    */
   inline Connection&            set_on_read_callback(ReadCallback callback);
-
 
   /**
    * @brief      Async write of a shared buffer with a length.
@@ -645,8 +620,6 @@ private:
   /** Callbacks */
   ConnectCallback         on_connect_;
   DisconnectCallback      on_disconnect_;
-  PacketDroppedCallback   on_packet_dropped_;
-  RtxTimeoutCallback      on_rtx_timeout_;
   CloseCallback           on_close_;
 
   /** Retransmission timer */
@@ -807,12 +780,6 @@ private:
 
   void signal_disconnect(Disconnect::Reason&& reason)
   { on_disconnect_(retrieve_shared(), Disconnect{reason}); }
-
-  void signal_packet_dropped(const Packet& packet, Drop_reason reason)
-  { if(on_packet_dropped_) on_packet_dropped_(packet, reason); }
-
-  void signal_rtx_timeout()
-  { if(on_rtx_timeout_) on_rtx_timeout_(rtx_attempt_+1, rttm.rto_ms()); }
 
   /*
     Drop a packet. Used for debug/callback.

--- a/api/net/tcp/connection.inc
+++ b/api/net/tcp/connection.inc
@@ -24,16 +24,6 @@ inline Connection& Connection::on_write(WriteCallback cb) {
   return *this;
 }
 
-inline Connection& Connection::on_packet_dropped(PacketDroppedCallback callback) {
-  on_packet_dropped_ = callback;
-  return *this;
-}
-
-inline Connection& Connection::on_rtx_timeout(RtxTimeoutCallback cb) {
-  on_rtx_timeout_ = cb;
-  return *this;
-}
-
 inline Connection& Connection::on_close(CloseCallback cb) {
   on_close_ = cb;
   return *this;

--- a/src/net/tcp/connection.cpp
+++ b/src/net/tcp/connection.cpp
@@ -113,8 +113,6 @@ void Connection::reset_callbacks()
   on_disconnect_ = {this, &Connection::default_on_disconnect};
   on_connect_.reset();
   writeq.on_write(nullptr);
-  on_packet_dropped_.reset();
-  on_rtx_timeout_.reset();
   on_close_.reset();
 
   if(read_request)
@@ -950,7 +948,6 @@ void Connection::rtx_timeout() {
   debug("<Connection::RTX@timeout> Timed out (RTO %lld ms). FS: %u\n",
     rttm.rto_ms().count(), flight_size());
 
-  signal_rtx_timeout();
   // experimental
   if(rto_limit_reached()) {
     debug("<TCP::Connection::rtx_timeout> RTX attempt limit reached, closing.\n");
@@ -1093,8 +1090,6 @@ void Connection::clean_up() {
 
   on_connect_.reset();
   on_disconnect_.reset();
-  on_packet_dropped_.reset();
-  on_rtx_timeout_.reset();
   on_close_.reset();
   if(read_request)
     read_request->callback.reset();
@@ -1275,7 +1270,6 @@ bool Connection::uses_SACK() const noexcept
 
 void Connection::drop(const Packet& packet, Drop_reason reason)
 {
-  signal_packet_dropped(packet, reason);
   host_.drop(packet);
 }
 


### PR DESCRIPTION
- Neither referenced by anybody
- on_packet_dropped can already be subscribed on at the TCP level (just needs an interface)
- I don`t really understand why on_rtx_timeout exists
