### PR TITLE
Fixes to Cmakefiles and a minor removal of some old printk's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,23 @@
 cmake_minimum_required(VERSION 3.1.0)
 
+project (includeos C CXX)
+
 set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
+if(NOT HAVE_FLAG_STD_CXX17)
+ message(FATAL_ERROR "The provided compiler: " ${CMAKE_CXX_COMPILER} "\n does not support c++17 standard please make sure your CC and CXX points to a compiler that supports c++17")
+endif()
+
+if ((CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT))
+ if (DEFINED ENV{INCLUDEOS_PREFIX})
+   set(CMAKE_INSTALL_PREFIX $ENV{INCLUDEOS_PREFIX} CACHE PATH "..." FORCE)
+ else()
+   message(WARNING "CMAKE_INSTALL_PREFIX is default ${CMAKE_INSTALL_PREFIX} did you forget to set INCLUDEOS_PREFIX")
+ endif()
+endif()
 
 # Target CPU Architecture
 if(DEFINED ENV{ARCH})
@@ -20,8 +37,6 @@ message(STATUS "Target triple ${TRIPLE}")
 option(WITH_SOLO5 "Install with solo5 support" ON)
 
 set(CMAKE_TOOLCHAIN_FILE ${INCLUDEOS_ROOT}/cmake/elf-toolchain.cmake)
-
-project (includeos C CXX)
 
 set(INC ${CMAKE_INSTALL_PREFIX}/includeos/include)
 set(LIB ${CMAKE_INSTALL_PREFIX}/includeos/lib)
@@ -164,9 +179,8 @@ if(vmbuild)
   # Install vmbuilder as an external project
   ExternalProject_Add(vmbuild
     PREFIX vmbuild # Build where
-    BUILD_ALWAYS 1
     SOURCE_DIR ${INCLUDEOS_ROOT}/vmbuild # Where is project located
-    BINARY_DIR ${INCLUDEOS_ROOT}/vmbuild/build
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/vmbuild/build
     INSTALL_DIR ${BIN} # Where to install
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
      -DINCLUDE_PATH=${CMAKE_INSTALL_PREFIX} # Pass installation folder
@@ -177,9 +191,8 @@ endif(vmbuild)
 option(diskbuilder "Build and install memdisk helper tool" ON)
 if(diskbuilder)
   ExternalProject_Add(diskbuilder
-    BUILD_ALWAYS 1
     SOURCE_DIR ${INCLUDEOS_ROOT}/diskimagebuild
-    BINARY_DIR ${INCLUDEOS_ROOT}/diskimagebuild/build
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/diskimagebuild/build
     INSTALL_DIR ${BIN}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
   )

--- a/diskimagebuild/CMakeLists.txt
+++ b/diskimagebuild/CMakeLists.txt
@@ -1,15 +1,25 @@
 cmake_minimum_required(VERSION 2.8.9)
 
 project (diskimagebuilder)
-set (CMAKE_CXX_STANDARD 14)
 
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag(-std=c++14 HAVE_FLAG_STD_CXX14)
+if(NOT HAVE_FLAG_STD_CXX14)
+ message(FATAL_ERROR "The provided compiler: ${CMAKE_CXX_COMPILER} \n \
+    does not support c++14 standard please make sure you are using one of the following:\n \
+    export your CC and CXX to a compiler that supports c++14")
+endif()
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O3")
 
 set(SOURCES main.cpp filetree.cpp writer.cpp)
 
 include_directories(../mod/GSL)
 add_executable(diskbuilder ${SOURCES})
-
+target_link_libraries(diskbuilder stdc++)
 #
 # Installation
 #

--- a/diskimagebuild/CMakeLists.txt
+++ b/diskimagebuild/CMakeLists.txt
@@ -6,9 +6,7 @@ include(CheckCXXCompilerFlag)
 
 check_cxx_compiler_flag(-std=c++14 HAVE_FLAG_STD_CXX14)
 if(NOT HAVE_FLAG_STD_CXX14)
- message(FATAL_ERROR "The provided compiler: ${CMAKE_CXX_COMPILER} \n \
-    does not support c++14 standard please make sure you are using one of the following:\n \
-    export your CC and CXX to a compiler that supports c++14")
+ message(FATAL_ERROR "The provided compiler: " ${CMAKE_CXX_COMPILER} "\n does not support c++14 standard please make sure your CC and CXX points to a compiler that supports c++14")
 endif()
 
 set(CMAKE_CXX_STANDARD 14)

--- a/src/musl/brk.cpp
+++ b/src/musl/brk.cpp
@@ -15,8 +15,6 @@ uintptr_t __init_brk(uintptr_t begin)
   brk_begin = begin;
   brk_end   = begin;
   brk_initialized = brk_end;
-  kprintf("* Brk initialized. Begin: %p, end %p, MAX %p\n",
-          (void*) brk_begin, (void*) brk_end, (void*) __brk_max);
   return brk_begin + __brk_max;
 }
 

--- a/src/musl/mmap.cpp
+++ b/src/musl/mmap.cpp
@@ -22,8 +22,6 @@ uintptr_t __init_mmap(uintptr_t addr_begin)
   int64_t len = (mem_end - aligned_begin) & ~int64_t(Alloc::align - 1);
 
   alloc = Alloc::create((void*)aligned_begin, len);
-  kprintf("* mmap initialized. Begin: 0x%zx, end: 0x%zx\n",
-          addr_begin, addr_begin + len);
   return aligned_begin + len;
 }
 

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -5,6 +5,17 @@ project (vmbuilder)
 set(SOURCES vmbuild.cpp)
 set(ELF_SYMS_SOURCES elf_syms.cpp ../src/util/crc32.cpp)
 
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag(-std=c++14 HAVE_FLAG_STD_CXX14)
+if(NOT HAVE_FLAG_STD_CXX14)
+ message(FATAL_ERROR "The provided compiler: ${CMAKE_CXX_COMPILER} \n \
+    does not support c++14 standard please make sure you are using one of the following:\n \
+    export your CC and CXX to a compiler that supports c++14")
+endif()
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O2 -g")
 
 # TODO: write scripts that automatically find include directories
@@ -16,7 +27,8 @@ include_directories(
 
 add_executable(vmbuild ${SOURCES})
 add_executable(elf_syms ${ELF_SYMS_SOURCES})
-
+target_link_libraries(vmbuild stdc++)
+target_link_libraries(elf_syms stdc++)
 #
 # Installation
 #

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -2,17 +2,17 @@ cmake_minimum_required(VERSION 2.8.9)
 
 project (vmbuilder)
 
-set(SOURCES vmbuild.cpp)
-set(ELF_SYMS_SOURCES elf_syms.cpp ../src/util/crc32.cpp)
-
 include(CheckCXXCompilerFlag)
 
 check_cxx_compiler_flag(-std=c++14 HAVE_FLAG_STD_CXX14)
 if(NOT HAVE_FLAG_STD_CXX14)
- message(FATAL_ERROR "The provided compiler: ${CMAKE_CXX_COMPILER} \n \
-    does not support c++14 standard please make sure you are using one of the following:\n \
-    export your CC and CXX to a compiler that supports c++14")
+ message(FATAL_ERROR "The provided compiler: " ${CMAKE_CXX_COMPILER} "\n does not support c++14 standard please make sure your CC and CXX points to a compiler that supports c++14")
 endif()
+
+set(SOURCES vmbuild.cpp)
+set(ELF_SYMS_SOURCES elf_syms.cpp ../src/util/crc32.cpp)
+
+
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -26,8 +26,8 @@ include_directories(
   ../api)
 
 add_executable(vmbuild ${SOURCES})
-add_executable(elf_syms ${ELF_SYMS_SOURCES})
 target_link_libraries(vmbuild stdc++)
+add_executable(elf_syms ${ELF_SYMS_SOURCES})
 target_link_libraries(elf_syms stdc++)
 #
 # Installation


### PR DESCRIPTION
Changes made to main CMakeLists.txt that can cause breakage 
You no longer have to pass CMAKE_INSTALL_PREFIX if your INCLUDEOS_PREFIX is set in environment 
vmbuild and diskbuilder cmake has gotten some hardening to ensure that there is a c++14 capable compiler in the env they are executing. 

The linkage to stdc++ is also added as it fixes issues with old cmake.