### PR TITLE
Point to solo5 285b80a

### DIFF
--- a/cmake/cross_compiled_libraries.cmake
+++ b/cmake/cross_compiled_libraries.cmake
@@ -33,7 +33,7 @@ ExternalProject_Add(solo5_repo
 	PREFIX precompiled
 	BUILD_IN_SOURCE 1
 	GIT_REPOSITORY https://github.com/solo5/solo5.git
-	GIT_TAG v0.3.0
+	GIT_TAG 285b80aa4da12b628838a78dc79793f4d669ae1b
 	CONFIGURE_COMMAND CC=gcc ./configure.sh
 	UPDATE_COMMAND ""
 	BUILD_COMMAND make


### PR DESCRIPTION
Point to latest solo5 master as of Aug 1st (285b80a). The difference between 0.3.0 (where includeos is currently pointing to) and 285b80a is minor fixes (including #1515).

Tested with `test/misc/ukvm` and `test/fs/integration/fat32` on an Ubuntu 16.04 using clang 6.0 and gcc 5.4.0.