### PR TITLE
statman: Refactor and simplify to use std::deque

### DIFF
--- a/api/util/statman.hpp
+++ b/api/util/statman.hpp
@@ -21,8 +21,8 @@
 
 #include <common>
 #include <cstddef>
+#include <deque>
 #include <string>
-#include <membitmap>
 #include <smp_utils>
 
 struct Stats_out_of_memory : public std::out_of_range {
@@ -51,32 +51,29 @@ public:
   };
 
   Stat(const Stat_type type, const std::string& name);
+  Stat(const Stat& other);
+  Stat& operator=(const Stat& other);
   ~Stat() = default;
 
   // increment stat counter
   void operator++();
 
-  ///
   Stat_type type() const noexcept
   { return type_; }
 
-  ///
   const char* name() const noexcept
   { return name_; }
 
-  ///
   bool unused() const noexcept {
     return name_[0] == 0;
   }
 
-  ///
-  float& get_float();
-
-  ///
-  uint32_t& get_uint32();
-
-  ///
-  uint64_t& get_uint64();
+  const float&    get_float() const;
+  float&          get_float();
+  const uint32_t& get_uint32() const;
+  uint32_t&       get_uint32();
+  const uint64_t& get_uint64() const;
+  uint64_t&       get_uint64();
 
   std::string to_string() const;
 
@@ -89,32 +86,20 @@ private:
   Stat_type type_;
 
   char name_[MAX_NAME_LEN+1];
-
-  Stat(const Stat& other) = delete;
-  Stat(const Stat&& other) = delete;
-  Stat& operator=(const Stat& other) = delete;
-  Stat& operator=(Stat&& other) = delete;
-
 }; //< class Stat
 
 
 class Statman {
 public:
-  using Size_type = ptrdiff_t;
-
   // retrieve main instance of Statman
   static Statman& get();
 
   // access a Stat by a given index
-  const Stat& operator[] (const int i) const
-  {
-    if (i < 0 || i >= cend() - cbegin())
-      throw std::out_of_range("Index " + std::to_string(i) + " was out of range");
-    return stats_[i];
+  const Stat& operator[] (const size_t i) const {
+    return m_stats.at(i);
   }
-  Stat& operator[] (const int i)
-  {
-    return const_cast<Stat&>(static_cast<const Statman&>(*this)[i]);
+  Stat& operator[] (const size_t i) {
+    return m_stats.at(i);
   }
 
   /**
@@ -122,84 +107,76 @@ public:
    **/
   Stat& create(const Stat::Stat_type type, const std::string& name);
   // retrieve stat based on address from stats counter: &stat.get_xxx()
-  Stat& get(const void* addr);
+  Stat& get(const Stat* addr);
   // if you know the name of a statistic already
   Stat& get_by_name(const char* name);
   // free/delete stat based on address from stats counter
   void free(void* addr);
 
   /**
-   * Returns the max capacity of the container
-   */
-  Size_type capacity() const noexcept
-  { return end_stats_ - stats_; }
-
-  /**
    * Returns the number of used elements
    */
-  Size_type size() const noexcept
-  { return bitmap.count_set(); }
+  size_t size() const noexcept {
+    return m_stats.size() - m_stats[0].get_uint32();
+  }
 
   /**
    * Returns the number of bytes necessary to dump stats
    */
-  Size_type num_bytes() const noexcept
-  { return (cend() - cbegin()) * sizeof(Stat); }
+  size_t num_bytes() const noexcept
+  { return sizeof(*this) + size() * sizeof(Stat); }
 
   /**
    * Is true if the span stats_ contains no Stat-objects
    */
-  bool empty() const noexcept
-  { return size() == 0; }
+  bool empty() const noexcept { return m_stats.empty(); }
 
-  /**
-   * Returns true if the container is full
-   */
-  bool full() const noexcept
-  { return size() == capacity(); }
-
-  /**
-   *  Returns a pointer to the first element
-   */
-  const Stat* cbegin() const noexcept
-  { return stats_; }
-
-  /**
-   *  Returns a pointer to after the last used element
-   */
-  const Stat* cend() const noexcept {
-    int idx = bitmap.last_set() + 1; // 0 .. N-1
-    return &stats_[idx];
-  }
-
-  Stat* begin() noexcept { return (Stat*) cbegin(); }
-  Stat* end() noexcept { return (Stat*) cend(); }
+  auto begin() const noexcept { return m_stats.begin(); }
+  auto end() const noexcept { return m_stats.end(); }
+  auto cbegin() const noexcept { return m_stats.cbegin(); }
+  auto cend() const noexcept { return m_stats.cend(); }
 
   void store(uint32_t id, liu::Storage&);
   void restore(liu::Restore&);
 
-  void init(const uintptr_t location, const Size_type size);
-
-  Statman() {}
-  Statman(const uintptr_t location, const Size_type size)
-  {
-    init(location, size);
-  }
-  ~Statman();
-
+  Statman();
 private:
-  Stat* stats_;
-  Stat* end_stats_;
-  MemBitmap::word* bdata = nullptr;
-  MemBitmap bitmap;
+  std::deque<Stat> m_stats;
 #ifdef INCLUDEOS_SMP_ENABLE
   spinlock_t stlock = 0;
 #endif
+  ssize_t find_free_stat() const noexcept;
 
   Statman(const Statman& other) = delete;
   Statman(const Statman&& other) = delete;
   Statman& operator=(const Statman& other) = delete;
   Statman& operator=(Statman&& other) = delete;
 }; //< class Statman
+
+inline float& Stat::get_float() {
+  if (UNLIKELY(type_ != FLOAT)) throw Stats_exception{"Stat type is not a float"};
+  return f;
+}
+inline uint32_t& Stat::get_uint32() {
+  if (UNLIKELY(type_ != UINT32)) throw Stats_exception{"Stat type is not an uint32"};
+  return ui32;
+}
+inline uint64_t& Stat::get_uint64() {
+  if (UNLIKELY(type_ != UINT64)) throw Stats_exception{"Stat type is not an uint64"};
+  return ui64;
+}
+
+inline const float& Stat::get_float() const {
+  if (UNLIKELY(type_ != FLOAT)) throw Stats_exception{"Stat type is not a float"};
+  return f;
+}
+inline const uint32_t& Stat::get_uint32() const {
+  if (UNLIKELY(type_ != UINT32)) throw Stats_exception{"Stat type is not an uint32"};
+  return ui32;
+}
+inline const uint64_t& Stat::get_uint64() const {
+  if (UNLIKELY(type_ != UINT64)) throw Stats_exception{"Stat type is not an uint64"};
+  return ui64;
+}
 
 #endif //< UTIL_STATMAN_HPP

--- a/linux/src/os.cpp
+++ b/linux/src/os.cpp
@@ -80,13 +80,9 @@ static void begin_timer(std::chrono::nanoseconds usec)
 }
 static void stop_timers() {}
 
-#include <statman>
 void OS::start(const char* cmdline)
 {
   __libc_initialized = true;
-  // statman
-  static char statman_data[1 << 16];
-  Statman::get().init((uintptr_t) statman_data, sizeof(statman_data));
   // setup Linux timer (with signal handler)
   struct sigevent sev;
   sev.sigev_notify = SIGEV_SIGNAL;

--- a/src/platform/x86_pc/kernel_start.cpp
+++ b/src/platform/x86_pc/kernel_start.cpp
@@ -76,7 +76,6 @@ static void global_ctor_test(){
 
 int kernel_main(int, char * *, char * *) {
   PRATTLE("<kernel_main> libc initialization complete \n");
-  kernel_sanity_checks();
   Expects(__global_ctors_ok == 42);
   extern bool __libc_initialized;
   __libc_initialized = true;

--- a/src/platform/x86_pc/os.cpp
+++ b/src/platform/x86_pc/os.cpp
@@ -24,7 +24,6 @@
 #include <kernel/memory.hpp>
 #include <kprint>
 #include <service>
-#include <statman>
 #include <cstdio>
 #include <cinttypes>
 #include "cmos.hpp"
@@ -38,7 +37,6 @@
 #endif
 
 extern "C" void* get_cpu_esp();
-extern "C" void kernel_sanity_checks();
 extern uintptr_t _start;
 extern uintptr_t _end;
 extern uintptr_t _ELF_START_;
@@ -136,7 +134,6 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr)
   extern void elf_protect_symbol_areas();
   elf_protect_symbol_areas();
 
-  memmap.assign_range({0x8000, 0xffff, "Statman"});
 #if defined(ARCH_x86_64)
   // protect the basic pagetable used by LiveUpdate and any other
   // systems that need to exit long/protected mode
@@ -157,11 +154,6 @@ void OS::start(uint32_t boot_magic, uint32_t boot_addr)
   MYINFO("Virtual memory map");
   for (const auto& entry : memmap)
       INFO2("%s", entry.second.to_string().c_str());
-
-  /// STATMAN ///
-  PROFILE("Statman");
-  /// initialize on page 9, 8 pages in size
-  Statman::get().init(0x8000, 0x8000);
 
   PROFILE("Platform init");
   extern void __platform_init();

--- a/src/platform/x86_solo5/os.cpp
+++ b/src/platform/x86_solo5/os.cpp
@@ -94,10 +94,6 @@ void OS::start(const char* cmdline)
   void* esp = get_cpu_esp();
   MYINFO("Stack: %p", esp);
 
-  /// STATMAN ///
-  /// initialize on page 7, 2 pages in size
-  Statman::get().init(0x6000, 0x3000);
-
   PROFILE("Memory map");
   // Assign memory ranges used by the kernel
   auto& memmap = memory_map();

--- a/src/util/statman.cpp
+++ b/src/util/statman.cpp
@@ -16,24 +16,33 @@
 // limitations under the License.
 
 #include <statman>
-#include <iterator>
 #include <info>
 #include <smp_utils>
 
-__attribute__((weak))
+// this is done to make sure construction only happens here
+static Statman statman_instance;
 Statman& Statman::get() {
-  static Statman statman;
-  return statman;
+  return statman_instance;
 }
 
-///////////////////////////////////////////////////////////////////////////////
 Stat::Stat(const Stat_type type, const std::string& name)
   : ui64(0), type_{type}
 {
-  if(name.size() > MAX_NAME_LEN)
-    throw Stats_exception{"Creating stat: Name cannot be longer than " + std::to_string(MAX_NAME_LEN) + " characters"};
+  if (name.size() > MAX_NAME_LEN)
+    throw Stats_exception("Stat name cannot be longer than " + std::to_string(MAX_NAME_LEN) + " characters");
 
   snprintf(name_, sizeof(name_), "%s", name.c_str());
+}
+Stat::Stat(const Stat& other) {
+  this->ui64 = other.ui64;
+  this->type_ = other.type_;
+  strncpy(this->name_, other.name_, MAX_NAME_LEN);
+}
+Stat& Stat::operator=(const Stat& other) {
+  this->ui64 = other.ui64;
+  this->type_ = other.type_;
+  strncpy(this->name_, other.name_, MAX_NAME_LEN);
+  return *this;
 }
 
 void Stat::operator++() {
@@ -41,29 +50,8 @@ void Stat::operator++() {
     case UINT32: ui32++;    break;
     case UINT64: ui64++;    break;
     case FLOAT:  f += 1.0f; break;
-    default:     throw Stats_exception{"Incrementing stat: Invalid Stat_type"};
+    default: throw Stats_exception("Invalid stat type encountered when incrementing");
   }
-}
-
-float& Stat::get_float() {
-  if (type_ not_eq FLOAT)
-    throw Stats_exception{"Get stat: Stat_type is not a float"};
-
-  return f;
-}
-
-uint32_t& Stat::get_uint32() {
-  if (type_ not_eq UINT32)
-    throw Stats_exception{"Get stat: Stat_type is not an uint32_t"};
-
-  return ui32;
-}
-
-uint64_t& Stat::get_uint64() {
-  if (type_ not_eq UINT64)
-    throw Stats_exception{"Get stat: Stat_type is not an uint64_t"};
-
-  return ui64;
 }
 
 std::string Stat::to_string() const {
@@ -71,86 +59,84 @@ std::string Stat::to_string() const {
     case UINT32: return std::to_string(ui32);
     case UINT64: return std::to_string(ui64);
     case FLOAT:  return std::to_string(f);
-    default:     return "Invalid Stat_type";
+    default:     return "Unknown stat type";
   }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-
-void Statman::init(const uintptr_t start, const Size_type num_bytes)
-{
-  if (num_bytes < 0)
-    throw Stats_exception("Can't initialize statman with negative size");
-
-  const int N = num_bytes / sizeof(Stat);
-  this->stats_     = reinterpret_cast<Stat*>(start);
-  this->end_stats_ = this->stats_ + N;
-
-  // create bitmap
-  int chunks = N / (sizeof(MemBitmap::word) * 8) + 1;
-  delete[] bdata;
-  bdata = new MemBitmap::word[chunks]();
-  bitmap = MemBitmap(bdata, chunks);
-
-  INFO("Statman", "Initialized with %u stats capacity", (uint32_t) capacity());
-}
-Statman::~Statman()
-{
-  delete[] bdata;
+Statman::Statman() {
+  this->create(Stat::UINT32, "statman.unused_stats");
 }
 
-Stat& Statman::create(const Stat::Stat_type type, const std::string& name) {
+Stat& Statman::create(const Stat::Stat_type type, const std::string& name)
+{
 #ifdef INCLUDEOS_SMP_ENABLE
   volatile scoped_spinlock lock(this->stlock);
 #endif
   if (name.empty())
     throw Stats_exception("Cannot create Stat with no name");
 
-  const int idx = bitmap.first_free();
-  if (idx == -1 || idx >= capacity())
-    throw Stats_out_of_memory{};
+  const ssize_t idx = this->find_free_stat();
+  if (idx < 0) {
+    m_stats.emplace_back(type, name);
+    return m_stats.back();
+  }
 
   // note: we have to create this early in case it throws
-  auto& stat = *new (&stats_[idx]) Stat(type, name);
-  bitmap.set(idx);
+  auto& stat = *new (&m_stats[idx]) Stat(type, name);
+  m_stats[0].get_uint32()--; // decrease unused stats
   return stat;
 }
 
-Stat& Statman::get(const void* addr)
+Stat& Statman::get(const Stat* st)
 {
-  auto* st = (Stat*) addr;
-  auto  mod  = ((uintptr_t) st - (uintptr_t) stats_) % sizeof(Stat);
-
-  if (st >= cbegin() && st < cend())
-  if (mod == 0) // verify stat boundary
-  {
-    if (st->unused() == false)
-      return *st;
-    else
-      throw Stats_exception{"Accessing deleted stat"};
+#ifdef INCLUDEOS_SMP_ENABLE
+  volatile scoped_spinlock lock(this->stlock);
+#endif
+  for (auto& stat : this->m_stats) {
+    if (&stat == st) {
+      if (stat.unused() == false)
+          return stat;
+      throw Stats_exception("Accessing deleted stat");
+    }
   }
-
-  throw std::out_of_range("Address out of range");
+  throw std::out_of_range("Not a valid stat in this statman instance");
 }
 
 Stat& Statman::get_by_name(const char* name)
 {
-  for (auto* st = begin(); st < end(); st++)
+#ifdef INCLUDEOS_SMP_ENABLE
+  volatile scoped_spinlock lock(this->stlock);
+#endif
+  for (auto& stat : this->m_stats)
   {
-    if (st->unused() == false)
-    if (strncmp(st->name(), name, Stat::MAX_NAME_LEN) == 0)
-        return *st;
+    if (stat.unused() == false)
+    if (strncmp(stat.name(), name, Stat::MAX_NAME_LEN) == 0)
+        return stat;
   }
   throw std::out_of_range("No stat found with exact given name");
 }
 
 void Statman::free(void* addr)
 {
-  auto& stat = this->get(addr);
-  auto  idx  = &stat - cbegin();
-
+  auto& stat = this->get((Stat*) addr);
+#ifdef INCLUDEOS_SMP_ENABLE
+  volatile scoped_spinlock lock(this->stlock);
+#endif
   // delete entry
   new (&stat) Stat(Stat::FLOAT, "");
-  bitmap.reset(idx);
+  m_stats[0].get_uint32()++; // increase unused stats
+}
+
+ssize_t Statman::find_free_stat() const noexcept
+{
+#ifdef INCLUDEOS_SMP_ENABLE
+  volatile scoped_spinlock lock(this->stlock);
+#endif
+  for (size_t i = 0; i < this->m_stats.size(); i++)
+  {
+    if (m_stats[i].unused()) return i;
+  }
+  return -1;
 }

--- a/src/util/statman_liu.cpp
+++ b/src/util/statman_liu.cpp
@@ -3,28 +3,21 @@
 
 void Statman::store(uint32_t id, liu::Storage& store)
 {
-  store.add_buffer(id, this->cbegin(), this->num_bytes());
+  store.add_vector<Stat>(id, {m_stats.begin(), m_stats.end()});
 }
 void Statman::restore(liu::Restore& store)
 {
-  auto buffer = store.as_buffer(); store.go_next();
+  auto stats = store.as_vector<const Stat>();
 
-  assert(buffer.size() % sizeof(Stat) == 0);
-  const size_t count = buffer.size() / sizeof(Stat);
-
-  const Stat* ptr = (Stat*) buffer.data();
-  const Stat* end = ptr + count;
-
-  for (; ptr < end; ptr++)
+  for (auto& merge_stat : stats)
   {
     try {
-      auto& stat = this->get_by_name(ptr->name());
-      std::memcpy(&stat, ptr, sizeof(Stat));
+      // TODO: merge here
+      this->get_by_name(merge_stat.name()) = merge_stat;
     }
     catch (const std::exception& e)
     {
-      auto& stat = this->create(ptr->type(), ptr->name());
-      std::memcpy(&stat, ptr, sizeof(Stat));
+      this->create(merge_stat.type(), merge_stat.name()) = merge_stat;
     }
   }
 }

--- a/test/kernel/integration/LiveUpdate/test_boot.cpp
+++ b/test/kernel/integration/LiveUpdate/test_boot.cpp
@@ -59,7 +59,7 @@ static void boot_resume_all(Restore& thing)
 #endif
   // statman
   auto& stm = Statman::get();
-  stm.restore(thing);
+  stm.restore(thing); thing.go_next();
   auto& stat = stm.get_by_name("system.updates");
   assert(stat.get_uint32() > 0);
   thing.pop_marker();

--- a/test/kernel/integration/LiveUpdate/vm.json
+++ b/test/kernel/integration/LiveUpdate/vm.json
@@ -3,5 +3,5 @@
   "net" : [
     {"device" : "virtio"}
   ],
-  "mem" : 64
+  "mem" : 256
 }

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -34,17 +34,6 @@ void* aligned_alloc(size_t alignment, size_t size) {
 char _DISK_START_;
 char _DISK_END_;
 
-#include <util/statman.hpp>
-Statman& Statman::get() {
-  static uintptr_t start {0};
-  static const size_t memsize = 0x1000000;
-  if (!start) {
-    start = (uintptr_t) malloc(memsize);
-  }
-  static Statman statman_{start, memsize / sizeof(Stat)};
-  return statman_;
-}
-
 /// RTC ///
 #include <rtc>
 RTC::timestamp_t RTC::booted_at = 0;


### PR DESCRIPTION
- Use standard deque
- Remove max capacity, making it dynamic
- Make serialization more C++