### PR TITLE
fix new without delete

### DIFF
--- a/linux/src/drivers/tap_driver.cpp
+++ b/linux/src/drivers/tap_driver.cpp
@@ -136,6 +136,7 @@ TAP_driver::TAP_driver(const char* devname,
 
 TAP_driver::~TAP_driver()
 {
+  delete epoll_ptr;
   close (this->tun_fd);
   close (this->epoll_fd);
 }


### PR DESCRIPTION
Called `new` in constructor
```cpp
new epoll_event;
```
but didn't release the resource in destructor.