### PR TITLE
Ip6: NDP improvements

### DIFF
--- a/api/hw/mac_addr.hpp
+++ b/api/hw/mac_addr.hpp
@@ -210,6 +210,26 @@ union Addr {
   constexpr uint64_t eui64() const noexcept
   { return Addr::eui64(*this); }
 
+  /**
+   * @brief      Construct a broadcast/"multicast" MAC for
+   *             the given IPv6 address.
+   *
+   * @param[in]  v6    The IPv6 address
+   *
+   * @tparam     IPv6  IPv6 address
+   *
+   * @return     A broadcast/"multicast" MAC address
+   */
+  template <typename IPv6>
+  static Addr ipv6_mcast(const IPv6& v6)
+  {
+    return { 0x33, 0x33,
+      v6.template get_part<uint8_t>(12),
+      v6.template get_part<uint8_t>(13),
+      v6.template get_part<uint8_t>(14),
+      v6.template get_part<uint8_t>(15)};
+  }
+
 
   static constexpr const size_t PARTS_LEN {6}; //< Number of parts in a MAC address
   uint8_t part[PARTS_LEN];                     //< The parts of the MAC address

--- a/api/net/ip6/ndp/message.hpp
+++ b/api/net/ip6/ndp/message.hpp
@@ -109,29 +109,30 @@ namespace net::ndp {
   {
     enum Flag : uint8_t
     {
-      Router    = 1 << 1,
-      Solicited = 1 << 2,
-      Override  = 1 << 3
+      Router    = 0b1000'0000,
+      Solicited = 0b0100'0000,
+      Override  = 0b0010'0000
     };
 
-    uint32_t flags;
-    /*uint32_t  router:1,
-              solicited:1,
-              override:1,
-              reserved:29;*/
+    uint32_t flags{0x0};
     ip6::Addr target;
 
-    void set_flag(uint32_t flag) noexcept
-    { flags = htonl(flag << 28); }
+    Neighbor_adv() = default;
+    Neighbor_adv(ip6::Addr tar)
+      : target{std::move(tar)}
+    {}
+
+    void set_flag(uint8_t flag) noexcept
+    { flags |= flag; }
 
     constexpr bool router() const noexcept
-    { return flags & ntohs(Router); }
+    { return flags & Router; }
 
     constexpr bool solicited() const noexcept
-    { return flags & ntohs(Solicited); }
+    { return flags & Solicited; }
 
     constexpr bool override() const noexcept
-    { return flags & ntohs(Override); }
+    { return flags & Override; }
 
   } __attribute__((packed));
   static_assert(sizeof(Neighbor_adv) == 20);

--- a/api/net/ip6/packet_icmp6.hpp
+++ b/api/net/ip6/packet_icmp6.hpp
@@ -248,7 +248,7 @@ namespace net::icmp6 {
     const T& view_payload_as()
     {
       const Span payload = this->payload();
-      Expects(payload.size() >= sizeof(T));
+      Expects(static_cast<size_t>(payload.size()) >= sizeof(T));
       return *reinterpret_cast<const T*>(payload.data());
     }
 

--- a/src/net/ip6/slaac.cpp
+++ b/src/net/ip6/slaac.cpp
@@ -150,6 +150,8 @@ namespace net
     if(dad_transmits_ == 0)
     {
       PRINT("<SLAAC> Out of transmits for router sol (no reply)\n");
+      for(auto& handler : this->config_handlers_)
+        handler(true); // we do have linklocal at least
       return;
     }
     dad_transmits_--;


### PR DESCRIPTION
Now replying to neighbor solicitation when sent from unspecified source, which is used when doing Duplicate Address Detection (DAD) when doing stateless autoconf (SLAAC).

By running IncludeOS on two instances having them ask for the same IP using the newly implemented token solution, I can now see the second autoconf fail.