### PR TITLE
nic: Silently return when nobody subscribes to the TQA event

### DIFF
--- a/api/hw/nic.hpp
+++ b/api/hw/nic.hpp
@@ -140,6 +140,9 @@ namespace hw {
 
     void transmit_queue_available_event(size_t packets)
     {
+      // early on its possible someone tries to transmit without subscribers
+      if (tqa_events_.empty()) return;
+
       // divide up fairly
       size_t div = packets / tqa_events_.size();
 


### PR DESCRIPTION
Should somebody ever find themselves replicating the crash we have seen, then try this commit and see what happens. It will tells us if the condition happens only during initialization, and then we can deal with it from there.