### PR TITLE
Minor fixes to buddy allocator

### DIFF
--- a/api/util/alloc_buddy.hpp
+++ b/api/util/alloc_buddy.hpp
@@ -199,7 +199,7 @@ namespace os::mem::buddy {
     }
 
     Addr_t highest_used() const noexcept {
-      return root().highest_used_r();
+      return std::min(root().highest_used_r(), start_addr_ + capacity());
     }
 
     Size_t bytes_free() const noexcept {


### PR DESCRIPTION
This is mainly fixes for the tests.

Fixes an off-by-one in the test for buddy allocator. Also takes overbooking into account when reporting "empty()" and "highest_used()". E.g. before this fix, if the allocator had attempted to allocate into the overbooking area empty would return false, even though no real allocations had happened, and "highest_used()" would falsely report that it had allocated into that area.
