### PR TITLE
Support multiple bridges with qemu + simplification of Nic by MAC

### DIFF
--- a/api/hw/devices.hpp
+++ b/api/hw/devices.hpp
@@ -46,6 +46,12 @@ namespace hw {
     static Block_device& drive(const int N)
     { return get<Block_device>(N); }
 
+    // Nic helpers
+    inline static int nic_index(const MAC::Addr& mac);
+
+    static int nic_index(const std::string& mac)
+    { return nic_index(MAC::Addr{mac.c_str()}); }
+
     /** List all devices (decorated, as seen in boot output) */
     inline static void print_devices();
 
@@ -112,11 +118,14 @@ namespace hw {
   /** Exception thrown when a device is not found (registered) */
   class Device_not_found : public std::out_of_range {
   public:
+    explicit Device_not_found(const std::string& what)
+      : std::out_of_range{what}
+    {}
     explicit Device_not_found(const std::string& type, const int n)
-      : std::out_of_range(
+      : Device_not_found{
           std::string{"Device of type "} + type +
           std::string{" not found at position #"}
-          + std::to_string(n))
+          + std::to_string(n)}
       {}
   }; //< class Device_not_found
 
@@ -129,6 +138,19 @@ namespace hw {
     {
       throw Device_not_found{Device_type::device_type(), N};
     }
+  }
+
+  inline int Devices::nic_index(const MAC::Addr& mac)
+  {
+    auto& nics = devices<Nic>();
+    int i = 0;
+    for(auto it = nics.begin(); it != nics.end(); it++)
+    {
+      if((*it)->mac() == mac)
+        return i;
+      i++;
+    }
+    return -1;
   }
 
   template <typename Device_type>

--- a/api/hw/devices.hpp
+++ b/api/hw/devices.hpp
@@ -49,9 +49,6 @@ namespace hw {
     // Nic helpers
     inline static int nic_index(const MAC::Addr& mac);
 
-    static int nic_index(const std::string& mac)
-    { return nic_index(MAC::Addr{mac.c_str()}); }
-
     /** List all devices (decorated, as seen in boot output) */
     inline static void print_devices();
 

--- a/api/net/super_stack.hpp
+++ b/api/net/super_stack.hpp
@@ -40,8 +40,9 @@ struct Stack_not_found : public Super_stack_err
 
 class Super_stack {
 public:
-  using Stacks = std::map<int, std::unique_ptr<Inet>>;
-  using IP4_stacks = std::vector<Stacks>;
+  // naming is hard...
+  using Indexed_stacks = std::map<int, std::unique_ptr<Inet>>;
+  using Stacks = std::vector<Indexed_stacks>;
 
 public:
   static Super_stack& inet()
@@ -68,11 +69,11 @@ public:
 
   Inet& create(hw::Nic& nic, int N, int sub);
 
-  IP4_stacks& ip4_stacks()
-  { return ip4_stacks_; }
+  Stacks& stacks()
+  { return stacks_; }
 
 private:
-  IP4_stacks ip4_stacks_;
+  Stacks stacks_;
 
   Super_stack();
 

--- a/api/net/super_stack.hpp
+++ b/api/net/super_stack.hpp
@@ -64,20 +64,9 @@ public:
    * @return     A stack
    */
   static Inet& get(const std::string& mac);
+  static Inet& get(const std::string& mac, int sub);
 
   Inet& create(hw::Nic& nic, int N, int sub);
-
-  /**
-   * @brief      Create a stack on the given Nic,
-   *             occupying the first free index.
-   *
-   * @param      nic   The nic
-   *
-   * @tparam     IP version
-   *
-   * @return     A stack
-   */
-  Inet& create(hw::Nic& nic);
 
   IP4_stacks& ip4_stacks()
   { return ip4_stacks_; }

--- a/etc/scripts/create_bridge.sh
+++ b/etc/scripts/create_bridge.sh
@@ -11,15 +11,20 @@ then
   GATEWAY=10.0.0.1
   NETMASK6=64
   GATEWAY6=fe80::e823:fcff:fef4:83e7
+  # Håreks cool hack:
+  # - First two bytes is fixed to "c001" because it's cool
+  # - Last four is the gateway IP, 10.0.0.1
+  HWADDR=c0:01:0a:00:00:01
 
-elif [ $# -eq 3 ]
+elif [ $# -eq 4 ]
 then
   BRIDGE=$1
   NETMASK=$2
   GATEWAY=$3
+  HWADDR=$4
 else
   me=`basename "$0"`
-  echo "Usage: $me [name netmask gateway]"
+  echo "Usage: $me [name netmask gateway hwaddr]"
   exit 1
 fi
 
@@ -28,12 +33,9 @@ if [ -n "$INCLUDEOS_BRIDGE" ]; then
 fi
 
 echo "    Creating bridge $BRIDGE, netmask $NETMASK, gateway $GATEWAY "
+if [[ -n "$GATEWAY6" ]]; then
 echo "    ipv6 netmask $NETMASK6, gateway $GATEWAY6 "
-
-# Håreks cool hack:
-# - First two bytes is fixed to "c001" because it's cool
-# - Last four is the gateway IP, 10.0.0.1
-HWADDR=c0:01:0a:00:00:01
+fi
 
 # For later use
 NETWORK=10.0.0.0
@@ -87,8 +89,11 @@ else
   echo "    Configuring network bridge (requires sudo):"
 
   sudo ifconfig $BRIDGE $GATEWAY netmask $NETMASK up || exit 1
-  sudo ifconfig $BRIDGE inet6 add $GATEWAY6/$NETMASK6
+  if [[ -n "$GATEWAY6" ]]; then
+    sudo ifconfig $BRIDGE inet6 add $GATEWAY6/$NETMASK6
+  fi
   if uname -s | grep Darwin > /dev/null 2>&1; then
+    echo "    Setting ether to $HWADDR"
 	sudo ifconfig $BRIDGE ether $HWADDR || exit 1
   else
 	sudo ifconfig $BRIDGE hw ether $HWADDR || exit 1

--- a/lib/uplink/ws_uplink.cpp
+++ b/lib/uplink/ws_uplink.cpp
@@ -517,7 +517,7 @@ namespace uplink {
 
     writer.StartArray();
 
-    auto& stacks = net::Super_stack::inet().ip4_stacks();
+    auto& stacks = net::Super_stack::inet().stacks();
     for(const auto& stack : stacks) {
       for(const auto& pair : stack)
         serialize_stack(writer, pair.second);
@@ -627,7 +627,7 @@ namespace uplink {
 
   std::shared_ptr<net::Conntrack> get_first_conntrack()
   {
-    for(auto& stacks : net::Super_stack::inet().ip4_stacks()) {
+    for(auto& stacks : net::Super_stack::inet().stacks()) {
       for(auto& stack : stacks)
       {
         if(stack.second != nullptr and stack.second->conntrack() != nullptr)

--- a/src/net/configure.cpp
+++ b/src/net/configure.cpp
@@ -67,7 +67,7 @@ void configure(const rapidjson::Value& net)
   Expects(net.IsArray() && "Member net is not an array");
 
   auto configs = net.GetArray();
-  if(configs.Size() > Super_stack::inet().ip4_stacks().size())
+  if(configs.Size() > Super_stack::inet().stacks().size())
     MYINFO("! WARNING: Found more configs than there are interfaces");
   // Iterate all interfaces in config
   for(auto& val : configs)

--- a/src/net/super_stack.cpp
+++ b/src/net/super_stack.cpp
@@ -27,7 +27,7 @@ Inet& Super_stack::create(hw::Nic& nic, int N, int sub)
   INFO("Network", "Creating stack for %s on %s (MTU=%u)",
         nic.driver_name(), nic.device_name().c_str(), nic.MTU());
 
-  auto& stacks = inet().ip4_stacks_.at(N);
+  auto& stacks = inet().stacks_.at(N);
 
   auto it = stacks.find(sub);
   if(it != stacks.end() and it->second != nullptr) {
@@ -57,7 +57,7 @@ Inet& Super_stack::get(int N)
     throw Stack_not_found{"No IP4 stack found with index: " + std::to_string(N) +
       ". Missing device (NIC) or driver."};
 
-  auto& stacks = inet().ip4_stacks_.at(N);
+  auto& stacks = inet().stacks_.at(N);
 
   if(stacks[0] != nullptr)
     return *stacks[0];
@@ -73,7 +73,7 @@ Inet& Super_stack::get(int N, int sub)
     throw Stack_not_found{"No IP4 stack found with index: " + std::to_string(N) +
       ". Missing device (NIC) or driver."};
 
-  auto& stacks = inet().ip4_stacks_.at(N);
+  auto& stacks = inet().stacks_.at(N);
 
   auto it = stacks.find(sub);
 
@@ -95,7 +95,7 @@ Inet& Super_stack::get(const std::string& mac)
   if(index < 0)
     throw Stack_not_found{"No NIC found with MAC address " + mac};
 
-  auto& stacks = inet().ip4_stacks_.at(index);
+  auto& stacks = inet().stacks_.at(index);
   auto& stack = stacks[0];
   if(stack != nullptr) {
     Expects(stack->link_addr() == link_addr);
@@ -123,8 +123,8 @@ Super_stack::Super_stack()
     INFO("Network", "No registered network interfaces found");
 
   for (size_t i = 0; i < hw::Devices::devices<hw::Nic>().size(); i++) {
-    ip4_stacks_.emplace_back();
-    ip4_stacks_.back()[0] = nullptr;
+    stacks_.emplace_back();
+    stacks_.back()[0] = nullptr;
   }
 }
 

--- a/src/net/super_stack.cpp
+++ b/src/net/super_stack.cpp
@@ -109,7 +109,7 @@ Inet& Super_stack::get(const std::string& mac)
 // Duplication of code to keep sanity intact
 Inet& Super_stack::get(const std::string& mac, int sub)
 {
-  auto index = hw::Devices::nic_index(mac);
+  auto index = hw::Devices::nic_index(mac.c_str());
 
   if(index < 0)
     throw Stack_not_found{"No NIC found with MAC address " + mac};

--- a/test/net/unit/super_stack.cpp
+++ b/test/net/unit/super_stack.cpp
@@ -36,7 +36,7 @@ CASE("Super stack functionality")
   nics.push_back(std::make_unique<Nic_mock>());
 
   // 3 stacks are preallocated
-  EXPECT(Super_stack::inet().ip4_stacks().size() == 3);
+  EXPECT(Super_stack::inet().stacks().size() == 3);
 
   // Retreiving the first stack creates an interface on the first nic
   auto& stack1 = Super_stack::get(0);
@@ -76,20 +76,6 @@ CASE("Super stack functionality")
   stack_err = false;
   try {
     Super_stack::inet().create(my_nic, 0, 0);
-  } catch(const Super_stack_err&) {
-    stack_err = true;
-  }
-  EXPECT(stack_err == true);
-
-  // Also possible to create without assigning index, which means it takes the first free one
-  auto& custom_created_stack = Super_stack::inet().create(my_nic);
-  EXPECT(&custom_created_stack == &Super_stack::get(1));
-
-  // Not allowed to create if all indexes are occupied tho
-  Super_stack::get(2); // occupy the last free one
-  stack_err = false;
-  try {
-    Super_stack::inet().create(my_nic);
   } catch(const Super_stack_err&) {
     stack_err = true;
   }

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -378,9 +378,13 @@ class qemu(hypervisor):
                              for mod in mods])
         return ["-initrd", mods_list]
 
-    def net_arg(self, backend, device, if_name = "net0", mac = None, bridge = None):
-        qemu_ifup = INCLUDEOS_HOME + "/includeos/scripts/qemu-ifup"
-        qemu_ifdown = INCLUDEOS_HOME + "/includeos/scripts/qemu-ifdown"
+    def net_arg(self, backend, device, if_name = "net0", mac = None, bridge = None, scripts = None):
+        if scripts:
+            qemu_ifup = scripts + "qemu-ifup"
+            qemu_ifdown = scripts + "qemu-ifdown"
+        else:
+            qemu_ifup = INCLUDEOS_HOME + "/includeos/scripts/qemu-ifup"
+            qemu_ifdown = INCLUDEOS_HOME + "/includeos/scripts/qemu-ifdown"
 
         # FIXME: this needs to get removed, e.g. fetched from the schema
         names = {"virtio" : "virtio-net", "vmxnet" : "vmxnet3", "vmxnet3" : "vmxnet3"}
@@ -523,7 +527,8 @@ class qemu(hypervisor):
             for net in self._config["net"]:
                 mac = net["mac"] if "mac" in net else None
                 bridge = net["bridge"] if "bridge" in net else None
-                net_args += self.net_arg(net["backend"], net["device"], "net"+str(i), mac, bridge)
+                scripts = net["scripts"] if "scripts" in net else None
+                net_args += self.net_arg(net["backend"], net["device"], "net"+str(i), mac, bridge, scripts)
                 i+=1
 
         mem_arg = []


### PR DESCRIPTION
With this small change, `vm.json` now supports the `scripts` member in `net`, which means qemu can use another ifup/ifdown script than the default one (`/includeos/scripts/qemu-ifup`).

The `create_bridge.sh` already (kinda) supported creating your own custom bridge, but now you also need to assign a mac address so you can have them different.

Usage:
`$ ./create_bridge.sh bridge44 10.0.1.1 255.255.255.0 c0:ff:0a:00:00:01`

Then I copy the `qemu-if*` scripts to `~/dev/bridge44/`, and edit the `BRIDGE` value inside the scripts to `bridge44`. Executable permission also needs to be set:
`$ chmod +x ~/dev/bridge44/qemu-if*`

In `vm.json` I point to the script path (they have to be named the same):
```
"net" : [
    {"device" : "vmxnet3", "mac" : "c0:01:0a:00:00:aa", "scripts": "/Users/andreas/dev/bridge44/"},
    {"device" : "vmxnet3", "mac" : "c0:01:0a:00:00:2a"}
  ]
```

This allows daredevils (like me) to create and try out the routing facilities we have. Not yet so stream lined - improvements are gladly welcomed!