### PR TITLE
test: fixing parallel build tests

### DIFF
--- a/test/misc/build_examples/test.sh
+++ b/test/misc/build_examples/test.sh
@@ -62,7 +62,9 @@ do
 	  continue
   fi
   # build_service "$dir"
-  parallel build_service ::: "$dir"
+  # parallel build_service ::: "$dir"
+  # build_service "$dir" | xargs -n 8
+  build_service "$dir" | xargs
 done
 
 echo "Done"


### PR DESCRIPTION
short term fix - reports failed tests now in log. However build_examples passes on ubuntu but reports fail on mac. PR to test if it works on vcloud workspace.