### PR TITLE
nic: add defaults for sendq- and and rx buffer limits

### DIFF
--- a/api/hw/nic.hpp
+++ b/api/hw/nic.hpp
@@ -21,6 +21,9 @@
 #include "mac_addr.hpp"
 #include <net/inet_common.hpp>
 
+#define NIC_SENDQ_LIMIT_DEFAULT  4096
+#define NIC_BUFFER_LIMIT_DEFAULT 4096
+
 namespace hw {
 
   /**
@@ -30,6 +33,12 @@ namespace hw {
   public:
     using upstream    = delegate<void(net::Packet_ptr)>;
     using downstream  = net::downstream_link;
+
+    /** Maximum number of packets allowed in dynamic send queue **/
+    static constexpr uint32_t sendq_limit_default  = NIC_SENDQ_LIMIT_DEFAULT;
+
+    /** Maximum number of packets that can be created during RX-ring refill **/
+    static constexpr uint32_t buffer_limit_default = NIC_BUFFER_LIMIT_DEFAULT;
 
     enum class Proto {ETH, IEEE802111};
 
@@ -106,7 +115,7 @@ namespace hw {
       this->m_buffer_limit = new_limit;
     }
     uint32_t buffer_limit() const noexcept { return m_buffer_limit; }
-    
+
     /** Set new sendq limit, where 0 means infinite **/
     void set_sendq_limit(uint32_t new_limit) {
       this->m_sendq_limit = new_limit;
@@ -156,8 +165,8 @@ namespace hw {
 
   private:
     int N;
-    uint32_t m_buffer_limit = 0;
-    uint32_t m_sendq_limit = 0;
+    uint32_t m_buffer_limit = buffer_limit_default;
+    uint32_t m_sendq_limit = sendq_limit_default;
     friend class Devices;
   };
 


### PR DESCRIPTION
These defaults are somewhat arbitrary, but a non-null default is necessary to avoid buffer bloat