### PR TITLE
Delegate changes

### DIFF
--- a/api/net/tcp/stream.hpp
+++ b/api/net/tcp/stream.hpp
@@ -101,7 +101,6 @@ namespace net::tcp
     void close() override
     {
       auto onclose = std::move(this->m_on_close);
-      this->m_on_close.reset();
       m_tcp->reset_callbacks();
       m_tcp->close();
       if (onclose) onclose();

--- a/api/util/delegate.hpp
+++ b/api/util/delegate.hpp
@@ -279,7 +279,7 @@ public:
 		copy_ptr_{ other.copy_ptr_ },
 		destructor_ptr_{ other.destructor_ptr_ }
 	{
-		other.destructor_ptr_ = [](storage_t&) -> void {};
+		other.destructor_ptr_ = nullptr;
 	}
 
 	inplace& operator= (const inplace& other)
@@ -311,7 +311,7 @@ public:
 			copy_ptr_ = other.copy_ptr_;
 			destructor_ptr_ = other.destructor_ptr_;
 
-			other.destructor_ptr_ = [](storage_t&) -> void {};
+			other.destructor_ptr_ = nullptr;
 		}
 		return *this;
 	}

--- a/test/util/unit/delegate.cpp
+++ b/test/util/unit/delegate.cpp
@@ -223,6 +223,13 @@ CASE("A delegate can be moved")
 
 	size_t ret = del_b();
 	EXPECT(ret == v.size());
+  EXPECT_NOT(del_a);
+
+  user_class usr(1);
+  auto usr_del = usr.get_del();
+  EXPECT(usr_del);
+  auto usr_del2 = std::move(usr_del);
+  EXPECT_NOT(usr_del);
 }
 
 CASE("A delegate can be constructed with a class member function pointer")


### PR DESCRIPTION
Checking if this breaks anything. Not sure if it has any side effects to make the destructor_ptr to nullptr, since the destructor of the inplace delegate checks if it exists before calling it. This will kinda fix #1821, but this is only for the inplace type. Could be that it's necessary to create custom move construct & assignment for the other types as well.