### PR TITLE
AC97 and Intel HDA audio drivers

### DIFF
--- a/api/hw/audio_device.hpp
+++ b/api/hw/audio_device.hpp
@@ -1,0 +1,70 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2017 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef HW_AUDIO_DEVICE_HPP
+#define HW_AUDIO_DEVICE_HPP
+
+#include <cstdint>
+#include <delegate>
+#include <memory>
+#include <vector>
+
+namespace hw
+{
+  class Audio_device {
+  public:
+    enum mixer_value_t {
+      MASTER_VOLUME,
+      PCM_OUT
+    };
+    /**
+     * Method to get the type of device
+     *
+     * @return The type of device as a C-String
+     */
+    static const char* device_type() noexcept
+    { return "Audio device"; }
+
+    /**
+     * Method to get the name of the device
+     *
+     * @return The name of the device as a std::string
+     */
+    virtual std::string device_name() const = 0;
+
+    /**
+     * Get the human-readable name of this device's controller
+     *
+     * @return The human-readable name of this device's controller
+     */
+    virtual const char* driver_name() const noexcept = 0;
+
+    /* Get & set hardware mixer values */
+    virtual void     set_mixer(mixer_value_t, uint32_t) = 0;
+    virtual uint32_t get_mixer(mixer_value_t) = 0;
+
+    /**
+     * Method to deactivate the block device
+     */
+    virtual void deactivate() = 0;
+
+    virtual ~Audio_device() noexcept = default;
+  }; //< Audio_device
+} //< hw
+
+#endif

--- a/api/hw/msi.hpp
+++ b/api/hw/msi.hpp
@@ -42,7 +42,7 @@ namespace hw {
 
   struct msix_t
   {
-    msix_t(PCI_Device&, uint32_t capoff);
+    msix_t(PCI_Device&, bool msix, uint32_t capoff);
 
     // initialize msi-x tables for device
     void mask_entry(size_t);
@@ -64,6 +64,10 @@ namespace hw {
     uintptr_t table_addr = 0;
     uintptr_t pba_addr   = 0;
     std::vector<bool> used_vectors;
+    bool is_msix;
+
+    void init_msi(uint32_t);
+    void init_msix(uint32_t);
 
     inline auto* get_entry(size_t idx)
     {

--- a/api/hw/pci_device.hpp
+++ b/api/hw/pci_device.hpp
@@ -217,7 +217,8 @@ struct msix_t;
     void intx_enable();
     // returns true if interrupt is asserted
     bool intx_status();
-
+    // the old ways
+    uint8_t get_legacy_irq();
     // return max number of possible MSI-x vectors for this device
     // or, zero if MSI-x support is not enabled
     uint8_t get_msix_vectors();

--- a/api/hw/ps2.hpp
+++ b/api/hw/ps2.hpp
@@ -83,7 +83,6 @@ namespace hw
     static void    flush_data();
     static uint8_t read_status();
     static uint8_t read_data();
-    static uint8_t read_fast(); // doesnt check status
     static void    write_cmd(uint8_t);
     static void    write_data(uint8_t);
     static void    write_port1(uint8_t);

--- a/api/hw/ps2.hpp
+++ b/api/hw/ps2.hpp
@@ -79,11 +79,25 @@ namespace hw
     static keystate_t get_kbd_vkey();
     static uint8_t    get_mouse_irq();
 
+    // if you want to control PS/2 yourself
+    static void    flush_data();
+    static uint8_t read_status();
+    static uint8_t read_data();
+    static uint8_t read_fast(); // doesnt check status
+    static void    write_cmd(uint8_t);
+    static void    write_data(uint8_t);
+    static void    write_port1(uint8_t);
+    static void    write_port2(uint8_t);
+
   private:
     KBM();
+    void internal_init();
+
     int  mouse_x;
     int  mouse_y;
     bool mouse_button[4];
+    bool mouse_enabled = false;
+    bool m_initialized = false;
 
     static keystate_t transform_vk(uint8_t scancode);
     static int transform_ascii(int vk);

--- a/api/kernel/pci_manager.hpp
+++ b/api/kernel/pci_manager.hpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <hw/nic.hpp>
 #include <hw/block_device.hpp>
+#include <hw/audio_device.hpp>
 
 namespace hw {
   class PCI_Device;
@@ -36,6 +37,9 @@ public:
 
   using BLK_driver = delegate< std::unique_ptr<hw::Block_device> (hw::PCI_Device&) >;
   static void register_blk(uint16_t, uint16_t, BLK_driver);
+
+  using SND_driver = delegate< std::unique_ptr<hw::Audio_device> (hw::PCI_Device&) >;
+  static void register_snd(uint16_t, uint16_t, SND_driver);
 
   static void init(uint8_t classcode);
   static  Device_vector devices();

--- a/cmake/post.service.cmake
+++ b/cmake/post.service.cmake
@@ -521,19 +521,23 @@ target_link_libraries(service
 file(WRITE ${CMAKE_BINARY_DIR}/binary.txt ${BINARY})
 
 # old behavior: remove all symbols after elfsym
-if (NOT debug)
+if (stripped)
+  set(STRIP_LV ${CMAKE_STRIP} --strip-all ${BINARY})
+elseif (NOT debug)
   set(STRIP_LV ${CMAKE_STRIP} --strip-debug ${BINARY})
 else()
   set(STRIP_LV true)
 endif()
 
-add_custom_target(
-  pruned_elf_symbols ALL
-  COMMAND ${INSTALL_LOC}/bin/elf_syms ${BINARY}
-  COMMAND ${CMAKE_OBJCOPY} --update-section .elf_symbols=_elf_symbols.bin ${BINARY} ${BINARY}
-  COMMAND ${STRIP_LV}
-  DEPENDS service
-  )
+if (NOT stripped)
+  add_custom_target(
+    pruned_elf_symbols ALL
+    COMMAND ${INSTALL_LOC}/bin/elf_syms ${BINARY}
+    COMMAND ${CMAKE_OBJCOPY} --update-section .elf_symbols=_elf_symbols.bin ${BINARY} ${BINARY}
+    COMMAND ${STRIP_LV}
+    DEPENDS service
+    )
+endif()
 
 # create bare metal .img: make legacy_bootloader
 add_custom_target(

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -63,6 +63,9 @@ add_dependencies(vga_emergency PrecompiledLibraries)
 add_library(ac97 STATIC ac97.cpp)
 add_dependencies(ac97 PrecompiledLibraries)
 
+add_library(ihda STATIC ihda.cpp)
+add_dependencies(ihda PrecompiledLibraries)
+
 #
 # Installation
 #
@@ -83,7 +86,7 @@ install(TARGETS
     ip4_reassembly
     heap_debugging
     disk_logger disklog_reader
-    ac97
+    ac97 ihda
     # stdout drivers that are simple enough to remain here
     boot_logger timestamps
   DESTINATION includeos/${ARCH}/drivers)

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -58,6 +58,11 @@ add_dependencies(vga_output PrecompiledLibraries)
 add_library(vga_emergency STATIC vga_emergency.cpp)
 add_dependencies(vga_emergency PrecompiledLibraries)
 
+# sound cards
+
+add_library(ac97 STATIC ac97.cpp)
+add_dependencies(ac97 PrecompiledLibraries)
+
 #
 # Installation
 #
@@ -78,6 +83,7 @@ install(TARGETS
     ip4_reassembly
     heap_debugging
     disk_logger disklog_reader
+    ac97
     # stdout drivers that are simple enough to remain here
     boot_logger timestamps
   DESTINATION includeos/${ARCH}/drivers)

--- a/src/drivers/ac97.cpp
+++ b/src/drivers/ac97.cpp
@@ -1,0 +1,138 @@
+#include "ac97.hpp"
+#include <arch.hpp>
+#include <kernel/events.hpp>
+#include <hw/ioport.hpp>
+
+#define AC97_NAMBAR  0x10  /* Native Audio Mixer BAR */
+#define AC97_NABMBAR 0x14  /* Native Audio Bus Mastering BAR */
+
+#define NABM_CR_RPBM   (1 << 0)  /* Run/pause bus master */
+#define NABM_CR_REGRST (1 << 1)  /* Reset registers */
+#define NABM_CR_IE_LVB (1 << 2)  /* Last valid buffer interrupt enable */
+#define NABM_CR_IE_FE  (1 << 3)  /* FIFO error interrupt enable */
+#define NABM_CR_IE_IOC (1 << 4)  /* Interrupt on completion enable */
+
+#define PORT_NAM_RESET          0x0000
+#define PORT_NAM_MASTER_VOLUME  0x0002
+#define PORT_NAM_MONO_VOLUME    0x0006
+#define PORT_NAM_PC_BEEP        0x000A
+#define PORT_NAM_PCM_VOLUME     0x0018
+#define PORT_NAM_EXT_AUDIO_ID   0x0028
+#define PORT_NAM_EXT_AUDIO_STC  0x002A
+#define PORT_NAM_FRONT_SPLRATE  0x002C
+#define PORT_NAM_LR_SPLRATE     0x0032
+
+#define NABM_PO_BDBAR       0x0010
+#define NABM_PO_CIV         0x0014
+#define NABM_PO_LVI         0x0015
+#define NABM_PO_STAT        0x0016
+#define NABM_PO_CTRL        0x001B
+#define NABM_GLB_CTRL_STAT  0x0060
+
+AC97::AC97(hw::PCI_Device& dev)
+{
+  INFO("AC97", "Intel AC97 Audio Device (rev=%#x)", dev.rev_id());
+  // find and store capabilities
+  dev.parse_capabilities();
+  // find BARs etc.
+  dev.probe_resources();
+  //assert(0);
+  this->m_mixer_io = dev.get_bar(0).start;
+  INFO("AC97", "Mixer bar: %#hx", m_mixer_io);
+  this->m_nabm_io = dev.get_bar(1).start;
+  INFO("AC97", "Bus Mastering bar: %#hx", m_nabm_io);
+
+  // AC97 bare metal IRQ
+  this->m_irq = dev.get_legacy_irq();
+  for (int i = 5; i < 12; i++) {
+    __arch_enable_legacy_irq(i);
+    Events::get().subscribe(i,
+      [this, i] () {
+        printf("Trigger on IRQ %u\n", i);
+        this->m_irq = i;
+        this->irq_handler();
+      });
+  }
+  INFO("AC97", "Legacy IRQ: %u", this->m_irq);
+
+  // allocate buffers
+  for (size_t i = 0; i < m_desc.size(); i++) {
+    const auto& buffer = m_buffers.at(i).buffer;
+    m_desc.at(i).buffer = (uint32_t) (uintptr_t) buffer.data();
+    m_desc.at(i).ctlv   = buffer.size() & 0xFFFF;
+    m_desc.at(i).ctlv   |= (1u << 31);
+  }
+  uint32_t bdl = (uint32_t) (uintptr_t) m_desc.data();
+  hw::outl(m_nabm_io + NABM_PO_BDBAR, bdl);
+
+  // current index
+  this->m_current_idx = 0;
+  write_nabm8(NABM_PO_LVI, m_current_idx);
+
+  // enable interrupts
+  this->enable_interrupts();
+  // full volume
+  write_mixer16(PORT_NAM_PCM_VOLUME, 0x0);
+
+  // start! (by unpausing)
+  write_nabm8(NABM_PO_CTRL, read_nabm8(NABM_PO_CTRL) | NABM_CR_RPBM);
+  //assert(dev.intx_status());
+  printf("Status: %#x\n", read_nabm8(NABM_PO_STAT));
+}
+
+void AC97::irq_handler()
+{
+  printf("Received interrupt %u\n", this->m_irq);
+
+}
+
+void AC97::set_mixer(mixer_value_t knob, uint32_t)
+{
+
+}
+uint32_t AC97::get_mixer(mixer_value_t knob)
+{
+  return 0;
+}
+
+void AC97::enable_interrupts() {
+  write_nabm8(NABM_PO_CTRL, NABM_CR_IE_FE | NABM_CR_IE_IOC);
+}
+void AC97::disable_interrupts() {
+  write_nabm8(NABM_PO_CTRL, 0x0);
+}
+
+uint8_t  AC97::read_mixer8(uint16_t offset) {
+  return hw::inb(this->m_mixer_io + offset);
+}
+uint16_t AC97::read_mixer16(uint16_t offset) {
+  return hw::inw(this->m_mixer_io + offset);
+}
+void AC97::write_mixer8(uint16_t offset, uint8_t value) {
+  hw::outb(this->m_mixer_io + offset, value);
+}
+void AC97::write_mixer16(uint16_t offset, uint16_t value) {
+  hw::outw(this->m_mixer_io + offset, value);
+}
+
+uint8_t  AC97::read_nabm8(uint16_t offset) {
+  return hw::inb(this->m_nabm_io + offset);
+}
+uint16_t AC97::read_nabm16(uint16_t offset) {
+  return hw::inw(this->m_nabm_io + offset);
+}
+void AC97::write_nabm8(uint16_t offset, uint8_t value) {
+  hw::outb(this->m_nabm_io + offset, value);
+}
+void AC97::write_nabm16(uint16_t offset, uint16_t value) {
+  hw::outw(this->m_nabm_io + offset, value);
+}
+
+#include <kernel/pci_manager.hpp>
+__attribute__((constructor))
+static void register_func()
+{
+  PCI_manager::register_snd(PCI::VENDOR_INTEL, 0x2415, &AC97::new_instance);
+  PCI_manager::register_snd(PCI::VENDOR_INTEL, 0x2425, &AC97::new_instance);
+  PCI_manager::register_snd(PCI::VENDOR_INTEL, 0x2445, &AC97::new_instance);
+}

--- a/src/drivers/ac97.hpp
+++ b/src/drivers/ac97.hpp
@@ -1,0 +1,54 @@
+#include <hw/audio_device.hpp>
+#include <hw/pci_device.hpp>
+
+class AC97 : public hw::Audio_device
+{
+public:
+  static const int NUM_DESC   = 32;
+  static const int BUFFER_LEN = 0x1000;
+
+  AC97(hw::PCI_Device&);
+
+  std::string device_name() const override {
+    return "ac97";
+  }
+  const char* driver_name() const noexcept override {
+    return "Intel AC'97";
+  }
+
+  void     set_mixer(mixer_value_t, uint32_t) override;
+  uint32_t get_mixer(mixer_value_t) override;
+
+  void deactivate() override {}
+
+  static std::unique_ptr<Audio_device> new_instance(hw::PCI_Device& d)
+  { return std::make_unique<AC97>(d); }
+
+private:
+  uint8_t  read_mixer8  (uint16_t offset);
+  uint16_t read_mixer16 (uint16_t offset);
+  void     write_mixer8 (uint16_t offset, uint8_t value);
+  void     write_mixer16(uint16_t offset, uint16_t value);
+  uint8_t  read_nabm8  (uint16_t offset);
+  uint16_t read_nabm16 (uint16_t offset);
+  void     write_nabm8 (uint16_t offset, uint8_t value);
+  void     write_nabm16(uint16_t offset, uint16_t value);
+  void irq_handler();
+  void enable_interrupts();
+  void disable_interrupts();
+  //
+  uint8_t  m_irq;
+  uint16_t m_mixer_io;
+  uint16_t m_nabm_io;
+  //
+  struct buffer_t {
+    std::array<uint8_t, 4096> buffer;
+  };
+  struct buffer_desc_t {
+    uint32_t  buffer;
+    uint32_t  ctlv;
+  } __attribute__((packed));
+  std::array<buffer_desc_t, NUM_DESC> m_desc = {};
+  std::array<buffer_t, NUM_DESC> m_buffers;
+  uint32_t m_current_idx = 0;
+};

--- a/src/drivers/ihda.cpp
+++ b/src/drivers/ihda.cpp
@@ -1,0 +1,309 @@
+#include "ihda.hpp"
+#include <arch.hpp>
+#include <kernel/events.hpp>
+#include <immintrin.h>
+#include <info>
+
+#define REG_GCTL      0x08
+#define REG_STATESTS  0x0E
+static const uint16_t RST_BIT = 1 << 15;
+#define RING_LBASE(r) (r.reg + 0x0)
+#define RING_UBASE(r) (r.reg + 0x4)
+#define RING_WP(r)    (r.reg + 0x8)
+#define RING_RP(r)    (r.reg + 0xA)
+#define RING_CTL(r)   (r.reg + 0xC)
+#define RING_STAT(r)  (r.reg + 0xD)
+#define RING_SIZE(r)  (r.reg + 0xE)
+#define REG_IMM_CMD   0x60
+#define REG_IMM_RESP  0x64
+#define REG_IMM_STAT  0x68
+
+static const uint32_t VERB_GET = 0xF0000;
+
+IHDA::IHDA(hw::PCI_Device& dev)
+{
+  INFO("IntelHDA", "+--[ Intel HD Audio Device (rev=%#x) ]", dev.rev_id());
+  // find and store capabilities
+  dev.parse_capabilities();
+  // find BARs etc.
+  dev.probe_resources();
+  // MSI config
+  if (dev.msix_cap() || dev.msi_cap())
+  {
+    dev.init_msix();
+    assert(dev.has_msix());
+
+    if (dev.msi_cap()) {
+      this->m_irq = dev.get_legacy_irq();
+    }
+    Events::get().subscribe(this->m_irq, {this, &IHDA::event_handler});
+  }
+  else {
+    assert(0 && "Legacy INT#x not supported");
+  }
+  INFO2("|  |- IRQ: %u", this->m_irq);
+  // MMIO BAR
+  this->m_hdbar = dev.get_bar(0).start;
+  INFO2("|  |- MMIO address: %p", (void*) this->m_hdbar);
+
+  const uint8_t major = read<uint8_t>(0x3);
+  const uint8_t minor = read<uint8_t>(0x2);
+  INFO2("|  |- Version: %d.%d", major, minor);
+
+  this->reset();
+  this->detect_codecs();
+  INFO("IntelHDA", "|  +--[ Codecs: %zu ]", m_codecs.size());
+  m_corb.reg = 0x40;
+  m_rirb.reg = 0x50;
+  this->setup_ring(m_corb, true);
+  this->setup_ring(m_rirb, false);
+
+  for (auto& codec : m_codecs)
+  {
+    // get subnode count
+    auto req = this->get(0, codec.idx, 0x4);
+    codec.start_node = (req.resp >> 16) & 0xFF;
+    const int afg_count = req.resp & 0xff;
+
+    for (int i = 0; i < afg_count; i++)
+    {
+      const int subnode = codec.start_node + i;
+      // get subnode count
+      auto req = this->get(subnode, codec.idx, 0x4);
+      // get function group type
+      auto func_group = this->get(subnode, codec.idx, 0x5);
+
+      codec.afgs.emplace_back();
+      auto& afg = codec.afgs.back();
+      afg.node_id = subnode;
+      afg.type    = func_group.resp;
+      afg.start_node = (req.resp >> 16) & 0xff;
+      afg.node_count = req.resp & 0xff;
+
+      INFO2("|     o--[ Function Group %u ]", i);
+
+      for (uint32_t w = 0; w < afg.node_count; w++)
+      {
+        afg.widgets.emplace_back();
+        auto& widget = afg.widgets.back();
+        widget.m_node_id = afg.start_node + w;
+        // get function group type
+        auto func_group = this->get(widget.nid(), codec.idx, 0x5);
+        // get widget capabilities
+        auto req_caps = this->get(widget.nid(), codec.idx, 0x9);
+        widget.m_caps = req_caps.resp;
+        // get conn list length
+        auto req_cll = this->get(widget.nid(), codec.idx, 0xE);
+        widget.m_conn_listen_len = req_cll.resp;
+        // get conn list entries
+        auto req_fcle = this->cmd(widget.nid(), codec.idx, 0xF02 << 8);
+        widget.m_first_conn_list_entry = req_fcle.resp;
+
+        INFO2("|     +-- Widget %u: %s (%#x)", w, widget.name(), widget.type());
+      }
+      INFO2("|");
+    }
+  }
+
+  // enable interrupts
+
+}
+
+void IHDA::reset()
+{
+  // reset the device and wait
+  this->write<uint32_t>(REG_GCTL, 0);
+  for(int n = 0; n < 6000; n++) asm("pause");
+  // start the device
+  this->write<uint32_t>(REG_GCTL, 1);
+  // wait for bit to reset
+  while ((this->read<uint32_t>(REG_GCTL) & 0x1) == 0) asm("pause");
+}
+
+void IHDA::detect_codecs()
+{
+  uint8_t stat = this->read<uint8_t>(REG_STATESTS);
+  for (int i = 0; i < 16; i++) {
+    if (stat & (1 << i)) {
+      m_codecs.emplace_back();
+      m_codecs.back().idx = i;
+    }
+  }
+}
+
+void IHDA::setup_ring(corb_t& ring, bool corb)
+{
+  assert(ring.reg != 0);
+  this->stop_dma(ring);
+  // we only support 256 buffers (mode=2)
+  // 1=0, 16=2, 256=4, resv=8
+  const uint8_t sz = this->read<uint8_t> (RING_SIZE(ring));
+  assert(sz & 0b0010 && "We support only 16 descriptors");
+  // 0=1, 1=16, 2=256, 3=resv
+  this->write<uint8_t> (RING_SIZE(ring), 0x1);
+  // RIRB entries are 2x the size of CORB entries
+  const size_t entry_size = (corb) ? 4 : 8;
+  ring.entries = (verb_t*) memalign(128, NUM_CORB * entry_size);
+  auto data = (uintptr_t) ring.entries;
+  assert((data & 0x7F) == 0 && "Must be 128-byte aligned");
+  this->write<uint32_t> (RING_UBASE(ring), data >> 32);
+  this->write<uint32_t> (RING_LBASE(ring), data & 0xFFFFFFFF);
+
+  if (corb)
+  {
+    // reset write pointer
+    this->write<uint16_t> (RING_WP(ring), 0);
+    // clear read pointer
+    while ((this->read<uint16_t> (RING_RP(ring)) & RST_BIT) == 0) {
+      this->write<uint16_t> (RING_RP(ring), RST_BIT);
+      __builtin_ia32_pause();
+    }
+    this->write<uint16_t> (RING_RP(ring), 0x0);
+  }
+  else
+  {
+    // NOTE: reset read pointer to 1
+    this->write<uint16_t> (RING_RP(ring), 1);
+    // clear write pointer
+    this->write<uint16_t> (RING_WP(ring), RST_BIT);
+  }
+}
+
+void IHDA::start_dma(corb_t& ring)
+{
+  while ((this->read<uint8_t> (RING_CTL(ring)) & 0x2) != 2) {
+    this->write<uint8_t> (RING_CTL(ring), 0x2); _mm_pause();
+  }
+}
+void IHDA::stop_dma(corb_t& ring)
+{
+  while ((this->read<uint8_t> (RING_CTL(ring)) & 0x2) == 2) {
+    this->write<uint8_t> (RING_CTL(ring), 0x0); _mm_pause();
+  }
+}
+
+void IHDA::blocking_write(corb_t& ring, verb_t& verb)
+{
+  this->start_dma(ring);
+  while (true) {
+    uint16_t rp = this->read<uint16_t> (RING_RP(ring)) & 0xff;
+    uint16_t wp = this->read<uint16_t> (RING_WP(ring)) & 0xff;
+
+    __sync_synchronize();
+    if (wp == rp) {
+      // next free is at (WP + 4) % size
+      wp = (wp + 1) % NUM_CORB;
+      ring.entries[wp].whole = verb.whole;
+      this->write<uint16_t> (RING_WP(ring), wp);
+      return;
+    }
+  }
+}
+IHDA::response_t IHDA::blocking_read(corb_t& ring)
+{
+  while (true)
+  {
+    this->start_dma(ring);
+    // RIRP responses are 64-bit (2 entries)
+    uint16_t rp = this->read<uint16_t> (RING_RP(ring)) & 0xff;
+
+    const response_t resp {
+      .resp = ring.entries[rp * 2 + 0].whole,
+      .rext = ring.entries[rp * 2 + 1].whole
+    };
+
+    this->stop_dma(ring);
+    // advance read position
+    rp = (rp + 1) % NUM_CORB;
+    this->write<uint16_t> (RING_RP(ring), rp);
+
+    this->start_dma(ring);
+    return resp;
+  }
+}
+
+IHDA::response_t IHDA::corb_read(verb_t& verb)
+{
+  // complex, and WIP
+  this->blocking_write(this->m_corb, verb);
+  return this->blocking_read(this->m_rirb);
+}
+IHDA::response_t IHDA::immediate_read(verb_t& verb)
+{
+  // immediate, supported by Qemu
+  this->write<uint32_t> (REG_IMM_CMD, verb.whole);
+  this->write<uint32_t> (REG_IMM_STAT, 0x1); // ship!
+  // wait for response
+  while ((this->read<uint32_t>(REG_IMM_STAT) & 0x2) == 0) _mm_pause();
+  const response_t response {
+      this->read<uint32_t> (REG_IMM_RESP),
+      0
+    };
+  // response read
+  this->write<uint32_t> (REG_IMM_STAT, 0x0);
+  return response;
+}
+
+IHDA::response_t IHDA::cmd(uint8_t nid, uint8_t cad, uint32_t cmd)
+{
+  verb_t verb {
+    .verb = cmd,
+    .nid  = nid,
+    .indirect_nid = 0,
+    .cad  = cad
+  };
+  return immediate_read(verb);
+}
+IHDA::response_t IHDA::get(uint8_t nid, uint8_t cad, uint8_t param)
+{
+  return this->cmd(nid, cad, VERB_GET | param);
+}
+
+void IHDA::event_handler()
+{
+  printf("Interrupt!\n");
+}
+
+template <typename T>
+inline T IHDA::read(uint32_t reg)
+{
+  return *(volatile T*) (this->m_hdbar + reg);
+}
+template <typename T>
+inline void IHDA::write(uint32_t reg, T value)
+{
+  *(volatile T*) (this->m_hdbar + reg) = value;
+}
+
+void IHDA::set_mixer(mixer_value_t, uint32_t)
+{
+
+}
+uint32_t IHDA::get_mixer(mixer_value_t)
+{
+  return 0;
+}
+
+const char* IHDA::widget_t::name() const noexcept
+{
+  switch (this->type())
+  {
+    case 0x0:
+        return "Audio Output";
+    case 0x1:
+        return "Audio Input";
+    case 0x4:
+        return "Pin Complex";
+    default:
+        return "Unknown widget";
+  }
+}
+
+#include <kernel/pci_manager.hpp>
+__attribute__((constructor))
+static void register_func()
+{
+  PCI_manager::register_snd(PCI::VENDOR_INTEL, 0x2668, &IHDA::new_instance);
+  PCI_manager::register_snd(PCI::VENDOR_INTEL, 0x27D8, &IHDA::new_instance);
+  PCI_manager::register_snd(PCI::VENDOR_AMD,   0x4383, &IHDA::new_instance);
+}

--- a/src/drivers/ihda.hpp
+++ b/src/drivers/ihda.hpp
@@ -1,0 +1,95 @@
+#include <hw/audio_device.hpp>
+#include <hw/pci_device.hpp>
+
+class IHDA : public hw::Audio_device
+{
+public:
+  static const int NUM_CORB   = 16;
+  static const int BUFFER_LEN = 0x1000;
+
+  IHDA(hw::PCI_Device&);
+
+  std::string device_name() const override {
+    return "ihda";
+  }
+  const char* driver_name() const noexcept override {
+    return "Intel High-Definition Audio";
+  }
+
+  void     set_mixer(mixer_value_t, uint32_t) override;
+  uint32_t get_mixer(mixer_value_t) override;
+
+  void deactivate() override {}
+
+  static std::unique_ptr<Audio_device> new_instance(hw::PCI_Device& d)
+  { return std::make_unique<IHDA>(d); }
+
+private:
+  template <typename T> T read(uint32_t);
+  template <typename T> void write(uint32_t, T);
+  void reset();
+  void detect_codecs();
+  void event_handler();
+
+  struct widget_t
+  {
+    const char* name() const noexcept;
+    uint8_t nid() const noexcept { return this->m_node_id; }
+    uint8_t type() const noexcept { return (this->m_caps >> 20) & 0xF; }
+
+    uint32_t m_node_id;
+    uint32_t m_type;
+    uint32_t m_conn_listen_len;
+    uint32_t m_caps;
+    uint32_t m_first_conn_list_entry;
+  };
+  struct afg_t {
+    uint32_t node_id;
+    uint32_t type;
+    uint32_t start_node;
+    uint32_t node_count;
+    std::vector<widget_t> widgets;
+  };
+  struct codec_t {
+    uint8_t  idx = 0;
+    uint32_t start_node;
+    std::vector<afg_t> afgs;
+  };
+  struct response_t {
+    const uint32_t resp;
+    const uint32_t rext;
+  };
+
+  union verb_t {
+    struct {
+      uint32_t verb : 20;
+      uint32_t nid  : 7;
+      uint32_t indirect_nid : 1;
+      uint32_t cad  : 4;
+    };
+    uint32_t whole = 0;
+  };
+  struct alignas(128) corb_t {
+    verb_t* entries = nullptr;
+    uint32_t reg = 0;
+  };
+
+  void setup_ring(corb_t&, bool corb);
+  void start_dma(corb_t&);
+  void stop_dma(corb_t&);
+  void blocking_write(corb_t&, verb_t&);
+  response_t blocking_read(corb_t& ring);
+  response_t corb_read(verb_t&);
+  response_t immediate_read(verb_t&);
+  // GetParam function
+  response_t get(uint8_t nid, uint8_t cad, uint8_t param);
+  response_t cmd(uint8_t nid, uint8_t cad, uint32_t cmd);
+
+  uintptr_t m_hdbar = 0;
+  uint8_t   m_irq;
+  corb_t m_corb;
+  corb_t m_rirb;
+  std::vector<codec_t> m_codecs;
+
+  static_assert(sizeof(verb_t) == 4, "Entries are 4 bytes each");
+};

--- a/src/hw/pci_device.cpp
+++ b/src/hw/pci_device.cpp
@@ -130,6 +130,7 @@ namespace hw {
             devtype_.subclass);
       break;
     case PCI::classcode::STORAGE:
+    case PCI::classcode::MULTIMEDIA:
       INFO2("+--[ %s, %s (0x%x) ]",
             PCI::classcode_str(devtype_.classcode),
             PCI::vendor_str(vendor_id()),
@@ -259,4 +260,12 @@ namespace hw {
     return stat & (1 << 3);
   }
 
+  uint8_t PCI_Device::get_legacy_irq()
+  {
+    uint32_t value = this->read32(PCI::CONFIG_INTR);
+    if ((value & 0xFF) != 0xFF) {
+      return value & 0xFF;
+    }
+    return 0;
+  }
 } //< namespace hw

--- a/src/hw/pci_msi.cpp
+++ b/src/hw/pci_msi.cpp
@@ -45,7 +45,15 @@ namespace hw
     auto cmd = read16(PCI_CMD_REG);
     write16(PCI_CMD_REG, cmd | (1 << 10));
     // enable MSI-X
-    this->msix = new msix_t(*this, msix_cap());
+    if (this->msix_cap()) {
+      this->msix = new msix_t(*this, true, msix_cap());
+    }
+    else if (this->msi_cap()) {
+      this->msix = new msix_t(*this, false, msi_cap());
+    }
+    else {
+      assert(0 && "No MSI or MSI-X capability found");
+    }
     // deallocate if it failed
     if (this->msix->vectors() == 0) {
       delete this->msix;

--- a/src/kernel/pci_manager.cpp
+++ b/src/kernel/pci_manager.cpp
@@ -33,6 +33,7 @@ using fixed_factory_t = std::vector<Driver_entry<Driver>>;
 static std::vector<hw::PCI_Device> devices_;
 static std::vector<Driver_entry<PCI_manager::NIC_driver>> nic_fact;
 static std::vector<Driver_entry<PCI_manager::BLK_driver>> blk_fact;
+static std::vector<Driver_entry<PCI_manager::SND_driver>> snd_fact;
 
 template <typename Factory, typename Class>
 static inline bool register_device(hw::PCI_Device& dev,
@@ -105,6 +106,14 @@ void PCI_manager::scan_bus(const uint8_t classcode, const int bus)
           register_device_nic(stored_dev, nic_fact);
         }
         break;
+      case PCI::MULTIMEDIA:
+        if (classcode == PCI::MULTIMEDIA
+          && (devclass.subclass == 0x1 || devclass.subclass == 0x3))
+        {
+          auto& stored_dev = devices_.emplace_back(pci_addr, id, devclass.reg);
+          register_device<SND_driver, hw::Audio_device>(stored_dev, snd_fact);
+        }
+        break;
       case PCI::BRIDGE:
         // scan secondary bus for PCI-to-PCI bridges
         if (devclass.subclass == 0x4) {
@@ -148,4 +157,8 @@ void PCI_manager::register_nic(uint16_t vendor, uint16_t prod, NIC_driver factor
 void PCI_manager::register_blk(uint16_t vendor, uint16_t prod, BLK_driver factory)
 {
   blk_fact.emplace_back(driver_id(vendor, prod), factory);
+}
+void PCI_manager::register_snd(uint16_t vendor, uint16_t prod, SND_driver factory)
+{
+  snd_fact.emplace_back(driver_id(vendor, prod), factory);
 }

--- a/src/platform/x86_pc/platform.cpp
+++ b/src/platform/x86_pc/platform.cpp
@@ -104,6 +104,8 @@ void __platform_init()
   OS::m_block_drivers_ready = true;
   // Initialize network devices
   PCI_manager::init(PCI::NIC);
+  // Initialize all multimedia devices
+  PCI_manager::init(PCI::MULTIMEDIA);
 
   // Print registered devices
   hw::Devices::print_devices();

--- a/vmrunner/vm.schema.json
+++ b/vmrunner/vm.schema.json
@@ -99,6 +99,11 @@
       "enum" : ["std", "cirrus", "vmware", "qxl", "xenfb", "tcx", "cg3", "virtio", "none"]
     },
 
+    "snd" : {
+      "description" : "Enable sound card",
+      "enum" : ["sb16", "ac97", "hda", "pcspk", "all"]
+    },
+
     "vfio" : {
       "description" : "VFIO PCI-passthrough on device",
       "type" : "string"

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -539,6 +539,9 @@ class qemu(hypervisor):
         if "vga" in self._config:
             vga_arg = ["-vga", str(self._config["vga"])]
 
+        if "snd" in self._config:
+            vga_arg.extend(["-soundhw", str(self._config["snd"])])
+
         trace_arg = []
         if "trace" in self._config:
             trace_arg = ["-trace", "events=" + str(self._config["trace"])]


### PR DESCRIPTION
- AC97 doesnt work because we dont have legacy interrupt (int#x) support
- Intel HDA is extremely complex, but the foundation is there
