### PR TITLE
kernel: separate liveupdate from heap, improve OOM handling

### DIFF
--- a/api/kernel/os.hpp
+++ b/api/kernel/os.hpp
@@ -203,6 +203,9 @@ public:
     return memory_end_;
   }
 
+  /** Total used memory, including reserved areas */
+  static size_t total_memuse() noexcept;
+
   static void init_heap(uintptr_t phys_begin, size_t size) noexcept;
 
   /**
@@ -211,8 +214,15 @@ public:
    */
   static bool is_live_updated() noexcept;
 
-  /** Returns the automatic location set aside for storing system and program state **/
+  /** Returns the virtual memory location set aside for storing system and program state **/
   static void* liveupdate_storage_area() noexcept;
+
+  /** Returns the amount of memory set aside for LiveUpdate */
+  static size_t liveupdate_phys_size(size_t) noexcept;
+
+  /** Computes the physical location of LiveUpdate storage area */
+  static uintptr_t liveupdate_phys_loc(size_t) noexcept;
+
 
   /**
    * A map of memory ranges. The key is the starting address in numeric form.

--- a/api/util/bitops.hpp
+++ b/api/util/bitops.hpp
@@ -193,7 +193,10 @@ inline bool is_aligned(uintptr_t A, uintptr_t ptr)
   return (ptr & (A - 1)) == 0;
 }
 
-
+inline size_t upercent(size_t a, size_t b) noexcept
+{
+  return (100 * a + b / 2) / b;
+}
 
 } // ns bitops
 } // ns util

--- a/src/kernel/heap.cpp
+++ b/src/kernel/heap.cpp
@@ -60,6 +60,9 @@ uintptr_t OS::heap_end() noexcept
   return mmap_allocation_end();
 }
 
+size_t OS::total_memuse() noexcept {
+  return heap_usage() + OS::liveupdate_phys_size(OS::heap_max()) + heap_begin_;
+}
 
 constexpr size_t heap_alignment = 4096;
 __attribute__((weak)) ssize_t __brk_max = 0x100000;

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -81,6 +81,16 @@ void* OS::liveupdate_storage_area() noexcept
 }
 
 __attribute__((weak))
+size_t OS::liveupdate_phys_size(size_t phys_max) noexcept {
+  return 4096;
+};
+
+__attribute__((weak))
+size_t OS::liveupdate_phys_loc(size_t phys_max) noexcept {
+  return phys_max - liveupdate_phys_size(phys_max);
+};
+
+__attribute__((weak))
 void OS::setup_liveupdate(uintptr_t)
 {
   // without LiveUpdate: storage location is at the last page?

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -23,6 +23,7 @@
 #include <info>
 #include <smp>
 #include <cstring>
+#include <util/bitops.hpp>
 
 #if defined (UNITTESTS) && !defined(__MACH__)
 #define THROW throw()
@@ -139,9 +140,11 @@ void panic(const char* why)
   uintptr_t heap_total = OS::heap_max() - OS::heap_begin();
   fprintf(stderr, "Heap is at: %p / %p  (diff=%lu)\n",
          (void*) OS::heap_end(), (void*) OS::heap_max(), (ulong) (OS::heap_max() - OS::heap_end()));
-  fprintf(stderr, "Heap area: %lu / %lu Kb (allocated %zu kb)\n\n", // (%.2f%%)\n",
+  fprintf(stderr, "Heap area: %lu / %lu Kb (allocated %zu kb)\n", // (%.2f%%)\n",
          (ulong) (OS::heap_end() - OS::heap_begin()) / 1024,
           (ulong) heap_total / 1024, OS::heap_usage() / 1024); //, total * 100.0);
+  fprintf(stderr, "Total memory use: ~%zu%% (%zu of %zu b)\n",
+          util::bits::upercent(OS::total_memuse(), OS::memory_end()), OS::total_memuse(), OS::memory_end());
 
   print_backtrace();
   fflush(stderr);

--- a/src/musl/mmap.cpp
+++ b/src/musl/mmap.cpp
@@ -18,7 +18,8 @@ Alloc& os::mem::allocator() {
 uintptr_t __init_mmap(uintptr_t addr_begin)
 {
   auto aligned_begin = (addr_begin + Alloc::align - 1) & ~(Alloc::align - 1);
-  int64_t len = (OS::heap_max() - aligned_begin) & ~int64_t(Alloc::align - 1);
+  auto mem_end = OS::liveupdate_phys_loc(OS::heap_max());
+  int64_t len = (mem_end - aligned_begin) & ~int64_t(Alloc::align - 1);
 
   alloc = Alloc::create((void*)aligned_begin, len);
   kprintf("* mmap initialized. Begin: 0x%zx, end: 0x%zx\n",

--- a/src/net/buffer_store.cpp
+++ b/src/net/buffer_store.cpp
@@ -65,7 +65,7 @@ namespace net {
       else
           throw std::runtime_error("This BufferStore has run out of buffers");
     }
-    
+
     auto* addr = available_.back();
     available_.pop_back();
     BSD_PRINT("%d: Gave away %p, %zu buffers remain\n",
@@ -76,7 +76,9 @@ namespace net {
   void BufferStore::create_new_pool()
   {
     auto* pool = (uint8_t*) aligned_alloc(OS::page_size(), poolsize_);
-    assert(pool != nullptr);
+    if (UNLIKELY(pool == nullptr)) {
+      throw std::runtime_error("Buffer store failed to allocate memory");
+    }
     this->pools_.push_back(pool);
 
     for (uint8_t* b = pool; b < pool + poolsize_; b += bufsize_) {
@@ -90,7 +92,7 @@ namespace net {
   {
     // TODO: hmm
   }
-  
+
   __attribute__((weak))
   bool BufferStore::growth_enabled() const {
     return true;

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -218,8 +218,11 @@ uintptr_t __brk_max = 0;
 uintptr_t OS::heap_begin() noexcept {
   return 0;
 }
+
+uintptr_t OS::memory_end_ = 1 << 30;
+
 uintptr_t OS::heap_end() noexcept {
-  return 1 << 30;
+  return memory_end_;
 }
 
 size_t OS::heap_usage() noexcept {
@@ -228,6 +231,10 @@ size_t OS::heap_usage() noexcept {
 
 uintptr_t OS::heap_max() noexcept {
   return -1;
+}
+
+size_t OS::total_memuse() noexcept {
+  return heap_end();
 }
 
 #endif


### PR DESCRIPTION
This is supposed to prevent the heap from allocating memory inside the liveupdate area and better handle situations where the IP stack runs out of memory. There's also a new function that will report total memory usage including reserved areas, used here by panic to give a better idea of how close we are to actually being out of memory.