### PR TITLE
TCP read buffer size

### DIFF
--- a/api/net/tcp/common.hpp
+++ b/api/net/tcp/common.hpp
@@ -23,6 +23,7 @@
 #include <net/checksum.hpp>
 #include <chrono>
 #include <vector>
+#include <util/units.hpp>
 
 namespace net {
   namespace tcp {
@@ -47,6 +48,10 @@ namespace net {
 
     static const std::chrono::seconds       default_msl {30};
     static const std::chrono::milliseconds  default_dack_timeout {40};
+
+    using namespace util::literals;
+    static constexpr size_t default_min_bufsize {4_KiB};
+    static constexpr size_t default_max_bufsize {256_KiB};
 
     using Address = net::Addr;
 

--- a/api/net/tcp/read_buffer.hpp
+++ b/api/net/tcp/read_buffer.hpp
@@ -37,10 +37,18 @@ public:
   /**
    * @brief      Construct a read buffer.
    *
-   * @param[in]  capacity  The capacity of the buffer
+   * p@aram[in]  capacity  The capacity of the buffer
    * @param[in]  seq       The sequence number to start on
    */
-  Read_buffer(const size_t capacity, const seq_t start);
+  /**
+   * @brief      Construct a read buffer.
+   *             Min and max need to be power of 2.
+   *
+   * @param[in]  start  The sequence number the buffer starts on
+   * @param[in]  min    The minimum size of the buffer (preallocated)
+   * @param[in]  max    The maximum size of the buffer (how much it can grow)
+   */
+  Read_buffer(const seq_t start, const size_t min, const size_t max);
 
   /**
    * @brief      Insert data into the buffer relative to the sequence number.
@@ -93,7 +101,7 @@ public:
    * @return     The capacity
    */
   size_t capacity() const noexcept
-  { return buf->capacity(); }
+  { return cap; }
 
   /**
    * @brief      How far into the internal buffer data has been written.
@@ -168,6 +176,7 @@ public:
 private:
   buffer_t        buf;
   seq_t           start;
+  size_t          cap;
   int32_t         hole; // number of bytes missing
   bool            push_seen{false};
 

--- a/api/net/tcp/read_buffer.hpp
+++ b/api/net/tcp/read_buffer.hpp
@@ -36,12 +36,6 @@ class Read_buffer {
 public:
   /**
    * @brief      Construct a read buffer.
-   *
-   * p@aram[in]  capacity  The capacity of the buffer
-   * @param[in]  seq       The sequence number to start on
-   */
-  /**
-   * @brief      Construct a read buffer.
    *             Min and max need to be power of 2.
    *
    * @param[in]  start  The sequence number the buffer starts on
@@ -181,12 +175,9 @@ private:
   bool            push_seen{false};
 
   /**
-   * @brief      Reset the buffer if either non-unique or
-   *             a decrease of the current capacity.
-   *
-   * @param[in]  capacity  The capacity
+   * @brief      Reset the buffer if non-unique
    */
-  void reset_buffer_if_needed(const size_t capacity);
+  void reset_buffer_if_needed();
 
 }; // < class Read_buffer
 

--- a/api/net/tcp/read_request.hpp
+++ b/api/net/tcp/read_request.hpp
@@ -44,7 +44,7 @@ public:
 
   void set_start(seq_t seq);
 
-  void reset(size_t size, const seq_t seq);
+  void reset(const seq_t seq);
 
   const Read_buffer& front() const
   { return *buffers.front(); }

--- a/api/net/tcp/read_request.hpp
+++ b/api/net/tcp/read_request.hpp
@@ -34,7 +34,7 @@ public:
   static constexpr size_t buffer_limit = 2;
   ReadCallback callback;
 
-  Read_request(size_t size, seq_t start, ReadCallback cb);
+  Read_request(seq_t start, size_t min, size_t max, ReadCallback cb);
 
   size_t insert(seq_t seq, const uint8_t* data, size_t n, bool psh = false);
 

--- a/api/net/tcp/sack.hpp
+++ b/api/net/tcp/sack.hpp
@@ -63,7 +63,7 @@ struct Block {
   bool contains(const seq_t seq) const noexcept
   {
     return static_cast<int32_t>(seq - start) >= 0 and
-           static_cast<int32_t>(seq - end) <= 0;
+           static_cast<int32_t>(seq - end) < 0;
   }
 
   bool precedes(const seq_t seq) const noexcept

--- a/api/net/tcp/tcp.hpp
+++ b/api/net/tcp/tcp.hpp
@@ -30,6 +30,7 @@
 #include <deque>  // writeq
 #include <net/socket.hpp>
 #include <net/ip4/ip4.hpp>
+#include <util/bitops.hpp>
 
 namespace net {
 
@@ -370,6 +371,36 @@ namespace net {
     { return max_syn_backlog_; }
 
     /**
+     * @brief      Sets the minimum buffer size.
+     *
+     * @param[in]  size  The size
+     */
+    void set_min_bufsize(const size_t size)
+    {
+      Expects(util::bits::is_pow2(size));
+      Expects(size <= max_bufsize_);
+      min_bufsize_ = size;
+    }
+
+    /**
+     * @brief      Sets the maximum buffer size.
+     *
+     * @param[in]  size  The size
+     */
+    void set_max_bufsize(const size_t size)
+    {
+      Expects(util::bits::is_pow2(size));
+      Expects(size >= min_bufsize_);
+      max_bufsize_ = size;
+    }
+
+    auto min_bufsize() const
+    { return min_bufsize_; }
+
+    auto max_bufsize() const
+    { return max_bufsize_; }
+
+    /**
      * @brief      The Maximum Segment Size to be used for this instance.
      *             [RFC 793] [RFC 879] [RFC 6691]
      *             This is the MTU - IP_hdr - TCP_hdr
@@ -516,6 +547,9 @@ namespace net {
     std::chrono::milliseconds dack_timeout_;
     /** Maximum SYN queue backlog */
     uint16_t                  max_syn_backlog_;
+
+    size_t min_bufsize_       {tcp::default_min_bufsize};
+    size_t max_bufsize_       {tcp::default_max_bufsize};
 
     /** Stats */
     uint64_t* bytes_rx_ = nullptr;

--- a/api/util/alloc_buddy.hpp
+++ b/api/util/alloc_buddy.hpp
@@ -110,7 +110,7 @@ namespace os::mem::buddy {
     static Size_t pool_size(Size_t bufsize){
       using namespace util;
 
-      auto pool_size = 0;
+      auto pool_sz = 0;
       // Find closest usable power of two depending on policy
       if constexpr (P == Policy::overbook) {
           auto pow2 = bits::next_pow2(bufsize);
@@ -121,15 +121,15 @@ namespace os::mem::buddy {
 
       }
 
-      pool_size = bits::keeplast(bufsize - 1); // -1 starts the recursion
+      pool_sz = bits::keeplast(bufsize - 1); // -1 starts the recursion
 
-      auto unalloc   = bufsize - pool_size;
-      auto overhead  = Alloc::overhead(pool_size);
+      auto unalloc   = bufsize - pool_sz;
+      auto overhead  = Alloc::overhead(pool_sz);
 
       // If bufsize == overhead + pow2, and overhead was too small to fit alloc
       // Try the next power of two recursively
       if(unalloc < overhead)
-        return Alloc::pool_size<P>(pool_size);
+        return Alloc::pool_size<P>(pool_sz);
 
       auto free = bufsize - overhead;
       return bits::keeplast(free);

--- a/api/util/uri.hpp
+++ b/api/util/uri.hpp
@@ -185,13 +185,6 @@ class URI {
   std::string host_and_port() const;
 
   ///
-  /// Get the raw port number in decimal character representation.
-  ///
-  /// @return The raw port number in decimal character representation
-  ///
-  util::sview port_str() const noexcept;
-
-  ///
   /// Get numeric port number.
   ///
   /// @warning The RFC don't specify dimension. This method will bind
@@ -300,7 +293,6 @@ private:
   util::sview scheme_;
   util::sview userinfo_;
   util::sview host_;
-  util::sview port_str_;
   util::sview path_;
   util::sview query_;
   util::sview fragment_;

--- a/lib/LiveUpdate/serialize_tcp.cpp
+++ b/lib/LiveUpdate/serialize_tcp.cpp
@@ -179,7 +179,7 @@ void Connection::deserialize_from(void* addr)
   auto* readq = (read_buffer*) &area->vla[writeq_len];
   if (readq->capacity)
   {
-    read_request = std::make_unique<Read_request>(readq->capacity, readq->seq, nullptr);
+    read_request = std::make_unique<Read_request>(readq->seq, readq->capacity, host_.max_bufsize(), nullptr);
     read_request->front().deserialize_from(readq);
   }
 

--- a/src/net/tcp/connection.cpp
+++ b/src/net/tcp/connection.cpp
@@ -61,7 +61,7 @@ void Connection::_on_read(size_t recv_bufsz, ReadCallback cb)
 {
   if(read_request == nullptr)
   {
-    read_request = std::make_unique<Read_request>(recv_bufsz, seq_t(this->cb.RCV.NXT), cb);
+    read_request.reset(new Read_request(this->cb.RCV.NXT, host_.min_bufsize(), host_.max_bufsize(), cb));
   }
   // read request is already set, only reset if new size.
   else

--- a/src/net/tcp/connection.cpp
+++ b/src/net/tcp/connection.cpp
@@ -59,6 +59,7 @@ Connection::~Connection()
 
 void Connection::_on_read(size_t recv_bufsz, ReadCallback cb)
 {
+  (void) recv_bufsz;
   if(read_request == nullptr)
   {
     read_request.reset(new Read_request(this->cb.RCV.NXT, host_.min_bufsize(), host_.max_bufsize(), cb));
@@ -69,7 +70,7 @@ void Connection::_on_read(size_t recv_bufsz, ReadCallback cb)
     //printf("on_read already set\n");
     read_request->callback = cb;
     // this will flush the current data to the user (if any)
-    read_request->reset(recv_bufsz, seq_t(this->cb.RCV.NXT));
+    read_request->reset(this->cb.RCV.NXT);
 
     // due to throwing away buffers (and all data) we also
     // need to clear the sack list if anything is stored here.

--- a/src/net/tcp/read_buffer.cpp
+++ b/src/net/tcp/read_buffer.cpp
@@ -33,7 +33,6 @@ Read_buffer::Read_buffer(const seq_t startv, const size_t min, const size_t max)
 
 size_t Read_buffer::insert(const seq_t seq, const uint8_t* data, size_t len, bool push)
 {
-  auto old_cap = buf->capacity();
   assert(buf != nullptr && "Buffer seems to be stolen, make sure to renew()");
 
   // get the relative sequence number (the diff)
@@ -75,29 +74,30 @@ void Read_buffer::reset(const seq_t seq, const size_t capacity)
   start = seq;
   hole = 0;
   push_seen = false;
-  reset_buffer_if_needed(capacity);
+  cap = capacity;
+  reset_buffer_if_needed();
 }
 
-void Read_buffer::reset_buffer_if_needed(const size_t capacity)
+void Read_buffer::reset_buffer_if_needed()
 {
   // if the buffer isnt unique, create a new one
   if (buf.use_count() != 1)
   {
     buf = tcp::construct_buffer();
-    buf->reserve(capacity);
+    buf->reserve(cap);
     return;
   }
   // from here on the buffer is ours only
   buf->clear();
   const auto bufcap = buf->capacity();
-  if (UNLIKELY(capacity < bufcap))
+  if (UNLIKELY(cap < bufcap))
   {
     buf->shrink_to_fit();
-    buf->reserve(capacity);
+    buf->reserve(cap);
   }
-  else if (UNLIKELY(capacity != bufcap))
+  else if (UNLIKELY(cap != bufcap))
   {
-    buf->reserve(capacity);
+    buf->reserve(cap);
   }
 }
 

--- a/src/net/tcp/read_request.cpp
+++ b/src/net/tcp/read_request.cpp
@@ -65,7 +65,6 @@ namespace tcp {
           // it means the local sequence number is much farther behind
           // the real one
           seq = end_seq - rem;
-
           buf->reset(seq);
           //printf("size=1, reset rem=%u start=%u end=%u\n",
           //  rem, buf->start_seq(), buf->end_seq());

--- a/src/net/tcp/read_request.cpp
+++ b/src/net/tcp/read_request.cpp
@@ -185,7 +185,7 @@ namespace tcp {
     }
   }
 
-  void Read_request::reset(size_t size, const seq_t seq)
+  void Read_request::reset(const seq_t seq)
   {
     Expects(not buffers.empty());
 
@@ -207,7 +207,7 @@ namespace tcp {
       callback(buf->buffer());
     }
     // reset the first buffer
-    buf->reset(seq, size);
+    buf->reset(seq);
     // throw the others away
     buffers.erase(++it, buffers.end());
 

--- a/src/net/tcp/read_request.cpp
+++ b/src/net/tcp/read_request.cpp
@@ -20,10 +20,10 @@
 namespace net {
 namespace tcp {
 
-  Read_request::Read_request(size_t size, seq_t start, ReadCallback cb)
+  Read_request::Read_request(seq_t start, size_t min, size_t max, ReadCallback cb)
     : callback{cb}
   {
-    buffers.push_back(std::make_unique<Read_buffer>(size, start));
+    buffers.push_back(std::make_unique<Read_buffer>(start, min, max));
   }
 
   size_t Read_request::insert(seq_t seq, const uint8_t* data, size_t n, bool psh)
@@ -125,7 +125,7 @@ namespace tcp {
       // we probably need to create multiple buffers,
       // ... or just decide we only support gaps of 1 buffer size.
       buffers.push_back(
-        std::make_unique<Read_buffer>(cur_back->capacity(), cur_back->end_seq()));
+        std::make_unique<Read_buffer>(cur_back->end_seq(), cur_back->capacity(), cur_back->capacity()));
 
       auto& back = buffers.back();
       //printf("new buffer added start=%u end=%u, fits(%lu)=%lu\n",

--- a/src/util/uri.cpp
+++ b/src/util/uri.cpp
@@ -21,6 +21,7 @@
 #include <uri>
 #include <utility>
 #include <vector>
+#include <array>
 
 #include "../../mod/http-parser/http_parser.h"
 
@@ -116,7 +117,6 @@ URI::URI(const URI& u)
   , scheme_   {updated_copy(uri_str_, u.scheme_,   u.uri_str_)}
   , userinfo_ {updated_copy(uri_str_, u.userinfo_, u.uri_str_)}
   , host_     {updated_copy(uri_str_, u.host_,     u.uri_str_)}
-  , port_str_ {updated_copy(uri_str_, u.port_str_, u.uri_str_)}
   , path_     {updated_copy(uri_str_, u.path_,     u.uri_str_)}
   , query_    {updated_copy(uri_str_, u.query_,    u.uri_str_)}
   , fragment_ {updated_copy(uri_str_, u.fragment_, u.uri_str_)}
@@ -136,7 +136,6 @@ URI::URI(URI&& u) noexcept
   , scheme_   {u.scheme_}
   , userinfo_ {u.userinfo_}
   , host_     {u.host_}
-  , port_str_ {u.port_str_}
   , path_     {u.path_}
   , query_    {u.query_}
   , fragment_ {u.fragment_}
@@ -151,7 +150,6 @@ URI& URI::operator=(const URI& u) {
   scheme_   = updated_copy(uri_str_, u.scheme_,   u.uri_str_);
   userinfo_ = updated_copy(uri_str_, u.userinfo_, u.uri_str_);
   host_     = updated_copy(uri_str_, u.host_,     u.uri_str_);
-  port_str_ = updated_copy(uri_str_, u.port_str_, u.uri_str_);
   path_     = updated_copy(uri_str_, u.path_,     u.uri_str_);
   query_    = updated_copy(uri_str_, u.query_,    u.uri_str_);
   fragment_ = updated_copy(uri_str_, u.fragment_, u.uri_str_);
@@ -173,7 +171,6 @@ URI& URI::operator=(URI&& u) noexcept {
   scheme_    = u.scheme_;
   userinfo_  = u.userinfo_;
   host_      = u.host_;
-  port_str_  = u.port_str_;
   path_      = u.path_;
   query_     = u.query_;
   fragment_  = u.fragment_;
@@ -214,11 +211,6 @@ bool URI::host_is_ip6() const noexcept {
 ///////////////////////////////////////////////////////////////////////////////
 std::string URI::host_and_port() const {
   return std::string{host_.data(), host_.length()} + ':' + std::to_string(port_);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-util::sview URI::port_str() const noexcept {
-  return port_str_;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -299,12 +291,25 @@ URI& URI::parse() {
   scheme_   = (u.field_set & (1 << UF_SCHEMA))   ? util::sview{p + u.field_data[UF_SCHEMA].off,   u.field_data[UF_SCHEMA].len}   : util::sview{};
   userinfo_ = (u.field_set & (1 << UF_USERINFO)) ? util::sview{p + u.field_data[UF_USERINFO].off, u.field_data[UF_USERINFO].len} : util::sview{};
   host_     = (u.field_set & (1 << UF_HOST))     ? util::sview{p + u.field_data[UF_HOST].off,     u.field_data[UF_HOST].len}     : util::sview{};
-  port_str_ = (u.field_set & (1 << UF_PORT))     ? util::sview{p + u.field_data[UF_PORT].off,     u.field_data[UF_PORT].len}     : util::sview{};
   path_     = (u.field_set & (1 << UF_PATH))     ? util::sview{p + u.field_data[UF_PATH].off,     u.field_data[UF_PATH].len}     : util::sview{};
   query_    = (u.field_set & (1 << UF_QUERY))    ? util::sview{p + u.field_data[UF_QUERY].off,    u.field_data[UF_QUERY].len}    : util::sview{};
   fragment_ = (u.field_set & (1 << UF_FRAGMENT)) ? util::sview{p + u.field_data[UF_FRAGMENT].off, u.field_data[UF_FRAGMENT].len} : util::sview{};
 
-  port_ = bind_port(scheme_, u.port);
+  auto port_str_ = (u.field_set & (1 << UF_PORT)) ?
+    util::sview{p + u.field_data[UF_PORT].off, u.field_data[UF_PORT].len} : util::sview{};
+
+  if(not port_str_.empty())
+  {
+    std::array<char, 32> buf;
+    std::copy(port_str_.begin(), port_str_.end(), buf.begin());
+    buf[port_str_.size()] = 0;
+    port_ = std::atoi(buf.data());
+  }
+  else
+  {
+    port_ = bind_port(scheme_, u.port);
+  }
+
 
   return *this;
 }

--- a/test/net/unit/tcp_read_buffer_test.cpp
+++ b/test/net/unit/tcp_read_buffer_test.cpp
@@ -18,14 +18,16 @@
 #include <common.cxx>
 #include <net/tcp/read_buffer.hpp>
 
+static const size_t MIN_BUFSZ = 128;
+static const size_t MAX_BUFSZ = 128;
 CASE("Filling a hole")
 {
   using namespace net::tcp;
   const seq_t SEQ_START = 322;
   seq_t SEQ = SEQ_START;
-  const size_t BUFSZ = 128;
+  const size_t BUFSZ = MIN_BUFSZ;
 
-  Read_buffer buf{BUFSZ, SEQ};
+  Read_buffer buf{SEQ, MIN_BUFSZ, MAX_BUFSZ};
 
   EXPECT(buf.size() == 0);
   EXPECT(buf.capacity() == BUFSZ);
@@ -83,9 +85,9 @@ CASE("Filling the buffer")
   using namespace net::tcp;
   const seq_t SEQ_START = 322;
   seq_t SEQ = SEQ_START;
-  const size_t BUFSZ = 128;
+  const size_t BUFSZ = MIN_BUFSZ;
 
-  Read_buffer buf{BUFSZ, SEQ};
+  Read_buffer buf{SEQ, MIN_BUFSZ, MAX_BUFSZ};
 
   using namespace std::string_literals;
 
@@ -120,9 +122,9 @@ CASE("Reseting the buffer")
   using namespace net::tcp;
   const seq_t SEQ_START = 322;
   seq_t SEQ = SEQ_START;
-  const size_t BUFSZ = 128;
+  const size_t BUFSZ = MIN_BUFSZ;
 
-  Read_buffer buf{BUFSZ, SEQ};
+  Read_buffer buf{SEQ, MIN_BUFSZ, MAX_BUFSZ};
 
   using namespace std::string_literals;
 
@@ -179,7 +181,7 @@ CASE("fits()")
 
   std::unique_ptr<Read_buffer> buf;
 
-  buf.reset(new Read_buffer(BUFSZ, seq));
+  buf.reset(new Read_buffer(seq, BUFSZ, BUFSZ));
 
   EXPECT(buf->fits(1000) == BUFSZ - (1000 - seq));
   EXPECT(buf->fits(1200) == BUFSZ - (1200 - seq));
@@ -189,7 +191,7 @@ CASE("fits()")
   const uint32_t MAX_UINT = std::numeric_limits<uint32_t>::max();
 
   seq = MAX_UINT - 500;
-  buf.reset(new Read_buffer(BUFSZ, seq));
+  buf.reset(new Read_buffer(seq, BUFSZ, BUFSZ));
   EXPECT(buf->fits(seq) == BUFSZ);
   EXPECT(buf->fits(seq + 500) == BUFSZ - 500);
   EXPECT(buf->fits(seq + 1000) == BUFSZ - 1000);

--- a/test/net/unit/tcp_read_buffer_test.cpp
+++ b/test/net/unit/tcp_read_buffer_test.cpp
@@ -163,10 +163,10 @@ CASE("Reseting the buffer")
   auto* data = buf.buffer()->data();
   buf.reset(SEQ, BUFSZ*2);
   EXPECT(buf.buffer().get() == ptr);
-  // but not same data
-  EXPECT(buf.buffer()->data() != data);
+  // and the same data
+  EXPECT(buf.buffer()->data() == data);
 
-  // decreasing the cap also means new data
+  // decreasing the cap means new data
   data = buf.buffer()->data();
   buf.reset(SEQ, BUFSZ/2);
   EXPECT(buf.buffer()->data() != data);

--- a/test/net/unit/tcp_read_request_test.cpp
+++ b/test/net/unit/tcp_read_request_test.cpp
@@ -34,7 +34,7 @@ CASE("Operating with out of order data")
     no_reads++;
   };
 
-  auto req = std::make_unique<Read_request>(BUFSZ, seq, read_cb);
+  auto req = std::make_unique<Read_request>(seq, BUFSZ, BUFSZ, read_cb);
   no_reads = 0;
 
   // Insert hole, first missing

--- a/test/util/unit/uri_test.cpp
+++ b/test/util/unit/uri_test.cpp
@@ -114,12 +114,6 @@ CASE("host_is_ip6() returns whether uri's host is an IPv6 address")
   EXPECT(uri.host_is_ip6() == true);
 }
 
-CASE("port_str() returns uri's port as string")
-{
-  uri::URI uri {"http://www.vg.no:8080"};
-  EXPECT(uri.port_str() == "8080");
-}
-
 CASE("URI construction, assignment")
 {
   uri::URI uri1 {"http://www.vg.no:8080"};


### PR DESCRIPTION
Some changes how to TCP read buffer size is set.
For now, size into `on_read(size, ...)` is ignored. This is now set on the TCP instance per interface with `set_min_bufsize()` and `set_max_bufsize()`. Min bufsize is now the amount of bytes reserved in the read buffer to start with, and max bufsize is the limit on how big the read buffer can grow.

`on_read` signature still needs to be refactored (removing the number). This is done in the next PR.

Also fixed a small, but critical, bug in SACK.