### PR TITLE
nic: Make buffer limit default unlimited, to avoid exhaustion

### DIFF
--- a/api/hw/nic.hpp
+++ b/api/hw/nic.hpp
@@ -22,7 +22,7 @@
 #include <net/inet_common.hpp>
 
 #define NIC_SENDQ_LIMIT_DEFAULT  4096
-#define NIC_BUFFER_LIMIT_DEFAULT 4096
+#define NIC_BUFFER_LIMIT_DEFAULT 0 /* unlimited to avoid exhaustion */
 
 namespace hw {
 


### PR DESCRIPTION
* Driver A buffer limit should be larger than driver B sendq limit in a routing scenario, otherwise the simple math "Buffer limit - Remote sendq size = 0" leaving nothing for RX ring, which stops everything.
* However, the virtionet driver still completes the router test eventually, at least thats what ive heard. To solve this problem we have to make the bufferstore able to signal the driver that it has buffers again, effectively prioritizing keeping the RX rings filled.
