### PR TITLE
x86: typo in bootloader

### DIFF
--- a/src/platform/x86_pc/boot/bootloader.asm
+++ b/src/platform/x86_pc/boot/bootloader.asm
@@ -87,7 +87,7 @@ protected_mode:
 	cli
 	;; Load global descriptor table register
 	lgdt [gdtr] ;;Bochs seems to allready have one
-	;; Set the 2n'd bit in cr0
+	;; Set the 1st bit in cr0
 	mov eax, cr0
 	or   al, 1
 	mov cr0, eax


### PR DESCRIPTION
Having read the bootloader, I found a very little typo in the comments.

This is confirmed by the documentation, for instance here : https://wiki.osdev.org/CPU_Registers_x86