### PR TITLE
refactor emplace back

### DIFF
--- a/api/fs/vfs.hpp
+++ b/api/fs/vfs.hpp
@@ -285,13 +285,13 @@ namespace fs {
     };
 
     Obs_ptr insert_parent(const std::string& token){
-      children_.emplace_back(new VFS_entry{token, "Directory"});
+      children_.emplace_back(std::make_unique<VFS_entry>(token, "Directory"));
       return children_.back().get();
     }
 
     template <typename T>
     VFS_entry& insert(const std::string& token, T& obj, const std::string& desc) {
-      children_.emplace_back(new VFS_entry(obj, token, desc));
+      children_.emplace_back(std::make_unique<VFS_entry>(obj, token, desc));
       return *children_.back();
     }
 

--- a/lib/LiveUpdate/serialize_tcp.cpp
+++ b/lib/LiveUpdate/serialize_tcp.cpp
@@ -113,7 +113,7 @@ int Write_queue::deserialize_from(void* addr)
     len += sizeof(write_buffer);
 
     // insert shared buffer into write queue
-    this->q.emplace_back(new std::vector<uint8_t> ());
+    this->q.emplace_back(std::make_shared<std::vector<uint8_t>>());
 
     // copy data
     auto wbuf = this->q.back();


### PR DESCRIPTION
It's not exception safe to do this,
```cpp
vector<unique_ptr<T>> v;
v.emplace_back(new T());
```

as `emplace_back` could cause a leak of this pointer if it throws a exception before emplacement (e.g. not enough memory to add a new element)