### PR TITLE
clang-tidy performance-faster-string-find

### DIFF
--- a/src/kernel/terminal.cpp
+++ b/src/kernel/terminal.cpp
@@ -132,7 +132,7 @@ split(const std::string& text, std::string& command)
   if (text.empty()) return retv;
   // extract command
   {
-    x = text.find(" ");
+    x = text.find(' ');
     // early return for cmd-only msg
     if (x == std::string::npos)
     {
@@ -145,8 +145,8 @@ split(const std::string& text, std::string& command)
   }
   // parse remainder
   do {
-    x = text.find(" ", p+1);
-    size_t y = text.find(":", x+1); // find last param
+    x = text.find(' ', p+1);
+    size_t y = text.find(':', x+1); // find last param
 
     if (y == x+1) {
       // single argument

--- a/src/plugins/unik.cpp
+++ b/src/plugins/unik.cpp
@@ -48,7 +48,7 @@ void unik::Client::register_instance(net::Inet& inet, const net::UDP::port_t por
       std::string strdata(data, len);
       INFO("Unik client","received UDP data from %s:%i: %s ", addr.to_string().c_str(), port, strdata.c_str());
 
-      auto dotloc = strdata.find(":");
+      auto dotloc = strdata.find(':');
 
       if (dotloc == std::string::npos) {
         INFO("Unik client","Unexpected UDP data format - no ':' in string.");


### PR DESCRIPTION
> Optimize calls to std::string::find() and friends when the needle passed is a single character string literal. The character literal overload is more efficient.

Runs clang-tidy over the compilation database. 

I may push more changes from clang-tidy results.