### PR TITLE
run: some fixes to vmrunner

### DIFF
--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -10,7 +10,6 @@ import traceback
 import validate_vm
 import signal
 import psutil
-import magic
 from shutil import copyfile
 
 from prettify import color
@@ -83,8 +82,9 @@ def info(*args):
 
 
 def file_type(filename):
-    with magic.Magic() as m:
-        return m.id_filename(filename)
+    p = subprocess.Popen(['file',filename],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+    output, errors = p.communicate()
+    return output
 
 def is_Elf64(filename):
     magic = file_type(filename)
@@ -553,7 +553,7 @@ class qemu(hypervisor):
             qemu_binary = self._config["qemu"]
 
         # TODO: sudo is only required for tap networking and kvm. Check for those.
-        command = ["sudo", "--preserve-env", qemu_binary]
+        command = ["sudo", qemu_binary]
         if self._kvm_present: command.extend(["--enable-kvm"])
 
         command += kernel_args


### PR DESCRIPTION
Removed the dependency on python-magic as its different on different flavors of Linux causing unnecessary confusion and frustration 
 
file should however work on all flavors mac and Linux at a small execution cost
A nicer yet more comprehensive fix would be to wrap the c library libmagic manually using ctags 

Also removed --preserve-env as this feature depends on the sudo/selinux configuration this needs to be tested but bugsquash runs in qemu kvm without it. 

if we are keeping --preserve-env we need to test it and notify the user why and what to do as it does not fail gracefully