### PR TITLE
Updating NaCl (new dynamic implementation)

### DIFF
--- a/cmake/nacl.cmake
+++ b/cmake/nacl.cmake
@@ -21,24 +21,10 @@ set(NACL_SRC
   ${NACL_DIR}/cpp_template.mustache
   ${NACL_DIR}/shared.py
   )
-set(NACL_SUBTRANS_SRC
-  ${NACL_DIR}/subtranspilers/__init__.py
-  ${NACL_DIR}/subtranspilers/function_transpiler.py
-  ${NACL_DIR}/subtranspilers/value_transpiler.py
-  )
-set(NACL_TYPEPROC_SRC
-  ${NACL_DIR}/type_processors/__init__.py
-  ${NACL_DIR}/type_processors/conntrack.py
-  ${NACL_DIR}/type_processors/function.py
-  ${NACL_DIR}/type_processors/gateway.py
-  ${NACL_DIR}/type_processors/iface.py
-  ${NACL_DIR}/type_processors/load_balancer.py
-  ${NACL_DIR}/type_processors/syslog.py
-  )
 set(NACL_BIN ${CMAKE_CURRENT_BINARY_DIR}/nacl_bin/src/nacl_bin)
 
 install(PROGRAMS ${NACL_EXE} DESTINATION includeos/nacl)
 install(FILES ${NACL_SRC} DESTINATION includeos/nacl)
-install(FILES ${NACL_SUBTRANS_SRC} DESTINATION includeos/nacl/subtranspilers)
-install(FILES ${NACL_TYPEPROC_SRC} DESTINATION includeos/nacl/type_processors)
+install(DIRECTORY ${NACL_DIR}/subtranspilers DESTINATION includeos/nacl)
+install(DIRECTORY ${NACL_DIR}/type_processors DESTINATION includeos/nacl)
 install(DIRECTORY ${NACL_BIN}/ DESTINATION includeos/nacl)

--- a/cmake/nacl.cmake
+++ b/cmake/nacl.cmake
@@ -18,13 +18,27 @@ ExternalProject_Add(nacl_bin
 set(NACL_DIR ${INCLUDEOS_ROOT}/NaCl)
 set(NACL_EXE ${NACL_DIR}/NaCl.py)
 set(NACL_SRC
-  ${NACL_DIR}/cpp_transpile_function.py
   ${NACL_DIR}/cpp_template.mustache
-  ${NACL_DIR}/cpp_resolve_values.py
-  ${NACL_DIR}/shared_constants.py
+  ${NACL_DIR}/shared.py
+  )
+set(NACL_SUBTRANS_SRC
+  ${NACL_DIR}/subtranspilers/__init__.py
+  ${NACL_DIR}/subtranspilers/function_transpiler.py
+  ${NACL_DIR}/subtranspilers/value_transpiler.py
+  )
+set(NACL_TYPEPROC_SRC
+  ${NACL_DIR}/type_processors/__init__.py
+  ${NACL_DIR}/type_processors/conntrack.py
+  ${NACL_DIR}/type_processors/function.py
+  ${NACL_DIR}/type_processors/gateway.py
+  ${NACL_DIR}/type_processors/iface.py
+  ${NACL_DIR}/type_processors/load_balancer.py
+  ${NACL_DIR}/type_processors/syslog.py
   )
 set(NACL_BIN ${CMAKE_CURRENT_BINARY_DIR}/nacl_bin/src/nacl_bin)
 
 install(PROGRAMS ${NACL_EXE} DESTINATION includeos/nacl)
 install(FILES ${NACL_SRC} DESTINATION includeos/nacl)
+install(FILES ${NACL_SUBTRANS_SRC} DESTINATION includeos/nacl/subtranspilers)
+install(FILES ${NACL_TYPEPROC_SRC} DESTINATION includeos/nacl/type_processors)
 install(DIRECTORY ${NACL_BIN}/ DESTINATION includeos/nacl)


### PR DESCRIPTION
In NaCl.py we now create a NaCl_state object containing all the state (dictionaries, lists).
The subtranspilers folder and type_processors folder are scanned and each file's init function is called from NaCl.py's main function.
After the registration of the type_processors and subtranspilers, the NaCl file given as input to NaCl.py is visited (antlr), and all identified NaCl elements are registered in the NaCl_state object's elements dictionary.
NaCl.py's handle_input function is then called, which loops through all the registered elements and call each element's process() method, which transpiles and registers the element's values in the NaCl_state object's pystache_data dictionary. This dictionary is then given as input to the cpp_template.mustache file, which contains the template for the C++ file that is the output of this NaCl transpiler program.

Notes:

Each type_processor represents a NaCl type that can be created in a NaCl file (Iface, Load_balancer, Gateway etc.)
The subtranpspilers folder contains one subtranspiler that can transpile a NaCl value into C++ (name of an object, constant and more), and one subtranspiler that can transpile a NaCl function (Filter or Nat). These subtranspilers are called by the type_processors that need to transpile a value (every type_processor needs to do that in the end) or a function (the function type_processor).