### PR TITLE
Serialize statman, preserving stats

### DIFF
--- a/api/net/packet.hpp
+++ b/api/net/packet.hpp
@@ -190,8 +190,19 @@ namespace net
     Byte buf_[0];
   }; //< class Packet
 
-  void Packet::chain(Packet_ptr p) noexcept
+  void Packet::chain(Packet_ptr pkt) noexcept
   {
+    assert(pkt.get() != nullptr);
+    assert(pkt.get() != this);
+
+    auto* p = this;
+    while (p->chain_ != nullptr) {
+      p = p->chain_.get();
+      assert(pkt.get() != p);
+    }
+    p->chain_ = std::move(pkt);
+
+    /*
     if (!chain_) {
       chain_ = std::move(p);
       last_ = chain_.get();
@@ -201,6 +212,7 @@ namespace net
       last_ = ptr->last_in_chain() ? ptr->last_in_chain() : ptr;
       assert(last_);
     }
+    */
   }
 
   int Packet::chain_length() const noexcept

--- a/api/util/statman.hpp
+++ b/api/util/statman.hpp
@@ -35,6 +35,10 @@ struct Stats_exception : public std::runtime_error {
   using runtime_error::runtime_error;
 };
 
+namespace liu {
+  struct Storage; struct Restore;
+}
+
 class Stat {
 public:
   static const int MAX_NAME_LEN = 46;
@@ -73,6 +77,8 @@ public:
 
   ///
   uint64_t& get_uint64();
+
+  std::string to_string() const;
 
 private:
   union {
@@ -169,6 +175,8 @@ public:
   Stat* begin() noexcept { return (Stat*) cbegin(); }
   Stat* end() noexcept { return (Stat*) cend(); }
 
+  void store(uint32_t id, liu::Storage&);
+  void restore(liu::Restore&);
 
   void init(const uintptr_t location, const Size_type size);
 

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -142,6 +142,20 @@ namespace uplink {
     store.add_string(0, update_hash_);
     // nanos timestamp of when update begins
     store.add<uint64_t> (1, OS::nanos_since_boot());
+    // statman
+    auto& stm = Statman::get();
+    // increment number of updates performed
+    try {
+      ++stm.get_by_name("system.updates");
+    }
+    catch (std::exception e)
+    {
+      ++stm.create(Stat::UINT32, "system.updates");
+    }
+    // store all stats
+    stm.store(2, store);
+    // go to end
+    store.put_marker(100);
   }
 
   void WS_uplink::restore(liu::Restore& store)
@@ -152,6 +166,13 @@ namespace uplink {
     // calculate update cycles taken
     uint64_t prev_nanos = store.as_type<uint64_t> (); store.go_next();
     this->update_time_taken = OS::nanos_since_boot() - prev_nanos;
+    // statman
+    if (!store.is_end())
+    {
+      Statman::get().restore(store);
+    }
+    // done marker
+    store.pop_marker(100);
 
     INFO2("Update took %.3f millis", this->update_time_taken / 1.0e6);
   }

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -38,7 +38,7 @@ int main(int, char** args)
 #endif
 
   // initialize Linux platform
-  OS::start(args[0], 0u);
+  OS::start(args[0]);
 
   // calls Service::start
   OS::post_start();

--- a/linux/src/os.cpp
+++ b/linux/src/os.cpp
@@ -81,7 +81,7 @@ static void begin_timer(std::chrono::nanoseconds usec)
 static void stop_timers() {}
 
 #include <statman>
-void OS::start(char* cmdline, uintptr_t)
+void OS::start(const char* cmdline)
 {
   __libc_initialized = true;
   // statman

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(${INCLUDEOS_ROOT}/mod/)
 include_directories(${INCLUDEOS_ROOT}/mod/GSL/)
 include_directories(${INCLUDEOS_ROOT}/mod/rapidjson/include)
 include_directories(${INCLUDEOS_ROOT}/mod/uzlib/src) # tinf.h for tar
+include_directories(${INCLUDEOS_ROOT}/lib/LiveUpdate)
 include_directories(${BOTAN_DIR})
 include_directories(${OPENSSL_DIR}/include)
 if(${ARCH} STREQUAL "x86_64")
@@ -35,7 +36,8 @@ set(OS_OBJECTS
   kernel/fiber.cpp kernel/tls.cpp kernel/profile.cpp kernel/scoped_profiler.cpp
   kernel/terminal.cpp kernel/timers.cpp kernel/rtc.cpp kernel/rng.cpp
   kernel/system_log.cpp kernel/rdrand.cpp kernel/solo5_manager.cpp
-  util/memstream.c util/async.cpp util/statman.cpp util/logger.cpp util/sha1.cpp
+  util/memstream.c util/async.cpp util/statman.cpp "util/statman_liu.cpp"
+  util/logger.cpp util/sha1.cpp
   util/syslog_facility.cpp util/syslogd.cpp util/uri.cpp util/percent_encoding.cpp
   util/tar.cpp util/path_to_regex.cpp util/config.cpp util/autoconf.cpp util/crc32.cpp
   crt/c_abi.c crt/ctype_b_loc.c crt/ctype_tolower_loc.c crt/string.c

--- a/src/util/statman.cpp
+++ b/src/util/statman.cpp
@@ -66,6 +66,15 @@ uint64_t& Stat::get_uint64() {
   return ui64;
 }
 
+std::string Stat::to_string() const {
+  switch (this->type_) {
+    case UINT32: return std::to_string(ui32);
+    case UINT64: return std::to_string(ui64);
+    case FLOAT:  return std::to_string(f);
+    default:     return "Invalid Stat_type";
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/util/statman_liu.cpp
+++ b/src/util/statman_liu.cpp
@@ -1,0 +1,30 @@
+#include <statman>
+#include <liveupdate.hpp>
+
+void Statman::store(uint32_t id, liu::Storage& store)
+{
+  store.add_buffer(id, this->cbegin(), this->num_bytes());
+}
+void Statman::restore(liu::Restore& store)
+{
+  auto buffer = store.as_buffer(); store.go_next();
+
+  assert(buffer.size() % sizeof(Stat) == 0);
+  const size_t count = buffer.size() / sizeof(Stat);
+
+  const Stat* ptr = (Stat*) buffer.data();
+  const Stat* end = ptr + count;
+
+  for (; ptr < end; ptr++)
+  {
+    try {
+      auto& stat = this->get_by_name(ptr->name());
+      std::memcpy(&stat, ptr, sizeof(Stat));
+    }
+    catch (std::exception e)
+    {
+      auto& stat = this->create(ptr->type(), ptr->name());
+      std::memcpy(&stat, ptr, sizeof(Stat));
+    }
+  }
+}

--- a/test/kernel/integration/LiveUpdate/test_boot.cpp
+++ b/test/kernel/integration/LiveUpdate/test_boot.cpp
@@ -2,6 +2,7 @@
 #include <kernel/syscalls.hpp>
 #include <liveupdate>
 #include <timers>
+#include <statman>
 #include <system_log>
 using namespace liu;
 
@@ -28,6 +29,16 @@ static void boot_save(Storage& storage, const buffer_t* blob)
 #else
   storage.add_buffer(2, *blob);
 #endif
+  auto& stm = Statman::get();
+  // increment number of updates performed
+  try {
+    ++stm.get_by_name("system.updates");
+  }
+  catch (std::exception e)
+  {
+    ++stm.create(Stat::UINT32, "system.updates");
+  }
+  stm.store(3, storage);
 }
 static void boot_resume_all(Restore& thing)
 {
@@ -46,6 +57,11 @@ static void boot_resume_all(Restore& thing)
 #else
   bloberino = thing.as_buffer(); thing.go_next();
 #endif
+  // statman
+  auto& stm = Statman::get();
+  stm.restore(thing);
+  auto& stat = stm.get_by_name("system.updates");
+  assert(stat.get_uint32() > 0);
   thing.pop_marker();
 }
 
@@ -69,6 +85,10 @@ LiveUpdate::storage_func begin_test_boot()
         printf("%lld\n", stamp);
       }
       */
+      for (auto& stat : Statman::get()) {
+        printf("%s: %s\n", stat.name(), stat.to_string().c_str());
+      }
+
       printf("Verifying that timers are started...\n");
 
       using namespace std::chrono;


### PR DESCRIPTION
- Overwrites stats with stats from previous system
- Uplink serializes stats by default
    - Counts system updates (system.updates)
    - No API or uplink protocol changes
