### PR TITLE
solo5: Make event loop tickless

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CAPABS "${CAPABS} -fstack-protector-strong -D_STACK_GUARD_VALUE_=0x${STACK_P
 # Various global defines
 # * NO_DEBUG disables output from the debug macro
 # * OS_TERMINATE_ON_CONTRACT_VIOLATION provides classic assert-like output from Expects / Ensures
-set(CAPABS "${CAPABS} -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_LIBCPP_HAS_MUSL_LIBC -D_GNU_SOURCE")
+set(CAPABS "${CAPABS} -DNO_DEBUG=1 -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_LIBCPP_HAS_MUSL_LIBC -D_GNU_SOURCE -D__includeos__")
 set(WARNS "-Wall -Wextra") # -Werror
 
 # configure options

--- a/api/kernel/timers.hpp
+++ b/api/kernel/timers.hpp
@@ -50,6 +50,10 @@ public:
   /// returns the number of free timers
   static size_t free();
 
+  /// returns the time to next timer, or zero
+  /// implementations may treat 1 nanosecond as "timer activation imminent"
+  static duration_t next();
+
   /// NOTE: All above operations operate on the current CPU
   /// NOTE: There is a separate timer system on each active CPU
 

--- a/cmake/post.service.cmake
+++ b/cmake/post.service.cmake
@@ -43,7 +43,7 @@ endif()
 # Various global defines
 # * OS_TERMINATE_ON_CONTRACT_VIOLATION provides classic assert-like output from Expects / Ensures
 # * _GNU_SOURCE enables POSIX-extensions in newlib, such as strnlen. ("everything newlib has", ref. cdefs.h)
-set(CAPABS "${CAPABS} -fstack-protector-strong -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_LIBCPP_HAS_MUSL_LIBC -D_GNU_SOURCE -DSERVICE=\"\\\"${BINARY}\\\"\" -DSERVICE_NAME=\"\\\"${SERVICE_NAME}\\\"\"")
+set(CAPABS "${CAPABS} -fstack-protector-strong -DOS_TERMINATE_ON_CONTRACT_VIOLATION -D_LIBCPP_HAS_MUSL_LIBC -D_GNU_SOURCE -D__includeos__ -DSERVICE=\"\\\"${BINARY}\\\"\" -DSERVICE_NAME=\"\\\"${SERVICE_NAME}\\\"\"")
 set(WARNS  "-Wall -Wextra") #-pedantic
 
 # Compiler optimization

--- a/examples/TCP_perf/CMakeLists.txt
+++ b/examples/TCP_perf/CMakeLists.txt
@@ -20,13 +20,15 @@ set(SOURCES
 
 if ("$ENV{PLATFORM}" STREQUAL "x86_solo5")
   set(DRIVERS
-      solo5net     # Virtio networking
+      solo5net
+      #solo5blk
     )
 else()
   set(DRIVERS
     virtionet
     vmxnet3
     e1000
+    boot_logger
   )
 endif()
 

--- a/src/drivers/solo5blk.cpp
+++ b/src/drivers/solo5blk.cpp
@@ -36,7 +36,6 @@ Solo5Blk::buffer_t Solo5Blk::read_sync(block_t blk) {
   res = solo5_block_read((solo5_off_t) blk * SECTOR_SIZE,
                          buffer->data(), SECTOR_SIZE);
   if (res != SOLO5_R_OK) {
-    buffer.reset();
     return nullptr;
   }
   return buffer;
@@ -51,7 +50,6 @@ Solo5Blk::buffer_t Solo5Blk::read_sync(block_t blk, size_t count) {
     res = solo5_block_read((solo5_off_t) (blk + i) * SECTOR_SIZE,
                            data + (i * SECTOR_SIZE), SECTOR_SIZE);
     if (res != SOLO5_R_OK) {
-      buffer.reset();
       return nullptr;
     }
   }

--- a/src/kernel/timers.cpp
+++ b/src/kernel/timers.cpp
@@ -200,6 +200,21 @@ size_t Timers::free() {
 
 /// scheduling ///
 
+duration_t Timers::next()
+{
+  auto& system = get();
+  if (LIKELY(!system.scheduled.empty()))
+  {
+    auto it   = system.scheduled.begin();
+    auto when = it->first;
+    auto diff = when - now();
+    // avoid returning zero or negative diff
+    if (diff < nanoseconds(1)) return nanoseconds(1);
+    return diff;
+  }
+  return duration_t::zero();
+}
+
 void Timers::timers_handler()
 {
   auto& system = get();

--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -213,6 +213,3 @@ void OS::block()
   // Decrement level
   blocking_level -= 1;
 }
-
-extern "C"
-void __os_store_soft_reset(void*, size_t) {}

--- a/test/fs/integration/virtio_block/CMakeLists.txt
+++ b/test/fs/integration/virtio_block/CMakeLists.txt
@@ -10,11 +10,10 @@ project (test_virtioblk)
 
 set(SERVICE_NAME "VirtioBlk test")
 set(BINARY       "virtioblk")
-set(MAX_MEM 128)
 set(SOURCES
     service.cpp
   )
 
-set(DRIVERS virtioblk)
+set(DRIVERS virtioblk solo5blk)
 
 include($ENV{INCLUDEOS_PREFIX}/includeos/post.service.cmake)


### PR DESCRIPTION
Event loop now waits for next timer, when one is present, otherwise tick 500ms (change in solo5/os.cpp). Since all normal services use timers, the end result is a tickless kernel. Previously the kernel ticked every 0.5 milliseconds, which was overmuch.