### PR TITLE
paging: fix bug in protect + regression test

### DIFF
--- a/api/arch/x86/paging.hpp
+++ b/api/arch/x86/paging.hpp
@@ -754,7 +754,7 @@ public:
     {
       auto* ent = entry(req.lin + res.size);
 
-      Map sub {req.lin + res.size, req.phys + res.size, req.flags,
+      Map sub {req.lin + res.size, req.phys == any_addr ? any_addr : req.phys + res.size, req.flags,
           req.size - res.size, req.page_sizes};
 
       res += map_entry_r(ent, sub);


### PR DESCRIPTION
Fixes a bug where mem::protect would some times not protect the full range, and potentially remap one of the pages being protected