### PR TITLE
test: fixing dhcpd_dhclient_linux timer error created earlier

### DIFF
--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -96,29 +96,23 @@ def run_dhclient(trigger_line):
   print color.INFO("<Test.py>"), "Running dhclient"
 
   try:
-    dhclient = subprocess.Popen(
+    dhclient = subprocess32.check_output(
         ["sudo", "dhclient", "bridge43", "-4", "-n", "-v"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT
+        stderr=subprocess.STDOUT,
+        timeout=thread_timeout
     )
-    # timeout on dhclient process
-    kill_proc = lambda p: p.kill()
-    timer = Timer(thread_timeout, kill_proc, [dhclient])
-    timer.start()
-    process_output, _ = dhclient.communicate()
 
     print color.INFO("<dhclient>")
-    print process_output
+    print dhclient
 
-    check_dhclient_output(process_output)
-  except (OSError, subprocess.CalledProcessError) as exception:
-    cleanup()
+    # gets ip of dhclient used to ping
+    check_dhclient_output(dhclient)
+
+  except subprocess.CalledProcessError as exception:
     print color.FAIL("<Test.py> dhclient FAILED threw exception:")
-    print str(exception)
-    timer.cancel()
+    print exception.output
     vm.exit(1, "<Test.py> dhclient test failed")
-  finally:
-    timer.cancel()
+    return False
 
   ping_test()
 

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -86,21 +86,20 @@ def run_dhclient(trigger_line):
   route_output = subprocess.check_output(["route"])
 
   if "10.0.0.0" not in route_output:
-    subprocess32.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"], timeout=thread_timeout)
+    subprocess.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"]
     time.sleep(1)
 
   if "10.200.0.0" not in route_output:
-    subprocess32.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"], timeout=thread_timeout)
+    subprocess.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"])
     print color.INFO("<Test.py>"), "Route added to bridge43, 10.200.0.0"
 
   print color.INFO("<Test.py>"), "Running dhclient"
 
   try:
-    dhclient = subprocess32.Popen(
+    dhclient = subprocess.Popen(
         ["sudo", "dhclient", "bridge43", "-4", "-n", "-v"],
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        timeout=thread_timeout
+        stderr=subprocess.STDOUT
     )
     # timeout on dhclient process
     kill_proc = lambda p: p.kill()

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -86,11 +86,11 @@ def run_dhclient(trigger_line):
   route_output = subprocess.check_output(["route"])
 
   if "10.0.0.0" not in route_output:
-    subprocess.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"]
+    subprocess32.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"], timeout=thread_timeout)
     time.sleep(1)
 
   if "10.200.0.0" not in route_output:
-    subprocess.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"])
+    subprocess32.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"], timeout=thread_timeout)
     print color.INFO("<Test.py>"), "Route added to bridge43, 10.200.0.0"
 
   print color.INFO("<Test.py>"), "Running dhclient"
@@ -103,7 +103,7 @@ def run_dhclient(trigger_line):
     )
     # timeout on dhclient process
     kill_proc = lambda p: p.kill()
-    timer = Timer(20, kill_proc, [dhclient])
+    timer = Timer(thread_timeout, kill_proc, [dhclient])
     timer.start()
     process_output, _ = dhclient.communicate()
 


### PR DESCRIPTION
An `UboundLocalError` error was created due to adding `thread_timeout` in some subprocess calls (unnecessary use of subprocess32 call).
Removing the thread_timeout fixed the error:
```
Traceback (most recent call last):
File "/home/ubuntu/IncludeOS/vmrunner/vmrunner.py", line 861, in trigger_event
res = func(line)
File "test.py", line 122, in run_dhclient
timer.cancel()
UnboundLocalError: local variable 'timer' referenced before assignment
```