### PR TITLE
Decouple bufferstore from public APIs

### DIFF
--- a/api/hw/nic.hpp
+++ b/api/hw/nic.hpp
@@ -18,7 +18,6 @@
 #ifndef HW_NIC_HPP
 #define HW_NIC_HPP
 
-#include "../net/buffer_store.hpp"
 #include "mac_addr.hpp"
 #include <net/inet_common.hpp>
 
@@ -66,17 +65,6 @@ namespace hw {
     virtual void set_arp_upstream(upstream handler) = 0;
     virtual void set_vlan_upstream(upstream handler) = 0;
 
-    net::BufferStore& bufstore() noexcept
-    { return bufstore_; }
-
-    /** Number of free buffers in the BufferStore **/
-    size_t buffers_available()
-    { return bufstore_.available(); }
-
-    /** Number of total buffers in the BufferStore **/
-    size_t buffers_total()
-    { return bufstore_.total_buffers(); }
-
     /** Number of bytes in a frame needed by the link layer **/
     virtual size_t frame_offset_link() const noexcept = 0;
 
@@ -107,7 +95,7 @@ namespace hw {
 
     virtual ~Nic() {}
 
-    /** Trigger a read from buffers, pusing any packets up the stack */
+    /** Check for completed rx and pass rx packets up the stack */
     virtual void poll() = 0;
 
     /** Overridable MTU detection function per-network **/
@@ -119,8 +107,7 @@ namespace hw {
      *
      *  Constructed by the actual Nic Driver
      */
-    Nic(net::BufferStore& bufstore)
-      : bufstore_{bufstore}
+    Nic()
     {
       static int id_counter = 0;
       N = id_counter++;
@@ -147,7 +134,6 @@ namespace hw {
     }
 
   private:
-    net::BufferStore& bufstore_;
     int N;
     friend class Devices;
   };

--- a/api/net/inet.hpp
+++ b/api/net/inet.hpp
@@ -310,13 +310,6 @@ namespace net {
       return nic_.transmit_queue_available();
     }
 
-    size_t buffers_available() {
-      return nic_.buffers_available();
-    }
-    size_t buffers_total() {
-      return nic_.buffers_total();
-    }
-
     void force_start_send_queues();
 
     void move_to_this_cpu();

--- a/api/net/link_layer.hpp
+++ b/api/net/link_layer.hpp
@@ -30,7 +30,7 @@ public:
   using upstream    = hw::Nic::upstream;
   using downstream_link  = hw::Nic::downstream;
 public:
-  explicit Link_layer(Protocol&& protocol, BufferStore& bufstore);
+  explicit Link_layer(Protocol&& protocol);
 
   std::string device_name() const override {
     return link_.link_name();
@@ -88,8 +88,8 @@ private:
 };
 
 template <class Protocol>
-Link_layer<Protocol>::Link_layer(Protocol&& protocol, BufferStore& bufstore)
-  : hw::Nic(bufstore),
+Link_layer<Protocol>::Link_layer(Protocol&& protocol)
+  : hw::Nic(),
     link_{std::forward<Protocol>(protocol)}
 {
 }

--- a/api/net/vif.hpp
+++ b/api/net/vif.hpp
@@ -32,7 +32,7 @@ public:
   using Linklayer  = Link_layer<Protocol>;
 
   Vif(hw::Nic& link, const int id)
-    : Linklayer(Protocol{{this, &Vif<Protocol>::transmit}, link.mac(), id}, link.bufstore()),
+    : Linklayer(Protocol{{this, &Vif<Protocol>::transmit}, link.mac(), id}),
       link_{link}, id_{id}, phys_down_{link_.create_physical_downstream()}
   {}
 

--- a/cmake/linux.service.cmake
+++ b/cmake/linux.service.cmake
@@ -93,11 +93,7 @@ if (ENABLE_LTO OR USE_LLD)
 endif()
 
 if (STRIP_BINARY)
-  add_custom_target(
-    strip_binary ALL
-    COMMAND strip --strip-all ${BINARY}
-    DEPENDS service
-  )
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s")
 endif()
 
 # write binary name to file

--- a/linux/src/drivers/usernet.cpp
+++ b/linux/src/drivers/usernet.cpp
@@ -4,7 +4,7 @@
 constexpr MAC::Addr UserNet::MAC_ADDRESS;
 
 UserNet::UserNet(const uint16_t mtu)
-  : Link(Link_protocol{{this, &UserNet::transmit}, mac()}, buffer_store),
+  : Link(Link_protocol{{this, &UserNet::transmit}, mac()}),
     mtu_value(mtu), buffer_store(256u, 128 + mtu) {}
 
 UserNet& UserNet::create(const uint16_t mtu)
@@ -78,4 +78,3 @@ net::Packet_ptr UserNet::create_packet(int link_offset)
 
   return net::Packet_ptr(ptr);
 }
-// wrap buffer-length (that should belong to bufferstore) in packet wrapper

--- a/linux/src/drivers/usernet.hpp
+++ b/linux/src/drivers/usernet.hpp
@@ -47,9 +47,6 @@ public:
 
   net::Packet_ptr create_packet(int) override;
 
-  size_t frame_offset_device() override
-  { return sizeof(driver_hdr); };
-
   net::downstream create_physical_downstream() override
   { return {this, &UserNet::transmit}; }
 

--- a/src/drivers/e1000.cpp
+++ b/src/drivers/e1000.cpp
@@ -65,7 +65,7 @@ static inline uint16_t buffer_size_for_mtu(const uint16_t mtu)
 #define NUM_PACKET_BUFFERS (NUM_TX_DESC + NUM_RX_DESC + NUM_TX_QUEUE + 8)
 
 e1000::e1000(hw::PCI_Device& d, uint16_t mtu) :
-    Link(Link_protocol{{this, &e1000::transmit}, mac()}, bufstore_),
+    Link(Link_protocol{{this, &e1000::transmit}, mac()}),
     m_pcidev(d), m_mtu(mtu), bufstore_{NUM_PACKET_BUFFERS, buffer_size_for_mtu(mtu)}
 {
   static_assert((NUM_RX_DESC * sizeof(rx_desc)) % 128 == 0, "Ring length must be 128-byte aligned");

--- a/src/drivers/e1000.hpp
+++ b/src/drivers/e1000.hpp
@@ -67,6 +67,8 @@ public:
     return free_transmit_descr() + NUM_TX_QUEUE - sendq_size;
   }
 
+  auto& bufstore() noexcept { return bufstore_; }
+
   void flush() override;
 
   void deactivate() override;

--- a/src/drivers/solo5net.cpp
+++ b/src/drivers/solo5net.cpp
@@ -15,10 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define PRINT_INFO
-#define DEBUG // Allow debuging
-#define DEBUG2
-
 #include "solo5net.hpp"
 #include <net/packet.hpp>
 #include <hw/pci.hpp>
@@ -34,7 +30,7 @@ using namespace net;
 const char* Solo5Net::driver_name() const { return "Solo5Net"; }
 
 Solo5Net::Solo5Net()
-  : Link(Link_protocol{{this, &Solo5Net::transmit}, mac()}, bufstore_),
+  : Link(Link_protocol{{this, &Solo5Net::transmit}, mac()}),
     packets_rx_{Statman::get().create(Stat::UINT64, device_name() + ".packets_rx").get_uint64()},
     packets_tx_{Statman::get().create(Stat::UINT64, device_name() + ".packets_tx").get_uint64()},
     bufstore_{NUM_BUFFERS, 2048u} // don't change this

--- a/src/drivers/solo5net.hpp
+++ b/src/drivers/solo5net.hpp
@@ -70,12 +70,9 @@ public:
     return 1000; // any big random number for now
   }
 
-  /** Number of incoming packets waiting in the RX-queue */
-  size_t receive_queue_waiting() {
-    return 0;
-  }
-
   net::Packet_ptr create_packet(int) override;
+
+  auto& bufstore() noexcept { return bufstore_; }
 
   void move_to_this_cpu() override {};
 

--- a/src/drivers/virtionet.cpp
+++ b/src/drivers/virtionet.cpp
@@ -62,7 +62,7 @@ void VirtioNet::get_config() {
 
 VirtioNet::VirtioNet(hw::PCI_Device& d, const uint16_t /*mtu*/)
   : Virtio(d),
-    Link(Link_protocol{{this, &VirtioNet::transmit}, mac()}, bufstore_),
+    Link(Link_protocol{{this, &VirtioNet::transmit}, mac()}),
     m_pcidev(d),
     bufstore_{VNET_TOT_BUFFERS(), 2048 /* half-page buffers */},
     packets_rx_{Statman::get().create(Stat::UINT64,

--- a/src/drivers/virtionet.hpp
+++ b/src/drivers/virtionet.hpp
@@ -156,6 +156,8 @@ public:
 
   bool link_up() const noexcept;
 
+  auto& bufstore() noexcept { return bufstore_; }
+
   void deactivate() override;
 
   void flush() override {

--- a/src/drivers/vmxnet3.cpp
+++ b/src/drivers/vmxnet3.cpp
@@ -117,7 +117,7 @@ static inline uint16_t buffer_size_for_mtu(const uint16_t mtu)
 }
 
 vmxnet3::vmxnet3(hw::PCI_Device& d, const uint16_t mtu) :
-    Link(Link_protocol{{this, &vmxnet3::transmit}, mac()}, bufstore_),
+    Link(Link_protocol{{this, &vmxnet3::transmit}, mac()}),
     m_pcidev(d), m_mtu(mtu), bufstore_{1024, buffer_size_for_mtu(mtu)}
 {
   INFO("vmxnet3", "Driver initializing (rev=%#x)", d.rev_id());

--- a/src/drivers/vmxnet3.hpp
+++ b/src/drivers/vmxnet3.hpp
@@ -70,6 +70,8 @@ public:
     return tx_tokens_free();
   }
 
+  auto& bufstore() noexcept { return bufstore_; }
+
   void flush() override;
 
   void deactivate() override;

--- a/test/lest_util/nic_mock.hpp
+++ b/test/lest_util/nic_mock.hpp
@@ -80,7 +80,7 @@ public:
 
   net::Packet_ptr create_packet(int) override
   {
-    auto buffer = bufstore().get_buffer();
+    auto buffer = bufstore_.get_buffer();
     auto* ptr = (net::Packet*) buffer.addr;
 
     new (ptr) net::Packet(frame_offs_link_,
@@ -115,7 +115,7 @@ public:
   //
 
   ~Nic_mock() {}
-  Nic_mock() : Nic(bufstore_), bufstore_{256u, 2048} {}
+  Nic_mock() : Nic(), bufstore_{256u, 2048} {}
 
   // Public data members (ahem)
   MAC::Addr mac_ = {0xc0,0x00,0x01,0x70,0x00,0x01};

--- a/test/linux/websockets/run.sh
+++ b/test/linux/websockets/run.sh
@@ -35,4 +35,5 @@ make_linux
 make_service
 
 #sudo mknod /dev/net/tap c 10 200
-sudo ./build/websockets
+BINARY=build/"`cat build/binary.txt`"
+sudo $BINARY

--- a/test/net/integration/tcp/service.cpp
+++ b/test/net/integration/tcp/service.cpp
@@ -62,15 +62,6 @@ void FINISH_TEST() {
       INFO("TEST", "Verify release of resources");
       CHECKSERT(stack().tcp().active_connections() == 0,
         "No (0) active connections");
-      INFO("Buffers", "%u avail / %u total",
-            stack().buffers_available(),
-            stack().buffers_total());
-      // unfortunately we can't know just how many buffers SHOULD be
-      // available, because drivers take some buffers, but there should
-      // be at least half the buffers left
-      auto total = stack().buffers_total();
-      CHECKSERT(stack().buffers_available() >= total / 2,
-                "Free buffers (%u available)", total);
       printf("# TEST SUCCESS #\n");
     });
 }
@@ -165,7 +156,6 @@ void Service::start()
     64,                                                     // Prefix6
     {  0xfe80,  0,  0, 0, 0xe823, 0xfcff, 0xfef4, 0x83e7 }  // Gateway6
   );
-  INFO("Buffers available", "%u", inet.buffers_available());
 
   auto& tcp = inet.tcp();
   // reduce test duration


### PR DESCRIPTION
The public APIs never used the bufferstore, and the drivers tended to accidentally use a virtual call to its own bufferstore.