### PR TITLE
examples: remove unneeded includes from http_client service example

### DIFF
--- a/examples/http_client/service.cpp
+++ b/examples/http_client/service.cpp
@@ -36,8 +36,6 @@ static SSL_CTX* init_ssl_context()
 
 #include <service>
 #include <net/http/client.hpp>
-#include <net/super_stack.hpp>
-#include <net/ip4/ip4.hpp>
 
 static void begin_http(net::Inet& inet)
 {

--- a/examples/http_client/service.cpp
+++ b/examples/http_client/service.cpp
@@ -36,6 +36,7 @@ static SSL_CTX* init_ssl_context()
 
 #include <service>
 #include <net/http/client.hpp>
+using namespace std::literals::string_literals;
 
 static void begin_http(net::Inet& inet)
 {
@@ -43,7 +44,7 @@ static void begin_http(net::Inet& inet)
 
   static Basic_client basic{inet.tcp()};
 
-  const std::string url{"http://www.google.com"};
+  const auto url{"http://www.google.com"s};
   INFO("HTTP", "GET %s", url.c_str());
 
   basic.get(url, {}, [url](Error err, Response_ptr res, Connection&)
@@ -62,7 +63,7 @@ static void begin_http(net::Inet& inet)
 
   static Client client{inet.tcp(), ctx};
 
-  const std::string url_sec{"https://www.google.com"};
+  const auto url_sec{"https://www.google.com"s};
   INFO("HTTPS", "(Secure) GET %s", url_sec.c_str());
 
   client.get("https://www.google.com", {}, [url = url_sec](Error err, Response_ptr res, Connection&)


### PR DESCRIPTION
`net/super_stack.hpp` and `net/ip4/ip4.hpp`are already included via `net/http/client.hpp`