### PR TITLE
Point dev solo5 to v0.3.0

### DIFF
--- a/cmake/cross_compiled_libraries.cmake
+++ b/cmake/cross_compiled_libraries.cmake
@@ -33,7 +33,7 @@ ExternalProject_Add(solo5_repo
 	PREFIX precompiled
 	BUILD_IN_SOURCE 1
 	GIT_REPOSITORY https://github.com/solo5/solo5.git
-	GIT_TAG 2765e0f5f090c0b27a8d62a48285842236e7d20f
+	GIT_TAG v0.3.0
 	CONFIGURE_COMMAND CC=gcc ./configure.sh
 	UPDATE_COMMAND ""
 	BUILD_COMMAND make

--- a/src/drivers/solo5blk.cpp
+++ b/src/drivers/solo5blk.cpp
@@ -16,27 +16,45 @@ extern "C" {
 Solo5Blk::Solo5Blk()
   : hw::Block_device()
 {
-  INFO("Solo5Blk", "Block device with %zu sectors", solo5_blk_sectors());
+  struct solo5_block_info bi;
+  solo5_block_info(&bi);
+  assert(bi.block_size == SECTOR_SIZE);
+  INFO("Solo5Blk", "Block device with %zu sectors",
+       bi.capacity / SECTOR_SIZE);
 }
 
 Solo5Blk::block_t Solo5Blk::size() const noexcept {
-  return solo5_blk_sectors();
+  struct solo5_block_info bi;
+  solo5_block_info(&bi);
+  return bi.capacity / SECTOR_SIZE;
 }
 
-Solo5Blk::buffer_t Solo5Blk::read_sync(block_t blk)
-{
-  auto buffer = fs::construct_buffer(block_size());
-  int rlen = SECTOR_SIZE;
+Solo5Blk::buffer_t Solo5Blk::read_sync(block_t blk) {
+  auto buffer = fs::construct_buffer(SECTOR_SIZE);
+  solo5_result_t res;
 
-  solo5_blk_read_sync((uint64_t) blk, buffer->data(), &rlen);
+  res = solo5_block_read((solo5_off_t) blk * SECTOR_SIZE,
+                         buffer->data(), SECTOR_SIZE);
+  if (res != SOLO5_R_OK) {
+    buffer.reset();
+    return nullptr;
+  }
   return buffer;
 }
 
 Solo5Blk::buffer_t Solo5Blk::read_sync(block_t blk, size_t count) {
-  auto buffer = fs::construct_buffer(block_size() * count);
-  int rlen = SECTOR_SIZE * count;
+  auto buffer = fs::construct_buffer(SECTOR_SIZE * count);
+  solo5_result_t res;
 
-  solo5_blk_read_sync((uint64_t) blk, buffer->data(), &rlen);
+  auto* data = (uint8_t*) buffer->data();
+  for (size_t i = 0; i < count; i++) {
+    res = solo5_block_read((solo5_off_t) (blk + i) * SECTOR_SIZE,
+                           data + (i * SECTOR_SIZE), SECTOR_SIZE);
+    if (res != SOLO5_R_OK) {
+      buffer.reset();
+      return nullptr;
+    }
+  }
   return buffer;
 }
 

--- a/src/drivers/solo5net.cpp
+++ b/src/drivers/solo5net.cpp
@@ -36,7 +36,10 @@ Solo5Net::Solo5Net()
     bufstore_{NUM_BUFFERS, 2048u} // don't change this
 {
   INFO("Solo5Net", "Driver initializing");
-  mac_addr = MAC::Addr(solo5_net_mac_str());
+  struct solo5_net_info ni;
+  solo5_net_info(&ni);
+  mac_addr = MAC::Addr(ni.mac_address[0], ni.mac_address[1], ni.mac_address[2],
+                       ni.mac_address[3], ni.mac_address[4], ni.mac_address[5]);
 }
 
 void Solo5Net::transmit(net::Packet_ptr pckt)
@@ -48,7 +51,7 @@ void Solo5Net::transmit(net::Packet_ptr pckt)
     // next in line
     auto next = tail->detach_tail();
     // write data to network
-    solo5_net_write_sync(tail->buf(), tail->size());
+    solo5_net_write(tail->buf(), tail->size());
     // set tail to next, releasing tail
     tail = std::move(next);
     // Stat increase packets transmitted
@@ -75,8 +78,8 @@ net::Packet_ptr Solo5Net::recv_packet()
   auto* pckt = (net::Packet*) buffer.addr;
   new (pckt) net::Packet(0, MTU(), packet_len(), buffer.bufstore);
   // Populate the packet buffer with new packet, if any
-  int size = packet_len();
-  if (solo5_net_read_sync(pckt->buf(), &size) == 0) {
+  size_t size = packet_len();
+  if (solo5_net_read(pckt->buf(), size, &size) == 0) {
     // Adjust packet size to match received data
     if (size) {
       pckt->set_data_end(size);

--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -154,7 +154,7 @@ void OS::event_loop()
     // XXX: temporarily ALWAYS sleep for 0.5 ms. We should ideally ask Timers
     // for the next immediate timer to fire (the first from the "scheduled" list
     // of timers?)
-    rc = solo5_poll(solo5_clock_monotonic() + 500000ULL); // now + 0.5 ms
+    rc = solo5_yield(solo5_clock_monotonic() + 500000ULL); // now + 0.5 ms
     Timers::timers_handler();
     if (rc) {
       for(auto& nic : hw::Devices::devices<hw::Nic>()) {
@@ -198,7 +198,7 @@ void OS::block()
       highest_blocking_level = blocking_level;
 
   int rc;
-  rc = solo5_poll(solo5_clock_monotonic() + 50000ULL); // now + 0.05 ms
+  rc = solo5_yield(solo5_clock_monotonic() + 50000ULL); // now + 0.05 ms
   if (rc == 0) {
     Timers::timers_handler();
   } else {


### PR DESCRIPTION
This is mainly for #1515 as solo5 version (0.3.0) has a fix for it. The solo5 interface changed slightly for 0.3.0 like function names, and args to `solo5_app_main` and the block ones (offsets are now bytes and not sectors anymore). All changes were straightforward except `src/drivers/solo5blk.cpp`: might not be doing the right thing with the smart pointers used for buffers (specially how to release them on error).

Tested with `tetst/misc/ukvm/test.sh` and `test/fs/integration/fat32` on an `Ubuntu 16.04` using clang 6.0.