### PR TITLE
uplink: Install headers and make instance retreivable from service

### DIFF
--- a/lib/uplink/CMakeLists.txt
+++ b/lib/uplink/CMakeLists.txt
@@ -23,7 +23,14 @@ set(SOURCES
   ws_uplink.cpp
   register_plugin.cpp
   config.cpp
+  uplink.cpp
   )
+
+# Install headers
+install(DIRECTORY . DESTINATION includeos/include/uplink
+  FILES_MATCHING PATTERN "*.hpp"
+  PATTERN "starbase" EXCLUDE
+  PATTERN "build" EXCLUDE)
 
 # Uplink library
 add_library(${LIBRARY_NAME} STATIC ${SOURCES})

--- a/lib/uplink/config.hpp
+++ b/lib/uplink/config.hpp
@@ -20,7 +20,7 @@
 #define UPLINK_CONFIG_HPP
 
 #include <string>
-#include <net/ip4/ip4.hpp>
+#include <net/inet>
 #include <uri>
 
 namespace uplink {

--- a/lib/uplink/log.hpp
+++ b/lib/uplink/log.hpp
@@ -21,8 +21,8 @@
 
 #include <util/fixed_vector.hpp>
 #include <kernel/events.hpp>
+#include <kernel/os.hpp>
 #include <common>
-#include <os>
 
 namespace uplink {
 

--- a/lib/uplink/uplink.cpp
+++ b/lib/uplink/uplink.cpp
@@ -1,7 +1,6 @@
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
-// Copyright 2017 Oslo and Akershus University College of Applied Sciences
-// and Alfred Bratterud
+// Copyright 2018 IncludeOS AS, Oslo, Norway
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,22 +16,28 @@
 
 #include "uplink.hpp"
 #include "common.hpp"
-#include <kernel/os.hpp>
 
-static void setup_uplink_plugin()
-{
-  try
-  {
-    uplink::get();
-  }
-  catch(const std::exception& e)
-  {
-    MYINFO("Rebooting");
-    OS::reboot();
-  }
-}
+namespace uplink {
 
-__attribute__((constructor))
-void register_plugin_uplink(){
-  OS::register_plugin(setup_uplink_plugin, "Uplink");
+  static WS_uplink setup_uplink()
+  {
+    MYINFO("Setting up WS uplink");
+    try
+    {
+      auto config = Config::read();
+      return WS_uplink{std::move(config)};
+    }
+    catch(const std::exception& e)
+    {
+      MYINFO("Uplink initialization failed: %s ", e.what());
+      throw;
+    }
+  }
+
+  WS_uplink& get()
+  {
+    static WS_uplink instance{setup_uplink()};
+    return instance;
+  }
+
 }

--- a/lib/uplink/uplink.hpp
+++ b/lib/uplink/uplink.hpp
@@ -1,7 +1,6 @@
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
-// Copyright 2017 Oslo and Akershus University College of Applied Sciences
-// and Alfred Bratterud
+// Copyright 2018 IncludeOS AS, Oslo, Norway
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,24 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "uplink.hpp"
-#include "common.hpp"
-#include <kernel/os.hpp>
+#pragma once
 
-static void setup_uplink_plugin()
-{
-  try
-  {
-    uplink::get();
-  }
-  catch(const std::exception& e)
-  {
-    MYINFO("Rebooting");
-    OS::reboot();
-  }
-}
+#include "ws_uplink.hpp"
 
-__attribute__((constructor))
-void register_plugin_uplink(){
-  OS::register_plugin(setup_uplink_plugin, "Uplink");
-}
+namespace uplink {
+
+  WS_uplink& get();
+
+} // < namespace uplink


### PR DESCRIPTION
```
#include <uplink/uplink.hpp>

void Service::start() {
  auto& link = uplink::get();
}
```

Works together with plugin (only instantiated once).