### PR TITLE
Dockerfile and gitignore additions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,3 @@
 build_*
 IncludeOS_install/
-diskimagebuild/build
-vmbuild/build
-src/chainload/build
-test/
-examples/
 **/build

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.img.*
 *.gz
 *.tar
+*nacl.txt
 .DS_Store
 nbproject
 dummy.disk
@@ -47,3 +48,6 @@ IncludeOS_install
 
 #CLion
 .idea/
+
+# Starbase disk file
+lib/uplink/starbase/disk

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ WORKDIR /root/IncludeOS
 COPY . .
 
 # Ability to specify custom tag that overwrites any existing tag. This will then match the reported IncludeOS version
-ARG TAG
+ARG CUSTOM_TAG
 RUN git describe --tags --dirty > /ios_version.txt
-RUN : ${TAG:=$(git describe --tags)} && git tag -d $(git describe --tags); git tag $TAG && git describe --tags --dirty > /tag.txt
+RUN : ${CUSTOM_TAG:=$(git describe --tags)} && git tag -d $(git describe --tags); git tag $CUSTOM_TAG && git describe --tags --dirty > /custom_tag.txt
 
 # Installation
 RUN ./install.sh -n
@@ -86,7 +86,7 @@ COPY --from=source-build  /root/IncludeOS/etc/install_dependencies_linux.sh /
 COPY --from=source-build  /root/IncludeOS/etc/use_clang_version.sh /
 COPY --from=source-build  /root/IncludeOS/lib/uplink/starbase /root/IncludeOS/lib/uplink/starbase/
 COPY --from=source-build  /ios_version.txt /
-COPY --from=source-build  /tag.txt /
+COPY --from=source-build  /custom_tag.txt /
 COPY --from=source-build  /root/IncludeOS/etc/docker_entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ COPY . .
 
 # Ability to specify custom tag that overwrites any existing tag. This will then match the reported IncludeOS version
 ARG TAG
-RUN : ${TAG:=$(git describe --tags)} && git tag -d $(git describe --tags); git tag $TAG && git describe --tags --dirty > /ios_version.txt
+RUN git describe --tags --dirty > /ios_version.txt
+RUN : ${TAG:=$(git describe --tags)} && git tag -d $(git describe --tags); git tag $TAG && git describe --tags --dirty > /tag.txt
 
 # Installation
 RUN ./install.sh -n
@@ -85,6 +86,7 @@ COPY --from=source-build  /root/IncludeOS/etc/install_dependencies_linux.sh /
 COPY --from=source-build  /root/IncludeOS/etc/use_clang_version.sh /
 COPY --from=source-build  /root/IncludeOS/lib/uplink/starbase /root/IncludeOS/lib/uplink/starbase/
 COPY --from=source-build  /ios_version.txt /
+COPY --from=source-build  /tag.txt /
 COPY --from=source-build  /root/IncludeOS/etc/docker_entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/etc/docker_entrypoint.sh
+++ b/etc/docker_entrypoint.sh
@@ -8,9 +8,7 @@ eval $( fixuid &> /dev/null )
 
 pushd / > /dev/null
 if version=$(grep -oP 'CLANG_VERSION_MIN_REQUIRED="\K[^"]+' use_clang_version.sh); then :
-elif version=$(grep -oP 'CLANG_VERSION_MIN_REQUIRED="\K[^"]+' install_dependencies_linux.sh); then :
-elif version=$(grep -oP 'CLANG_VERSION="\K[^"]+' install_dependencies_linux.sh); then :
-else version=3.8
+else version=5.0
 fi
 export CC=clang-$version
 export CXX=clang++-$version


### PR DESCRIPTION
Clean up dockerignore file. Clean up entrypoint script for docker. Add some useful ignores to gitignore.

Store both original IncludeOS `git describe` output and the custom tag.  