### PR TITLE
Let DHCP continue forever if no timeout

### DIFF
--- a/api/net/dhcp/dh4client.hpp
+++ b/api/net/dhcp/dh4client.hpp
@@ -30,7 +30,8 @@ namespace net {
   class DHClient
   {
   public:
-    static const int NUM_RETRIES = 5;
+    static constexpr std::chrono::seconds RETRY_FREQUENCY{1};
+    static constexpr std::chrono::seconds RETRY_FREQUENCY_SLOW{10};
 
     using Stack = IP4::Stack;
     using config_func = delegate<void(bool)>;
@@ -40,7 +41,7 @@ namespace net {
     DHClient(Stack& inet);
 
     // negotiate with local DHCP server
-    void negotiate(uint32_t timeout_secs);
+    void negotiate(std::chrono::seconds timeout = std::chrono::seconds::zero());
 
     // Signal indicating the result of DHCP negotation
     // timeout is true if the negotiation timed out
@@ -61,7 +62,7 @@ namespace net {
     std::string  domain_name;
     uint32_t     lease_time;
     std::vector<config_func> config_handlers_;
-    int          retries  = 0;
+    int          tries    = 0;
     int          progress = 0;
     Timer        timeout_timer_;
     std::chrono::milliseconds timeout;

--- a/src/net/inet.cpp
+++ b/src/net/inet.cpp
@@ -203,7 +203,7 @@ void Inet::negotiate_dhcp(double timeout, dhcp_timeout_func handler) {
   if (!dhcp_)
       dhcp_ = std::make_shared<DHClient>(*this);
   // @timeout for DHCP-server negotation
-  dhcp_->negotiate(timeout);
+  dhcp_->negotiate(std::chrono::seconds((uint32_t)timeout));
   // add timeout_handler if supplied
   if (handler)
       dhcp_->on_config(handler);


### PR DESCRIPTION
By supplying timeout = 0, DHCP will now continue forever.
I added to constants that can be tuned:
```
    static constexpr std::chrono::seconds RETRY_FREQUENCY{1};
    static constexpr std::chrono::seconds RETRY_FREQUENCY_SLOW{10};
```
There is also hardcoded that it should make 10 tries before slow face:
```
  void DHClient::restart_negotation()
  {
    ...
    static const int FAST_TRIES = 10;
    // never timeout
    if(tries <= FAST_TRIES)
    {
      // do fast retry
      timeout_timer_.start(RETRY_FREQUENCY);
    }
    else
```
Fixes #1716. Inet still got default timeout to 10 seconds (also not using std::chrono), same if nothing is supplied in config.json. For it to work, config.json needs the field `timeout: 0` to try forever.
So i guess that's todo/decision to be made what the default should be.