### PR TITLE
Print last packet on panic

### DIFF
--- a/api/net/link_layer.hpp
+++ b/api/net/link_layer.hpp
@@ -23,6 +23,8 @@
 
 namespace net {
 
+extern void set_last_packet(net::Packet*);
+
 template <class T>
 class Link_layer : public hw::Nic {
 public:
@@ -81,7 +83,10 @@ public:
 protected:
   /** Called by the underlying physical driver inheriting the Link_layer */
   void receive(net::Packet_ptr pkt)
-  { link_.receive(std::move(pkt)); }
+  {
+    set_last_packet(pkt.get());
+    link_.receive(std::move(pkt));
+  }
 
 private:
   Protocol link_;

--- a/lib/mana/include/mana/components/dashboard/components/statman.hpp
+++ b/lib/mana/include/mana/components/dashboard/components/statman.hpp
@@ -62,7 +62,7 @@ public:
       writer.String(type);
 
       writer.Key("index");
-      writer.Int(&stat - statman_.begin());
+      writer.Int(std::distance(statman_.begin(), it));
 
       writer.EndObject();
     }

--- a/linux/userspace/CMakeLists.txt
+++ b/linux/userspace/CMakeLists.txt
@@ -6,6 +6,7 @@ set(NET_SOURCES
   ${IOS}/src/net/configure.cpp
   ${IOS}/src/net/super_stack.cpp
   ${IOS}/src/net/inet.cpp
+  ${IOS}/src/net/packet_debug.cpp
 
   ${IOS}/src/net/ethernet/ethernet.cpp
   ${IOS}/src/net/ip4/arp.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ set(OS_OBJECTS
   net/http/server_connection.cpp net/http/server.cpp net/http/response_writer.cpp
   net/ws/websocket.cpp ${OPENSSL_MODULES} ${BOTAN_MODULES}
   net/nat/nat.cpp net/nat/napt.cpp
+  net/packet_debug.cpp
   fs/disk.cpp fs/filesystem.cpp fs/dirent.cpp fs/mbr.cpp fs/path.cpp
   fs/fat.cpp fs/fat_async.cpp fs/fat_sync.cpp fs/memdisk.cpp
   # POSIX

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -102,6 +102,10 @@ extern "C" __attribute__((noreturn)) void panic_epilogue(const char*);
 extern "C" __attribute__ ((weak))
 void panic_perform_inspection_procedure() {}
 
+namespace net {
+  __attribute__((weak)) void print_last_packet() {}
+}
+
 /**
  * panic:
  * Display reason for kernel panic
@@ -142,6 +146,9 @@ void panic(const char* why)
   fprintf(stderr, "Heap area: %lu / %lu Kb (allocated %zu kb)\n\n", // (%.2f%%)\n",
          (ulong) (OS::heap_end() - OS::heap_begin()) / 1024,
           (ulong) heap_total / 1024, OS::heap_usage() / 1024); //, total * 100.0);
+
+  // last packet
+  net::print_last_packet();
 
   print_backtrace();
   fflush(stderr);

--- a/src/net/packet_debug.cpp
+++ b/src/net/packet_debug.cpp
@@ -1,0 +1,84 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2018 IncludeOS AS, Oslo, Norway
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <net/packet.hpp>
+#include <net/ethernet/ethernet.hpp>
+
+namespace net {
+
+  static net::Packet* last_packet = nullptr;
+  static uint8_t* layer_begin = nullptr;
+
+  void set_last_packet(net::Packet* ptr)
+  {
+    Expects(ptr != nullptr);
+    last_packet = ptr;
+    layer_begin = ptr->layer_begin();
+  }
+
+  void print_last_packet()
+  {
+    if(last_packet == nullptr)
+      return;
+
+    auto* pkt = last_packet;
+    fprintf(stderr, "*** Last packet:\n");
+    fprintf(stderr, "Buffer: Begin: %p End: %p Size: %i\n",
+      pkt->buf(), pkt->buffer_end(), pkt->bufsize());
+    fprintf(stderr, "Layer: Recorded: %p Current: %p (%lub offset)\n",
+      layer_begin, pkt->layer_begin(), pkt->layer_begin() - layer_begin);
+    fprintf(stderr, "Size: %i ", pkt->size());
+    fprintf(stderr, "Capacity: %i ", pkt->capacity());
+    fprintf(stderr, "Data end: %p \n", pkt->data_end());
+
+    // assume ethernet
+    auto* layer = layer_begin;
+    Ethernet::header* eth = reinterpret_cast<Ethernet::header*>(layer);
+    fprintf(stderr, "Ethernet type: 0x%hx ", eth->type());
+    int print_len = sizeof(Ethernet::header);
+    switch(eth->type())
+    {
+      case Ethertype::IP4:
+      fprintf(stderr, "IPv4\n");
+      print_len += 20;
+      break;
+    case Ethertype::IP6:
+      fprintf(stderr, "IPv6\n");
+      print_len += 40;
+      break;
+    case Ethertype::ARP:
+      fprintf(stderr, "ARP\n");
+      print_len += 28;
+      break;
+    case Ethertype::VLAN:
+      fprintf(stderr, "VLAN\n");
+      print_len += 4;
+      break;
+    default:
+      fprintf(stderr, "Unknown\n");
+      print_len = 0;
+    }
+
+    // read 40 more optimistic bytes (could be garbage from old packet)
+    if(pkt->size() > print_len)
+      print_len += std::min(pkt->size() - print_len, 40);
+
+    fprintf(stderr, "Payload %i bytes from recorded layer begin (%p):\n", print_len, layer_begin);
+    for(int i = 0; i < print_len; i++)
+      fprintf(stderr, "%02x", *(layer_begin + i));
+    fprintf(stderr, "\n");
+  }
+}


### PR DESCRIPTION
```
Assertion failed: false (/Users/andreas/dev/IncludeOS/examples/demo_service/service.cpp: operator(): 122)

	**** PANIC ****
CPU: 0, Reason: TKILL called
Heap is at: 0x837000 / 0x7fdffff  (diff=125472767)
Heap area: 3140 / 125671 Kb (allocated 2360 kb)
Total memory use: ~6% (7819264 of 134086656 b)
*** Found 1 plugin constructors:
Plugin: register_autoconf_plugin() (0x206cc0)
*** Last packet:
Buffer: Begin: 0x7cd038 End: 0x7cd245 Size: 525
Layer: Recorded: 0x7cd042 Current: 0x7cd050 (14b offset)
Size: 501 Capacity: 501 Data end: 0x7cd245
Ethernet type: 0x8 IPv4
Payload 74 bytes from recorded layer begin (0x7cd042):
c0010a00002ac0010a0000010800450001f500004000400624f50a0000010a00000eea6100506a692491706b263a801810157c6700000101080a2d0878d25bb21021474554202f204854

*** Backtrace:
[0] 0x0000000000206e10 + 0x209: panic
[1] 0x0000000000304a60 + 0x00e: syscall_SYS_tkill
[2] 0x000000000040f9a0 + 0x02c: raise
[3] 0x000000000021f6d0 + 0x16f: net::tcp::Read_request::insert(unsigned int, unsigned char const*, unsigned long, bool)
[4] 0x000000000021a060 + 0x0be: net::tcp::Connection::recv_data(net::tcp::Packet_v<std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> > > const&)
[5] 0x000000000021d830 + 0x08b: net::tcp::Connection::Established::handle(net::tcp::Connection&, net::tcp::Packet_v<std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> > >&)
[6] 0x0000000000219540 + 0x01c: net::tcp::Connection::segment_arrived(net::tcp::Packet_v<std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> > >&)
[7] 0x0000000000215090 + 0x170: net::TCP::receive(net::tcp::Packet_v<std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> > >&)
[8] 0x0000000000214ff0 + 0x049: net::TCP::receive(std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> >)
[9] 0x0000000000329290 + 0x045: spec::inplace<32ul, 16ul, void, std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> > >::inplace<delegate<void (std::__1::unique_ptr<net::Packet, std::__1::default_
[10] 0x000000000022cc60 + 0x6b7: net::IP4::receive(std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> >, bool)
[11] 0x0000000000328f70 + 0x048: spec::inplace<32ul, 16ul, void, std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> >, bool>::inplace<delegate<void (std::__1::unique_ptr<net::Packet, std::__1::de
[12] 0x0000000000212530 + 0x1ef: net::Ethernet::receive(std::__1::unique_ptr<net::Packet, std::__1::default_delete<net::Packet> >)
[13] 0x0000000000203820 + 0x134: VirtioNet::msix_recv_handler()
[14] 0x0000000000208220 + 0x0a9: Events::process_events()
```