### PR TITLE
test: changes in process threads- Adding subprocess32 and thread_timeout

### DIFF
--- a/test/fs/integration/fat32/test.py
+++ b/test/fs/integration/fat32/test.py
@@ -2,6 +2,9 @@
 import sys
 import os
 import subprocess
+import subprocess32
+
+thread_timeout = 30
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -17,10 +20,10 @@ def cleanup():
     print subprocess.check_output(["./fat32_disk.sh", "clean"])
 
 # Setup disk
-subprocess.call(["./fat32_disk.sh"], shell=True)
+subprocess32.call(["./fat32_disk.sh"], shell=True, timeout=thread_timeout)
 
 # Clean up on exit
 vm.on_exit(cleanup)
 
 # Boot the VM
-vm.cmake().boot(30).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/fs/integration/ide/test.py
+++ b/test/fs/integration/ide/test.py
@@ -2,6 +2,9 @@
 import sys
 import os
 import subprocess
+import subprocess32
+
+thread_timeout = 30
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -17,10 +20,10 @@ def cleanup():
     print subprocess.check_output(["./fat32_disk.sh", "clean"])
 
 # Setup disk
-subprocess.call(["./fat32_disk.sh"], shell=True)
+subprocess32.call(["./fat32_disk.sh"], shell=True, timeout=thread_timeout)
 
 # Clean up on exit
 vm.on_exit(cleanup)
 
 # Boot the VM
-vm.cmake().boot(30).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/fs/integration/ide_write/test.py
+++ b/test/fs/integration/ide_write/test.py
@@ -2,6 +2,9 @@
 import sys
 import os
 import subprocess
+import subprocess32
+
+thread_timeout = 30
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -17,10 +20,10 @@ def cleanup():
     print subprocess.check_output(["./fat32_disk.sh", "clean"])
 
 # Setup disk
-subprocess.call(["./fat32_disk.sh"], shell=True)
+subprocess32.call(["./fat32_disk.sh"], shell=True, timeout = thread_timeout)
 
 # Clean up on exit
 vm.on_exit(cleanup)
 
 # Boot the VM
-vm.cmake().boot(30).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/fs/integration/vfs/test.py
+++ b/test/fs/integration/vfs/test.py
@@ -2,6 +2,9 @@
 import sys
 import subprocess
 import os
+import subprocess32
+
+thread_timeout = 20
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -16,12 +19,12 @@ def cleanup():
     for disk in disks:
         diskname = disk + ".disk"
         print "Removing disk file ", diskname
-        subprocess.check_call(["rm", "-f", diskname])
+        subprocess32.check_call(["rm", "-f", diskname], timeout=thread_timeout)
 
 # Create all data disk images from folder names
 for disk in disks:
-  subprocess.check_call(["./create_disk.sh", disk, disk])
+  subprocess32.check_call(["./create_disk.sh", disk, disk])
 
 vmrunner.vms[0].on_exit_success(cleanup)
 
-vmrunner.vms[0].cmake().boot(20).clean()
+vmrunner.vms[0].cmake().boot(thread_timeout).clean()

--- a/test/fs/integration/virtio_block/test.py
+++ b/test/fs/integration/virtio_block/test.py
@@ -1,12 +1,15 @@
 #! /usr/bin/env python
 import sys
 import subprocess
+import subprocess32
 import os
+
+thread_timeout = 50
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src)
-subprocess.call(['./image.sh'])
+subprocess32.call(['./image.sh'], timeout=thread_timeout)
 
 def cleanup():
   subprocess.call(['./cleanup.sh'])
@@ -15,4 +18,4 @@ from vmrunner import vmrunner
 vm = vmrunner.vms[0]
 
 vm.on_exit(cleanup)
-vm.cmake().boot(50).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/net/integration/dhclient/test.py
+++ b/test/net/integration/dhclient/test.py
@@ -4,6 +4,9 @@ import sys
 import os
 import time
 import subprocess
+import subprocess32
+
+thread_timeout = 20
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -28,16 +31,15 @@ def DHCP_test(trigger_line):
   try:
     command = ["ping", ip_string.rstrip(), "-c", str(ping_count), "-i", "0.2"]
     print color.DATA(" ".join(command))
-    print subprocess.check_output(command)
+    print subprocess32.check_output(command, timeout=thread_timeout)
     vm.exit(0,"<Test.py> Ping test passed. Process returned 0 exit status")
   except Exception as e:
     print color.FAIL("<Test.py> Ping FAILED Process threw exception:")
     print e
     return False
 
-
 # Add custom event-handler
 vm.on_output("Got IP from DHCP", DHCP_test)
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(20).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/net/integration/dhcpd/test.py
+++ b/test/net/integration/dhcpd/test.py
@@ -4,6 +4,9 @@ import sys
 import os
 import time
 import subprocess
+import subprocess32
+
+thread_timeout = 20
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -29,7 +32,7 @@ def DHCP_test(trigger_line):
   try:
     command = ["ping", "-c", str(ping_count), "-i", "0.2", ip_string.rstrip()]
     print color.DATA(" ".join(command))
-    print subprocess.check_output(command)
+    print subprocess32.check_output(command, timeout=thread_timeout)
     print color.INFO("<Test.py>"), "Number of ping tests passed: ", str(num_assigned_clients)
     if num_assigned_clients == 3:
       vm.exit(0,"<Test.py> Ping test for all 3 clients passed. Process returned 0 exit status")
@@ -44,4 +47,4 @@ vm.on_output("Client 2 got IP from IncludeOS DHCP server", DHCP_test)
 vm.on_output("Client 3 got IP from IncludeOS DHCP server", DHCP_test)
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(20).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -4,6 +4,9 @@ import sys
 import os
 import time
 import subprocess
+import subprocess32
+
+thread_timeout = 20
 
 from threading import Timer
 
@@ -69,7 +72,7 @@ def ping_test():
   try:
     command = ["ping", assigned_ip, "-c", str(ping_count), "-i", "0.2"]
     print color.DATA(" ".join(command))
-    print subprocess.check_output(command)
+    print subprocess32.check_output(command, timeout=thread_timeout)
     ping_passed = True
   except Exception as e:
     print color.FAIL("<Test.py> Ping FAILED Process threw exception:")
@@ -83,20 +86,21 @@ def run_dhclient(trigger_line):
   route_output = subprocess.check_output(["route"])
 
   if "10.0.0.0" not in route_output:
-    subprocess.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"])
+    subprocess32.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"], timeout=thread_timeout)
     time.sleep(1)
 
   if "10.200.0.0" not in route_output:
-    subprocess.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"])
+    subprocess32.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"], timeout=thread_timeout)
     print color.INFO("<Test.py>"), "Route added to bridge43, 10.200.0.0"
 
   print color.INFO("<Test.py>"), "Running dhclient"
 
   try:
-    dhclient = subprocess.Popen(
+    dhclient = subprocess32.Popen(
         ["sudo", "dhclient", "bridge43", "-4", "-n", "-v"],
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT
+        stderr=subprocess.STDOUT,
+        timeout=thread_timeout
     )
     # timeout on dhclient process
     kill_proc = lambda p: p.kill()
@@ -128,4 +132,4 @@ def run_dhclient(trigger_line):
 vm.on_output("Service started", run_dhclient)
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(20).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/net/integration/dns/test.py
+++ b/test/net/integration/dns/test.py
@@ -3,7 +3,9 @@
 import sys
 import os
 import subprocess
+import subprocess32
 
+thread_timeout = 20
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 sys.path.insert(0,includeos_src)
@@ -36,4 +38,4 @@ vm.on_output("Resolved IP address of github.com with DNS server 8.8.8.8", count)
 vm.on_output("some_address_that_doesnt_exist.com couldn't be resolved", count)
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(20).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/net/integration/icmp/test.py
+++ b/test/net/integration/icmp/test.py
@@ -3,6 +3,9 @@
 import sys
 import os
 import subprocess
+import subprocess32
+
+thread_timeout = 50
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -65,7 +68,7 @@ def start_icmp_test(trigger_line):
   # 2 Port unreachable
   print color.INFO("<Test.py>"), "Performing Destination Unreachable (port) test"
   # Sending 1 udp packet to 10.0.0.45 to port 8080
-  udp_port_output = subprocess.check_output(["sudo", "hping3", "10.0.0.45", "--udp", "-p", "8080", "-c", "1"])
+  udp_port_output = subprocess32.check_output(["sudo", "hping3", "10.0.0.45", "--udp", "-p", "8080", "-c", "1"], timeout=thread_timeout)
   print udp_port_output
 
   # Validate content in udp_port_output:
@@ -78,7 +81,7 @@ def start_icmp_test(trigger_line):
   # 3 Protocol unreachable
   print color.INFO("<Test.py>"), "Performing Destination Unreachable (protocol) test"
   # Sending 1 raw ip packet to 10.0.0.45 with protocol 16
-  rawip_protocol_output = subprocess.check_output(["sudo", "hping3", "10.0.0.45", "-d", "20", "-0", "--ipproto", "16", "-c", "1"])
+  rawip_protocol_output = subprocess32.check_output(["sudo", "hping3", "10.0.0.45", "-d", "20", "-0", "--ipproto", "16", "-c", "1"], timeout=thread_timeout)
   print rawip_protocol_output
 
   # Validate content in rawip_protocol_output:
@@ -99,4 +102,4 @@ def start_icmp_test(trigger_line):
 vm.on_output("Service IP address is 10.0.0.45", start_icmp_test);
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(50).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/net/integration/router/test.py
+++ b/test/net/integration/router/test.py
@@ -40,11 +40,10 @@ def clean():
 
 def iperf_server():
     global iperf_server_proc, iperf_srv_log
-    iperf_server_proc = subprocess32.Popen(["sudo","ip","netns","exec", nsname, iperf_cmd, "-s"],
+    iperf_server_proc = subprocess.Popen(["sudo","ip","netns","exec", nsname, iperf_cmd, "-s"],
                                     stdout = subprocess.PIPE,
                                     stdin = subprocess.PIPE,
-                                    stderr = subprocess.PIPE,
-                                    timeout=thread_timeout)
+                                    stderr = subprocess.PIPE)
 
 def iperf_client(o):
     print "Starting iperf client. Iperf output: "

--- a/test/net/integration/router/test.py
+++ b/test/net/integration/router/test.py
@@ -3,7 +3,10 @@
 import sys
 import os
 import subprocess
+import subprocess32
 import thread
+
+thread_timeout = 30
 
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
@@ -37,14 +40,15 @@ def clean():
 
 def iperf_server():
     global iperf_server_proc, iperf_srv_log
-    iperf_server_proc = subprocess.Popen(["sudo","ip","netns","exec", nsname, iperf_cmd, "-s"],
+    iperf_server_proc = subprocess32.Popen(["sudo","ip","netns","exec", nsname, iperf_cmd, "-s"],
                                     stdout = subprocess.PIPE,
                                     stdin = subprocess.PIPE,
-                                    stderr = subprocess.PIPE)
+                                    stderr = subprocess.PIPE,
+                                    timeout=thread_timeout)
 
 def iperf_client(o):
     print "Starting iperf client. Iperf output: "
-    print subprocess.check_output([iperf_cmd,"-c","10.42.42.2","-n", transmit_size])
+    print subprocess32.check_output([iperf_cmd,"-c","10.42.42.2","-n", transmit_size], timeout=thread_timeout)
     vmrunner.vms[0].exit(0, "Test completed without errors")
     return True
 
@@ -67,4 +71,4 @@ vm.on_output("Service ready", iperf_client)
 vm.on_exit(clean)
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(30).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/posix/integration/syslog_plugin/test.py
+++ b/test/posix/integration/syslog_plugin/test.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import atexit
 
+thread_timeout = 60
+
 includeos_src = os.environ.get('INCLUDEOS_SRC',
                                os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
 print 'includeos_src: {0}'.format(includeos_src)
@@ -122,4 +124,4 @@ def end():
 vm.on_output("Service IP address is 10.0.0.47", start)
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(60).clean()
+vm.cmake().boot(thread_timeout).clean()

--- a/test/stress/test.py
+++ b/test/stress/test.py
@@ -30,7 +30,7 @@ memuse_at_start = 0
 sock_timeout = 20
 
 # Boot the VM, taking a timeout as parameter
-timeout = BURST_COUNT * 30
+thread_timeout = BURST_COUNT * 30
 
 # It's to be expected that the VM allocates more room during the running of tests
 # e.g. for containers, packets etc. These should all be freed after a run.
@@ -266,7 +266,7 @@ vm.on_output("Ready for TCP", TCP)
 vm.on_output("Ready to end", check_vitals)
 
 if len(sys.argv) > 1:
-  timeout = int(sys.argv[1])
+  thread_timeout = int(sys.argv[1])
 
 if len(sys.argv) > 3:
   BURST_COUNT = int(sys.argv[2])
@@ -275,4 +275,4 @@ if len(sys.argv) > 3:
 print color.HEADER(test_name + " initializing")
 print color.INFO(name_tag),"configured for ", BURST_COUNT,"bursts of", BURST_SIZE, "packets each"
 
-vm.cmake().boot(timeout).clean()
+vm.cmake().boot(thread_timeout).clean()


### PR DESCRIPTION
#1931

Adding subprocess32 and thread_timeout where `subprocess_calls` seemed large and required a timeout that matches the test timeout.

A `thread_timeout` parameter has been added to assign a timeout for each test and use for two purposes so far.

For example,

-  the `boot(50)` where the `50` was the timeout has been replaced by `boot(thread_timeout)` 

- the subprocess call has been edited to use subprocess32 with a timeout as follows:

subprocess.check_output(["sudo", "hping3", "10.0.0.45", "-d", "20", "-0", "--ipproto", "16", "-c", "1"])

replaced with:
 
`subprocess32.check_output(["sudo", "hping3", "10.0.0.45", "-d", "20", "-0", "--ipproto", "16", "-c", "1"], timeout=thread_timeout)`


Thirteen (13) `test.py` files have been modified:   

**fs/integration/:**
fat32/test.py
ide/test.py
ide_write/test.py
vfs/test.py
virtio_block/test.py

**net/integration/:**
dhclient/test.py
dhcpd/test.py
dhcpd_dhclient_linux/test.py
dns/test.py
icmp/test.py
**stress/** test.py (had its own timeout parameter called `timeout `which is calculated in the script depending on the `BURST_COUNT`, the timeout parameter has been changed to `thread_timeout` to match all the other tests and also to avoid confusion with` subprocess32`’s own `timeout` parameter.

Added thread_timeout as a variable to two files:
**net/integration/router/** test.py
**posix/integration/syslog_plugin/** test.py

