### PR TITLE
build: Reorder stuff to fix things building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,6 @@
 cmake_minimum_required(VERSION 3.1.0)
 
-project (includeos C CXX)
-
 set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/)
-
-include(CheckCXXCompilerFlag)
-
-check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
-if(NOT HAVE_FLAG_STD_CXX17)
- message(FATAL_ERROR "The provided compiler: " ${CMAKE_CXX_COMPILER} "\n does not support c++17 standard please make sure your CC and CXX points to a compiler that supports c++17")
-endif()
-
-if ((CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT))
- if (DEFINED ENV{INCLUDEOS_PREFIX})
-   set(CMAKE_INSTALL_PREFIX $ENV{INCLUDEOS_PREFIX} CACHE PATH "..." FORCE)
- else()
-   message(WARNING "CMAKE_INSTALL_PREFIX is default ${CMAKE_INSTALL_PREFIX} did you forget to set INCLUDEOS_PREFIX")
- endif()
-endif()
 
 # Target CPU Architecture
 if(DEFINED ENV{ARCH})
@@ -36,7 +19,30 @@ message(STATUS "Target triple ${TRIPLE}")
 
 option(WITH_SOLO5 "Install with solo5 support" ON)
 
+# Remember we was APPLE in earlier life
+if(APPLE)
+  set(BORNED_AS_AN_APPLE FRUITSALAD)
+endif()
+
 set(CMAKE_TOOLCHAIN_FILE ${INCLUDEOS_ROOT}/cmake/elf-toolchain.cmake)
+
+project (includeos C CXX)
+
+if(NOT BORNED_AS_AN_APPLE)
+include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
+  if(NOT HAVE_FLAG_STD_CXX17)
+    message(FATAL_ERROR "The provided compiler: " ${CMAKE_CXX_COMPILER} "\n does not support c++17 standard please make sure your CC and CXX points to a compiler that supports c++17")
+  endif()
+endif()
+
+if ((CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT))
+ if (DEFINED ENV{INCLUDEOS_PREFIX})
+   set(CMAKE_INSTALL_PREFIX $ENV{INCLUDEOS_PREFIX} CACHE PATH "..." FORCE)
+ else()
+   message(WARNING "CMAKE_INSTALL_PREFIX is default ${CMAKE_INSTALL_PREFIX} did you forget to set INCLUDEOS_PREFIX")
+ endif()
+endif()
 
 set(INC ${CMAKE_INSTALL_PREFIX}/includeos/include)
 set(LIB ${CMAKE_INSTALL_PREFIX}/includeos/lib)

--- a/test/util/unit/buddy_alloc_test.cpp
+++ b/test/util/unit/buddy_alloc_test.cpp
@@ -279,7 +279,7 @@ CASE("mem::buddy random chaos with data verification"){
   std::vector<Allocation> allocs;
 
   for (auto rnd : test::random_1k) {
-    auto sz = std::max(rnd % alloc.pool_size_ / 1024, alloc.min_size);
+    auto sz = std::max<size_t>(rnd % alloc.pool_size_ / 1024, alloc.min_size);
     EXPECT(sz);
 
     if (not alloc.full()) {


### PR DESCRIPTION
So the issue was `project()` being defined before set `CMAKE_TOOLCHAIN_FILE`. When doing this toolchain is not respected, so the wrong compiler is used (WITH_SOLO5 isn't turned off).

I also had to avoid checking for c++17 support when building on Apple. This is the same reason that `set(CMAKE_CXX_COMPILER_WORKS 1)` in the toolchain file is done - CMake is trying to compile and do tests which doesn't work because of reasons. I think the reasons are because it's compiling macOS stuff which it then tries to link with binutils ld. But maybe someone knows more than me on this.