### PR TITLE
net: BufferStore now uses internal pools instead of a chain

### DIFF
--- a/api/hw/nic.hpp
+++ b/api/hw/nic.hpp
@@ -101,6 +101,18 @@ namespace hw {
     /** Overridable MTU detection function per-network **/
     static uint16_t MTU_detection_override(int idx, uint16_t default_MTU);
 
+    /** Set new buffer limit, where 0 means infinite **/
+    void set_buffer_limit(uint32_t new_limit) {
+      this->m_buffer_limit = new_limit;
+    }
+    uint32_t buffer_limit() const noexcept { return m_buffer_limit; }
+    
+    /** Set new sendq limit, where 0 means infinite **/
+    void set_sendq_limit(uint32_t new_limit) {
+      this->m_sendq_limit = new_limit;
+    }
+    uint32_t sendq_limit() const noexcept { return m_sendq_limit; }
+
   protected:
     /**
      *  Constructor
@@ -133,8 +145,17 @@ namespace hw {
       }
     }
 
+    bool buffers_still_available(uint32_t size) const noexcept {
+      return this->buffer_limit() == 0 || size < this->buffer_limit();
+    }
+    bool sendq_still_available(uint32_t size) const noexcept {
+      return this->sendq_limit() == 0 || size < this->sendq_limit();
+    }
+
   private:
     int N;
+    uint32_t m_buffer_limit = 0;
+    uint32_t m_sendq_limit = 0;
     friend class Devices;
   };
 

--- a/api/net/buffer_store.hpp
+++ b/api/net/buffer_store.hpp
@@ -59,14 +59,16 @@ namespace net
       return false;
     }
 
-    size_t available() const noexcept
-    {
+    size_t available() const noexcept {
       return this->available_.size();
     }
 
-    size_t total_buffers() const noexcept
-    {
+    size_t total_buffers() const noexcept {
       return this->pool_buffers() * this->pools_.size();
+    }
+
+    size_t buffers_in_use() const noexcept {
+      return this->total_buffers() - this->available();
     }
 
     /** move this bufferstore to the current CPU **/

--- a/api/net/buffer_store.hpp
+++ b/api/net/buffer_store.hpp
@@ -36,65 +36,52 @@ namespace net
    **/
   class BufferStore {
   public:
-    struct buffer_t
-    {
-      BufferStore* bufstore;
-      uint8_t*     addr;
-    };
-
-    BufferStore(size_t num, size_t bufsize);
+    BufferStore(uint32_t num, uint32_t bufsize);
     ~BufferStore();
 
-    buffer_t get_buffer();
+    uint8_t* get_buffer();
 
     inline void release(void*);
 
-    size_t local_buffers() const noexcept
-    { return poolsize_ / bufsize_; }
-
     /** Get size of a buffer **/
-    size_t bufsize() const noexcept
+    uint32_t bufsize() const noexcept
     { return bufsize_; }
 
-    size_t poolsize() const noexcept
+    uint32_t poolsize() const noexcept
     { return poolsize_; }
 
-    /** Check if a buffer belongs here */
-    bool is_from_this_pool(uint8_t* addr) const noexcept {
-      return (addr >= this->pool_begin()
-          and addr <  this->pool_end());
+    /** Check if an address belongs to this buffer store */
+    bool is_valid(uint8_t* addr) const noexcept
+    {
+      for (const auto* pool : pools_)
+          if ((addr - pool) % bufsize_ == 0
+            && addr >= pool && addr < pool + poolsize_) return true;
+      return false;
     }
 
-    /** Check if an address is the start of a buffer */
-    bool is_buffer(uint8_t* addr) const noexcept
-    { return (addr - pool_) % bufsize_ == 0; }
+    size_t available() const noexcept
+    {
+      return this->available_.size();
+    }
 
-    size_t available() const noexcept;
-
-    size_t total_buffers() const noexcept;
+    size_t total_buffers() const noexcept
+    {
+      return this->pool_buffers() * this->pools_.size();
+    }
 
     /** move this bufferstore to the current CPU **/
     void move_to_this_cpu() noexcept;
 
   private:
-    uint8_t* pool_begin() const noexcept {
-      return pool_;
-    }
-    uint8_t* pool_end() const noexcept {
-      return pool_begin() + poolsize_;
-    }
+    uint32_t pool_buffers() const noexcept { return poolsize_ / bufsize_; }
+    void create_new_pool();
+    bool growth_enabled() const;
 
-    BufferStore* get_next_bufstore();
-    inline buffer_t get_buffer_directly() noexcept;
-    inline void     release_directly(uint8_t*);
-    void release_internal(void*);
-
-    size_t               poolsize_;
-    size_t               bufsize_;
-    uint8_t*             pool_;
+    uint32_t              poolsize_;
+    uint32_t              bufsize_;
+    int                   index = -1;
     std::vector<uint8_t*> available_;
-    std::unique_ptr<BufferStore> next_;
-    int                  index;
+    std::vector<uint8_t*> pools_;
 #ifdef INCLUDEOS_SMP_ENABLE
     // has strict alignment reqs, so put at end
     spinlock_t           plock = 0;
@@ -108,16 +95,14 @@ namespace net
   inline void BufferStore::release(void* addr)
   {
     auto* buff = (uint8_t*) addr;
-    // try to release directly into pool
-    if (LIKELY(is_from_this_pool(buff))) {
+    if (LIKELY(this->is_valid(buff))) {
 #ifdef INCLUDEOS_SMP_ENABLE
       scoped_spinlock spinlock(this->plock);
 #endif
-      available_.push_back(buff);
+      this->available_.push_back(buff);
       return;
     }
-    // release via chained stores
-    release_internal(addr);
+    throw std::runtime_error("Buffer did not belong");
   }
 
 } //< net

--- a/src/drivers/e1000.cpp
+++ b/src/drivers/e1000.cpp
@@ -462,18 +462,17 @@ e1000::recv_packet(uint8_t* data, uint16_t size)
 net::Packet_ptr
 e1000::create_packet(int link_offset)
 {
-  auto buffer = bufstore().get_buffer();
-  auto* ptr = (net::Packet*) buffer.addr;
+  auto* ptr = (net::Packet*) bufstore().get_buffer();
   new (ptr) net::Packet(
         DRIVER_OFFSET + link_offset,
         0,
         DRIVER_OFFSET + frame_offset_link() + MTU(),
-        buffer.bufstore);
+        &bufstore());
   return net::Packet_ptr(ptr);
 }
 uintptr_t e1000::new_rx_packet()
 {
-  auto* pkt = bufstore().get_buffer().addr;
+  auto* pkt = bufstore().get_buffer();
   return (uintptr_t) &pkt[sizeof(net::Packet) + DRIVER_OFFSET];
 }
 

--- a/src/drivers/solo5net.cpp
+++ b/src/drivers/solo5net.cpp
@@ -66,17 +66,15 @@ void Solo5Net::transmit(net::Packet_ptr pckt)
 
 net::Packet_ptr Solo5Net::create_packet(int link_offset)
 {
-  auto buffer = bufstore().get_buffer();
-  auto* pckt = (net::Packet*) buffer.addr;
+  auto* pckt = (net::Packet*) bufstore().get_buffer();
 
-  new (pckt) net::Packet(link_offset, 0, packet_len(), buffer.bufstore);
+  new (pckt) net::Packet(link_offset, 0, packet_len(), &bufstore());
   return net::Packet_ptr(pckt);
 }
 net::Packet_ptr Solo5Net::recv_packet()
 {
-  auto buffer = bufstore().get_buffer();
-  auto* pckt = (net::Packet*) buffer.addr;
-  new (pckt) net::Packet(0, MTU(), packet_len(), buffer.bufstore);
+  auto* pckt = (net::Packet*) bufstore().get_buffer();
+  new (pckt) net::Packet(0, MTU(), packet_len(), &bufstore());
   // Populate the packet buffer with new packet, if any
   size_t size = packet_len();
   if (solo5_net_read(pckt->buf(), size, &size) == 0) {
@@ -86,7 +84,7 @@ net::Packet_ptr Solo5Net::recv_packet()
       return net::Packet_ptr(pckt);
     }
   }
-  bufstore().release(buffer.addr);
+  bufstore().release(&pckt);
   return nullptr;
 }
 

--- a/src/drivers/vmxnet3.cpp
+++ b/src/drivers/vmxnet3.cpp
@@ -125,6 +125,8 @@ vmxnet3::vmxnet3(hw::PCI_Device& d, const uint16_t mtu) :
     m_pcidev(d), m_mtu(mtu),
     stat_sendq_cur{Statman::get().create(Stat::UINT32, device_name() + ".sendq_now").get_uint32()},
     stat_sendq_max{Statman::get().create(Stat::UINT32, device_name() + ".sendq_max").get_uint32()},
+    stat_rx_refill_dropped{Statman::get().create(Stat::UINT64, device_name() + ".rx_refill_dropped").get_uint64()},
+    stat_sendq_dropped{Statman::get().create(Stat::UINT64, device_name() + ".sendq_dropped").get_uint64()},
     bufstore_{1024, buffer_size_for_mtu(mtu)}
 {
   INFO("vmxnet3", "Driver initializing (rev=%#x)", d.rev_id());
@@ -357,6 +359,14 @@ void vmxnet3::refill(rxring_state& rxq)
   bool added_buffers = (rxq.prod_count < VMXNET3_RX_FILL);
   while (rxq.prod_count < VMXNET3_RX_FILL)
   {
+    // break when not allowed to refill anymore
+    if (rxq.prod_count > 0 /* prevent full stop? */
+     && not Nic::buffers_still_available(bufstore().buffers_in_use()))
+    {
+      stat_rx_refill_dropped += VMXNET3_RX_FILL - rxq.prod_count;
+      break;
+    }
+
     size_t i = rxq.producers % vmxnet3::NUM_RX_DESC;
     const uint32_t generation =
         (rxq.producers & vmxnet3::NUM_RX_DESC) ? 0 : VMXNET3_RXF_GEN;
@@ -520,7 +530,12 @@ bool vmxnet3::receive_handler(const int Q)
 
 void vmxnet3::transmit(net::Packet_ptr pckt_ptr)
 {
-  while (pckt_ptr != nullptr) {
+  while (pckt_ptr != nullptr)
+  {
+    if (not Nic::sendq_still_available(this->sendq.size())) {
+      stat_sendq_dropped++;
+      continue;
+    }
     auto tail = pckt_ptr->detach_tail();
     sendq.emplace_back(std::move(pckt_ptr));
     pckt_ptr = std::move(tail);

--- a/src/drivers/vmxnet3.cpp
+++ b/src/drivers/vmxnet3.cpp
@@ -362,7 +362,7 @@ void vmxnet3::refill(rxring_state& rxq)
         (rxq.producers & vmxnet3::NUM_RX_DESC) ? 0 : VMXNET3_RXF_GEN;
 
     // get a pointer to packet data
-    auto* pkt_data = bufstore().get_buffer().addr;
+    auto* pkt_data = bufstore().get_buffer();
     rxq.buffers[i] = &pkt_data[sizeof(net::Packet) + DRIVER_OFFSET];
 
     // assign rx descriptor
@@ -393,13 +393,12 @@ vmxnet3::recv_packet(uint8_t* data, uint16_t size)
 net::Packet_ptr
 vmxnet3::create_packet(int link_offset)
 {
-  auto buffer = bufstore().get_buffer();
-  auto* ptr = (net::Packet*) buffer.addr;
+  auto* ptr = (net::Packet*) bufstore().get_buffer();
   new (ptr) net::Packet(
         DRIVER_OFFSET + link_offset,
         0,
         DRIVER_OFFSET + frame_offset_link() + MTU(),
-        buffer.bufstore);
+        &bufstore());
   return net::Packet_ptr(ptr);
 }
 

--- a/src/drivers/vmxnet3.hpp
+++ b/src/drivers/vmxnet3.hpp
@@ -143,6 +143,8 @@ private:
   // sendq as double-ended q
   uint32_t& stat_sendq_cur;
   uint32_t& stat_sendq_max;
+  uint64_t& stat_rx_refill_dropped;
+  uint64_t& stat_sendq_dropped;
   std::deque<net::Packet_ptr> sendq;
   net::BufferStore bufstore_;
 };

--- a/src/net/buffer_store.cpp
+++ b/src/net/buffer_store.cpp
@@ -22,48 +22,26 @@
 #include <cassert>
 #include <smp>
 #include <cstddef>
-//#define DEBUG_RELEASE
-//#define DEBUG_RETRIEVE
 //#define DEBUG_BUFSTORE
-#define ENABLE_BUFFERSTORE_CHAIN
-
-#ifdef DEBUG_RELEASE
-#define BSD_RELEASE(fmt, ...) printf(fmt, ##__VA_ARGS__);
-#else
-#define BSD_RELEASE(fmt, ...)  /** fmt **/
-#endif
-
-#ifdef DEBUG_RETRIEVE
-#define BSD_GET(fmt, ...) printf(fmt, ##__VA_ARGS__);
-#else
-#define BSD_GET(fmt, ...)  /** fmt **/
-#endif
 
 #ifdef DEBUG_BUFSTORE
-#define BSD_BUF(fmt, ...) printf(fmt, ##__VA_ARGS__);
+#define BSD_PRINT(fmt, ...) printf(fmt, ##__VA_ARGS__);
 #else
-#define BSD_BUF(fmt, ...)  /** fmt **/
+#define BSD_PRINT(fmt, ...)  /** fmt **/
 #endif
 
 namespace net {
 
-  BufferStore::BufferStore(size_t num, size_t bufsize) :
+  BufferStore::BufferStore(uint32_t num, uint32_t bufsize) :
     poolsize_  {num * bufsize},
-    bufsize_   {bufsize},
-    next_(nullptr)
+    bufsize_   {bufsize}
   {
     assert(num != 0);
     assert(bufsize != 0);
-    const size_t DATA_SIZE  = poolsize_;
-
-    this->pool_ = (uint8_t*) aligned_alloc(OS::page_size(), DATA_SIZE);
-    assert(this->pool_);
-
     available_.reserve(num);
-    for (uint8_t* b = pool_end()-bufsize; b >= pool_begin(); b -= bufsize) {
-        available_.push_back(b);
-    }
-    assert(available_.capacity() == num);
+
+    this->create_new_pool();
+    assert(this->available_.capacity() == num);
     assert(available() == num);
 
     static int bsidx = 0;
@@ -71,120 +49,51 @@ namespace net {
   }
 
   BufferStore::~BufferStore() {
-    this->next_ = nullptr;
-    free(this->pool_);
+    for (auto* pool : this->pools_)
+        free(pool);
   }
 
-  size_t BufferStore::available() const noexcept
-  {
-    auto avail = this->available_.size();
-#ifdef ENABLE_BUFFERSTORE_CHAIN
-    auto* parent = this;
-    while (parent->next_ != nullptr) {
-        parent = parent->next_.get();
-        avail += parent->available_.size();
-    }
-#endif
-    return avail;
-  }
-  size_t BufferStore::total_buffers() const noexcept
-  {
-    size_t total = this->local_buffers();
-#ifdef ENABLE_BUFFERSTORE_CHAIN
-    auto* parent = this;
-    while (parent->next_ != nullptr) {
-        parent = parent->next_.get();
-        total += parent->local_buffers();
-    }
-#endif
-    return total;
-  }
-
-  BufferStore* BufferStore::get_next_bufstore()
-  {
-#ifdef ENABLE_BUFFERSTORE_CHAIN
-    BufferStore* parent = this;
-    while (parent->next_ != nullptr) {
-        parent = parent->next_.get();
-        if (!parent->available_.empty()) return parent;
-    }
-    BSD_BUF("<BufferStore> Allocating %lu new buffers (%lu total)\n",
-            local_buffers(), total_buffers() + local_buffers());
-    parent->next_ = std::make_unique<BufferStore>(local_buffers(), bufsize());
-    return parent->next_.get();
-#else
-    return nullptr;
-#endif
-  }
-
-  BufferStore::buffer_t BufferStore::get_buffer_directly() noexcept
-  {
-    auto addr = available_.back();
-    available_.pop_back();
-    return { this, addr };
-  }
-
-  BufferStore::buffer_t BufferStore::get_buffer()
+  uint8_t* BufferStore::get_buffer()
   {
 #ifdef INCLUDEOS_SMP_ENABLE
-    scoped_spinlock spinlock(plock);
+    scoped_spinlock spinlock(this->plock);
 #endif
 
     if (UNLIKELY(available_.empty())) {
-#ifdef ENABLE_BUFFERSTORE_CHAIN
-      auto* next = get_next_bufstore();
-      if (next == nullptr)
-          throw std::runtime_error("Unable to create new bufstore");
-
-      // take buffer from external bufstore
-      auto buffer = next->get_buffer_directly();
-      BSD_GET("%d: Gave away EXTERN %p, %lu buffers remain\n",
-              this->index, buffer.addr, available());
-      return buffer;
-#else
-      panic("<BufferStore> Buffer pool empty! Not configured to increase pool size.\n");
-#endif
+      if (this->growth_enabled())
+          this->create_new_pool();
+      else
+          throw std::runtime_error("This BufferStore has run out of buffers");
     }
-
-    auto buffer = get_buffer_directly();
-    BSD_GET("%d: Gave away %p, %lu buffers remain\n",
-            this->index, buffer.addr, available());
-    return buffer;
+    
+    auto* addr = available_.back();
+    available_.pop_back();
+    BSD_PRINT("%d: Gave away %p, %zu buffers remain\n",
+            this->index, addr, available());
+    return addr;
   }
 
-  void BufferStore::release_internal(void* addr)
+  void BufferStore::create_new_pool()
   {
-    auto* buff = (uint8_t*) addr;
-    BSD_RELEASE("%d: Release %p -> ", this->index, buff);
+    auto* pool = (uint8_t*) aligned_alloc(OS::page_size(), poolsize_);
+    assert(pool != nullptr);
+    this->pools_.push_back(pool);
 
-#ifdef INCLUDEOS_SMP_ENABLE
-    scoped_spinlock spinlock(plock);
-#endif
-#ifdef ENABLE_BUFFERSTORE_CHAIN
-    // try to release buffer on linked bufferstore
-    BufferStore* ptr = next_.get();
-    while (ptr != nullptr) {
-      if (ptr->is_from_this_pool(buff)) {
-        BSD_RELEASE("released on other bufferstore\n");
-        ptr->release_directly(buff);
-        return;
-      }
-      ptr = ptr->next_.get();
+    for (uint8_t* b = pool; b < pool + poolsize_; b += bufsize_) {
+        this->available_.push_back(b);
     }
-#endif
-    throw std::runtime_error("Packet did not belong");
-  }
-
-  void BufferStore::release_directly(uint8_t* buffer)
-  {
-    BSD_GET("%d: Released EXTERN %p, %lu buffers remain\n",
-            this->index, buffer, available());
-    available_.push_back(buffer);
+    BSD_PRINT("%d: Creating new pool, now %zu total buffers\n",
+              this->index, this->total_buffers());
   }
 
   void BufferStore::move_to_this_cpu() noexcept
   {
     // TODO: hmm
   }
+  
+  __attribute__((weak))
+  bool BufferStore::growth_enabled() const {
+    return true;
+  }
 
-} //< namespace net
+} //< net

--- a/test/lest_util/nic_mock.hpp
+++ b/test/lest_util/nic_mock.hpp
@@ -80,13 +80,12 @@ public:
 
   net::Packet_ptr create_packet(int) override
   {
-    auto buffer = bufstore_.get_buffer();
-    auto* ptr = (net::Packet*) buffer.addr;
+    auto* ptr = (net::Packet*) bufstore_.get_buffer();
 
     new (ptr) net::Packet(frame_offs_link_,
                           0,
                           packet_len(),
-                          buffer.bufstore);
+                          &bufstore_);
 
     return net::Packet_ptr(ptr);
   }

--- a/test/lest_util/packet_factory.hpp
+++ b/test/lest_util/packet_factory.hpp
@@ -33,9 +33,8 @@ using namespace net;
 static net::Packet_ptr create_packet() noexcept
 {
   static net::BufferStore bufstore(BUFFER_CNT, BUFFER_SIZE);
-  auto buffer = bufstore.get_buffer();
-  auto* ptr = (net::Packet*) buffer.addr;
-  new (ptr) net::Packet(PHYS_OFFSET, 0, PHYS_OFFSET + PACKET_CAPA, buffer.bufstore);
+  auto* ptr = (net::Packet*) bufstore.get_buffer();
+  new (ptr) net::Packet(PHYS_OFFSET, 0, PHYS_OFFSET + PACKET_CAPA, &bufstore);
   return net::Packet_ptr(ptr);
 }
 

--- a/test/net/integration/bufstore/service.cpp
+++ b/test/net/integration/bufstore/service.cpp
@@ -28,11 +28,9 @@ static const uint32_t BS_CHAINS  = 10;
 static const uint32_t TOTAL_BUFFERS = BUFFER_CNT * BS_CHAINS;
 
 auto create_packet(BufferStore& bufstore) {
-  // get buffer (as packet + data)
-  auto buffer = bufstore.get_buffer();
+  auto* ptr = (Packet*) bufstore.get_buffer();
   // place packet at front of buffer
-  auto* ptr = (Packet*) buffer.addr;
-  new (ptr) Packet(0, 0, MTU, buffer.bufstore);
+  new (ptr) Packet(0, 0, MTU, &bufstore);
   // regular shared_ptr that calls delete on Packet
   return std::unique_ptr<Packet>(ptr);
 }

--- a/test/net/unit/bufstore.cpp
+++ b/test/net/unit/bufstore.cpp
@@ -31,7 +31,7 @@ CASE("Randomly release bufferstore buffers")
   for (volatile int rounds = 0; rounds < 128; rounds++)
   {
     BufferStore bufstore(BUFFER_CNT, BUFFER_SZ);
-    std::vector<BufferStore::buffer_t> buffers;
+    std::vector<uint8_t*> buffers;
 
     // force out chained bufferstores
     for (int chain = 0; chain < BS_CHAINS; chain++)
@@ -46,7 +46,7 @@ CASE("Randomly release bufferstore buffers")
     // release them randomly
     while (!buffers.empty()) {
       int idx = rand() % buffers.size();
-      bufstore.release(buffers[idx].addr);
+      bufstore.release(buffers[idx]);
       buffers.erase(buffers.begin() + idx, buffers.begin() + idx + 1);
     }
     EXPECT(bufstore.available() == BUFFER_CNT * BS_CHAINS);

--- a/test/net/unit/packets.cpp
+++ b/test/net/unit/packets.cpp
@@ -30,9 +30,8 @@ void panic(const char*) { throw std::runtime_error("panic()"); }
 
 CASE("Create empty packet")
 {
-  auto buffer = bufstore.get_buffer();
-  auto* ptr = (net::Packet*) buffer.addr;
-  new (ptr) net::Packet(0, 0, 0, buffer.bufstore);
+  auto* ptr = (net::Packet*) bufstore.get_buffer();
+  new (ptr) net::Packet(0, 0, 0, &bufstore);
   net::Packet_ptr packet(ptr);
 
   // everything is zero
@@ -49,9 +48,8 @@ CASE("Create empty packet")
 
 static Packet_ptr create_packet() noexcept
 {
-  auto buffer = bufstore.get_buffer();
-  auto* ptr = (net::Packet*) buffer.addr;
-  new (ptr) net::Packet(DRIVER_OFFSET, 0, DRIVER_OFFSET + PACKET_CAPA, buffer.bufstore);
+  auto* ptr = (net::Packet*) bufstore.get_buffer();
+  new (ptr) net::Packet(DRIVER_OFFSET, 0, DRIVER_OFFSET + PACKET_CAPA, &bufstore);
   return net::Packet_ptr(ptr);
 }
 


### PR DESCRIPTION
- Greatly simplifies bufferstore
- Chaining removed, replaced with internal pools that can grow
- Growth can be disabled by overriding a private function
