### PR TITLE
Ip6: Improve SLAAC

### DIFF
--- a/api/net/inet.hpp
+++ b/api/net/inet.hpp
@@ -296,8 +296,7 @@ namespace net {
     void negotiate_dhcp(double timeout = 10.0, dhcp_timeout_func = nullptr);
 
     /* Automatic configuration of ipv6 address for inet */
-    void autoconf_v6(int retries = 1, slaac_timeout_func = nullptr,
-            ip6::Addr alternate_addr = IP6::ADDR_ANY);
+    void autoconf_v6(int retries = 1, slaac_timeout_func = nullptr, uint64_t token = 0);
 
     bool is_configured() const
     {

--- a/api/net/inet.hpp
+++ b/api/net/inet.hpp
@@ -296,7 +296,8 @@ namespace net {
     void negotiate_dhcp(double timeout = 10.0, dhcp_timeout_func = nullptr);
 
     /* Automatic configuration of ipv6 address for inet */
-    void autoconf_v6(int retries = 1, slaac_timeout_func = nullptr, uint64_t token = 0);
+    void autoconf_v6(int retries = 1, slaac_timeout_func = nullptr,
+      uint64_t token = 0, bool use_token = false);
 
     bool is_configured() const
     {

--- a/api/net/ip6/addr.hpp
+++ b/api/net/ip6/addr.hpp
@@ -119,7 +119,7 @@ struct Addr {
   static const Addr site_dhcp_servers;  // RFC 3315
 
   // returns true if this Addr is a IPv6 multicast Address
-  bool is_multicast() const
+  bool is_multicast() const noexcept
   {
     /**
        RFC 4291 2.7 Multicast Addresses
@@ -135,17 +135,17 @@ struct Addr {
     return ((ntohs(i16[0]) & 0xFF00) == 0xFF00);
   }
 
-  bool is_linklocal() const
+  bool is_linklocal() const noexcept
   {
     return ((ntohs(i16[0]) & 0xFE80) == 0xFE80);
   }
 
-  bool is_solicit_multicast() const
+  bool is_solicit_multicast() const noexcept
   {
-      return ((ntohs(i32[0]) ^  (0xff020000)) |
-              ntohs(i32[1]) |
-              (ntohs(i32[2]) ^ (0x00000001)) |
-              (ntohs(i32[3]) ^ 0xff)) == 0;
+    return i32[0] == htonl(0xFF020000)
+       and i32[1] == 0
+       and i32[2] == htonl(0x1)
+       and (i32[3] & htonl(0xFF000000)) == htonl(0xFF000000);
   }
 
   uint8_t* data()

--- a/api/net/ip6/slaac.hpp
+++ b/api/net/ip6/slaac.hpp
@@ -42,20 +42,22 @@ namespace net {
     Slaac(Stack& inet);
 
     // autoconfigure linklocal and global address
-    void autoconf_start(int retries, uint64_t token);
+    void autoconf_start(int retries, uint64_t token, bool use_token);
     void autoconf_linklocal();
+    void autoconf_global_start();
     void autoconf_global();
     void autoconf_trigger();
     void on_config(config_func handler);
 
   private:
-    Stack& stack;
-    uint64_t     token_;
+    Stack&        stack;
+    uint64_t      token_;
+    bool          use_token_;
     ip6::Stateful_addr tentative_addr_;
-    bool         linklocal_completed;
+    bool          linklocal_completed;
     // Number of times to attempt DAD
-    int          dad_transmits_;
-    Timer        timeout_timer_;
+    int           dad_transmits_;
+    Timer         timeout_timer_;
     std::vector<config_func> config_handlers_;
     std::chrono::milliseconds interval;
 

--- a/api/net/ip6/slaac.hpp
+++ b/api/net/ip6/slaac.hpp
@@ -42,8 +42,7 @@ namespace net {
     Slaac(Stack& inet);
 
     // autoconfigure linklocal and global address
-    void autoconf_start(int retries,
-            IP6::addr alternate_addr = IP6::ADDR_ANY);
+    void autoconf_start(int retries, uint64_t token);
     void autoconf_linklocal();
     void autoconf_global();
     void autoconf_trigger();
@@ -51,7 +50,7 @@ namespace net {
 
   private:
     Stack& stack;
-    IP6::addr    alternate_addr_;
+    uint64_t     token_;
     ip6::Stateful_addr tentative_addr_;
     bool         linklocal_completed;
     // Number of times to attempt DAD

--- a/api/net/ip6/stateful_addr.hpp
+++ b/api/net/ip6/stateful_addr.hpp
@@ -39,6 +39,9 @@ namespace net::ip6 {
     const ip6::Addr& addr() const noexcept
     { return addr_; }
 
+    ip6::Addr& addr() noexcept
+    { return addr_; }
+
     uint8_t prefix() const noexcept
     { return prefix_; }
 

--- a/src/net/inet.cpp
+++ b/src/net/inet.cpp
@@ -225,14 +225,15 @@ void Inet::negotiate_dhcp(double timeout, dhcp_timeout_func handler) {
 }
 
 void Inet::autoconf_v6(int retries, slaac_timeout_func handler,
-        uint64_t token) {
+        uint64_t token, bool use_token)
+{
 
   INFO("Inet", "Attempting automatic configuration of ipv6 address");
   if (!slaac_)
       slaac_ = std::make_unique<Slaac>(*this);
 
   // @Retries for Slaac auto-configuration
-  slaac_->autoconf_start(retries, token);
+  slaac_->autoconf_start(retries, token, use_token);
 
   // add failure_handler if supplied
   if (handler)

--- a/src/net/inet.cpp
+++ b/src/net/inet.cpp
@@ -225,14 +225,14 @@ void Inet::negotiate_dhcp(double timeout, dhcp_timeout_func handler) {
 }
 
 void Inet::autoconf_v6(int retries, slaac_timeout_func handler,
-        IP6::addr alternate_addr) {
+        uint64_t token) {
 
   INFO("Inet", "Attempting automatic configuration of ipv6 address");
   if (!slaac_)
       slaac_ = std::make_unique<Slaac>(*this);
 
   // @Retries for Slaac auto-configuration
-  slaac_->autoconf_start(retries, alternate_addr);
+  slaac_->autoconf_start(retries, token);
 
   // add failure_handler if supplied
   if (handler)

--- a/test/net/unit/addr_test.cpp
+++ b/test/net/unit/addr_test.cpp
@@ -65,3 +65,8 @@ CASE("Addr v4/v6")
   EXPECT(addr.to_string() == std::string("fe80:0:0:0:e823:fcff:fef4:85bd"));
 
 }
+
+CASE("v6 Linklocal/Solicit/Mcast")
+{
+  // Test me
+}


### PR DESCRIPTION
* Supply token instead of alt addr.
  * May force to use token instead of eui64 generated from MAC.
* Configuring global address is now also on a timer.

DAD is still not working correctly (for link local). This is due to NDP RFC being long and boring.