### PR TITLE
Add memory read barrier to prevent speculative execution error

### DIFF
--- a/api/arch.hpp
+++ b/api/arch.hpp
@@ -1,4 +1,4 @@
-// -*-C++-*-
+﻿// -*-C++-*-
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
 // Copyright 2017 Oslo and Akershus University College of Applied Sciences
@@ -36,7 +36,8 @@ extern void __arch_install_irq(uint8_t, void(*)());
 extern void __arch_subscribe_irq(uint8_t);
 extern void __arch_unsubscribe_irq(uint8_t);
 extern void __arch_preempt_forever(void(*)());
-
+extern inline void __arch_read_memory_barrier() noexcept;
+extern inline void __arch_write_memory_barrier() noexcept;
 inline void __arch_hw_barrier() noexcept;
 inline void __sw_barrier() noexcept;
 

--- a/api/arch/x86_64.hpp
+++ b/api/arch/x86_64.hpp
@@ -1,4 +1,4 @@
-// -*-C++-*-
+﻿// -*-C++-*-
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
 // Copyright 2017 Oslo and Akershus University College of Applied Sciences
@@ -20,6 +20,13 @@
 #define X86_64_ARCH_HPP
 
 #define ARCH_x86
+
+inline void __arch_read_memory_barrier() noexcept {
+  __asm volatile("lfence" ::: "memory");
+}
+inline void __arch_write_memory_barrier() noexcept {
+  __asm volatile("mfence" ::: "memory");
+}
 
 inline uint64_t __arch_cpu_cycles() noexcept {
   uint32_t hi, lo;


### PR DESCRIPTION
Added a read ahead barrier to prevent desc.len from beeing read before its set.