### PR TITLE
net: Include offset bytes (since size() is calculated from layer) in …

### DIFF
--- a/src/net/packet_debug.cpp
+++ b/src/net/packet_debug.cpp
@@ -38,8 +38,9 @@ namespace net {
     fprintf(stderr, "*** Last packet:\n");
     fprintf(stderr, "Buffer: Begin: %p End: %p Size: %i\n",
       pkt->buf(), pkt->buffer_end(), pkt->bufsize());
+    const size_t offset = pkt->layer_begin() - layer_begin;
     fprintf(stderr, "Layer: Recorded: %p Current: %p (%lub offset)\n",
-      layer_begin, pkt->layer_begin(), pkt->layer_begin() - layer_begin);
+      layer_begin, pkt->layer_begin(), offset);
     fprintf(stderr, "Size: %i ", pkt->size());
     fprintf(stderr, "Capacity: %i ", pkt->capacity());
     fprintf(stderr, "Data end: %p \n", pkt->data_end());
@@ -73,7 +74,7 @@ namespace net {
     }
 
     // ignore the above, just hope we can write the full content of the packet
-    print_len = pkt->size();
+    print_len = offset + pkt->size();
 
     fprintf(stderr, "Payload %i bytes from recorded layer begin (%p):", print_len, layer_begin);
     for(int i = 0; i < print_len; i++) {


### PR DESCRIPTION
…packet debug

Because of `size()` being calculated from layer, it will start printing from Ethernet anyway, and by that not print the last 14 bytes.