### PR TITLE
test: saving-statistics

### DIFF
--- a/test/get_testStats.py
+++ b/test/get_testStats.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+import csv
+import datetime
+import subprocess
+import json
+import update
+import re
+import ntpath
+import multiprocessing
+import os
+
+#sub_test_stats = subTestStats()
+
+class statOps:
+    def __init__(self): # date, #testname #git commit # machinary config
+        dt = datetime.datetime.utcnow()
+        self.now = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        self.last_git_commit = subprocess.check_output(['git','log', '--date=iso-strict-local','-n 1','--pretty=format: %h, %ad']).strip()
+        self.latest_git_tag = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags']).strip()
+        # git describe --tags $(git rev-list --tags --max-count=1)
+        self.test_results = {}
+        self.final_time = None
+
+    def clean_csv(self, filename):
+        subprocess.call(["rm %s" % filename], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+
+    def append_stat_to_list(self, test_name, test_time, test_status, cpu_usage, memory_usage, machine):
+        key = ntpath.basename(test_name) + os.path.split(test_name)[0]
+        if key not in self.test_results:
+            self.test_results[key] = []
+
+        result_list = test_name, test_time[-2:-1], self.now, test_status, cpu_usage, memory_usage, machine
+        self.test_results[key].append('%s' % ', '.join(map(str, result_list)))
+
+    def register_all_test_stats(self, filename):
+        keys = sorted(self.test_results.keys())
+        with open("%s" % filename, "wb+") as csv_file:
+            writer = csv.writer(csv_file, delimiter="\t", quoting=csv.QUOTE_NONE)
+            writer.writerows(self.test_results.values())
+
+        sheet_name = "Includeos-Sub-Test-Stats"
+        update.main(filename, sheet_name)
+
+    # fetch and register test name and time taken by test
+    def save_stats_csv(self):
+        filename = 'TestOverview_{0}.csv'.format(self.now)
+        self.register_all_test_stats(filename)
+        self.clean_csv(filename)
+
+    def register_final_stats(self, final_time, test_description, skipped, test_status, fail_count): # name # time (end - start)
+        sheet_name = "IncludeOS-Test-Stats" #"IncludeOS-testing-stats"
+        filename = "TestStats.csv"
+    #    sheet_choice = "sh.sheet1"
+        num_cpus = int(multiprocessing.cpu_count())
+        machine = os.uname()[3]#.replace(" ", "_")
+        total_test_data = [self.now, final_time[:-1], test_description, skipped, test_status, self.latest_git_tag, "%s" % ''.join(self.last_git_commit), num_cpus, machine, fail_count]
+        with open("%s" % filename,'wb+') as csv_file:
+            writer = csv.writer(csv_file,lineterminator='\n')
+            writer.writerow(total_test_data)
+        update.main(filename, sheet_name)
+        self.clean_csv(filename)

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 import subprocess
 import sys
@@ -9,6 +9,8 @@ import time
 import multiprocessing  # To figure out number of cpus
 import junit_xml as jx
 import codecs
+import psutil
+import re
 
 sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 1) # line buffering
 sys.path.insert(0, ".")
@@ -17,11 +19,14 @@ sys.path.insert(0, "..")
 from vmrunner.prettify import color as pretty
 from vmrunner import validate_vm
 import validate_tests
+from get_testStats import statOps
+
 
 startdir = os.getcwd()
 
 test_categories = ['fs', 'hw', 'kernel', 'mod', 'net', 'performance', 'plugin', 'posix', 'stl', 'util']
 test_types = ['integration', 'stress', 'unit', 'misc', 'linux']
+test_results = statOps()
 
 """
 Script used for running all the valid tests in the terminal.
@@ -55,6 +60,9 @@ parser.add_argument("-p", "--parallel-tests", dest="parallel", default=0, type=i
                     help="How many tests to run at once in parallell, \
                     overrides cpu count which is default")
 
+parser.add_argument("-S", "--save-stats", dest="stats", action="store_true",
+                    help="Produces csv stat results")
+
 args = parser.parse_args()
 
 test_count = 0
@@ -68,6 +76,7 @@ def print_skipped(tests):
 
 class Test:
     """ A class to start a test as a subprocess and pretty-print status """
+
     def __init__(self, path, clean=False, command=['python', '-u', 'test.py'], name=None):
         self.command_ = command
         self.proc_ = None
@@ -76,6 +85,10 @@ class Test:
         self.clean = clean
         self.start_time = None
         self.properties_ = {"time_sensitive": False, "intrusive": False}
+        self.test_time = None
+        self.final_time = None
+
+
         # Extract category and type from the path variable
         # Category is linked to the top level folder e.g. net, fs, hw
         # Type is linked to the type of test e.g. integration, unit, stress
@@ -171,8 +184,8 @@ class Test:
         sys.stdout.flush()
 
     def print_duration(self):
-        print "{0:5.0f}s".format(time.time() - self.start_time),
-        sys.stdout.flush()
+        self.test_time = "{0:5.0f}s".format(time.time() - self.start_time)
+        print self.test_time
 
     def wait_status(self):
 
@@ -180,23 +193,37 @@ class Test:
 
         # Start and wait for the process
         self.proc_.communicate()
+        cpu_usage = psutil.cpu_percent()
+        pid = os.getpid()
+        py = psutil.Process(pid)
+        memory_usage = psutil.virtual_memory()[2] # memory percent
+        # py.memory_info()[0] #/(1024*1024) # memory usage in MB
+
+        machine = os.uname()[4]#.replace(" ", "_")
+
         self.print_duration()
 
+        # writes to log
         with codecs.open('{}/log_stdout.log'.format(self.path_), encoding='utf-8', errors='replace') as log_stdout:
             self.output_.append(log_stdout.read())
 
         with codecs.open('{}/log_stderr.log'.format(self.path_), encoding='utf-8', errors='replace') as log_stderr:
             self.output_.append(log_stderr.read())
 
-
         if self.proc_.returncode == 0:
             print pretty.PASS_INLINE()
+            test_status = "PASS"
         else:
             print pretty.FAIL_INLINE()
             print pretty.INFO("Process stdout")
             print pretty.DATA(self.output_[0].encode('ascii', 'ignore').decode('ascii'))
             print pretty.INFO("Process stderr")
             print pretty.DATA(self.output_[1].encode('ascii', 'ignore').decode('ascii'))
+            test_status = "FAIL"
+
+        # Save stats
+        if args.stats:
+            test_results.append_stat_to_list(self.path_,self.test_time, test_status, cpu_usage, memory_usage, machine)
 
         return self.proc_.returncode
 
@@ -273,6 +300,7 @@ def stress_test(stress_tests):
 
     for test in stress_tests:
         return 1 if test.wait_status() else 0
+
 
 
 def misc_working(misc_tests, test_type):
@@ -370,7 +398,6 @@ def integration_tests(tests):
 
     return fail_count
 
-
 def find_test_folders():
     """ Used to find all (integration) test folders
 
@@ -454,9 +481,6 @@ def filter_tests(all_tests, arguments):
                 if test.properties_[argument] and test not in tests_added:
                     tests_added.append(test)
 
-
-
-
     # 2) Remove tests defined by the skip argument
     print pretty.INFO("Tests marked skip on command line"), ", ".join(skip_args)
     skipped_tests = [ x for x in tests_added
@@ -516,10 +540,17 @@ def create_junit_output(tests):
     with open('output.xml', 'w') as f:
             jx.TestSuite.to_file(f, [ts], prettyprint=False)
 
+def time_now():
+    time_now = time.time()
+    return time_now
+
 
 def main():
     # Find leaf nodes
+    start_time = time_now()
     leaves = find_test_folders()
+    test_description = ''.join(args.tests)
+    skipped = ' '.join(args.skip)
 
     # Populate test objects
     all_tests = [ Test(path, args.clean) for path in leaves ]
@@ -544,8 +575,20 @@ def main():
     if (status == 0):
         print pretty.SUCCESS(str(test_count - status) + " / " + str(test_count)
                             +  " tests passed, exiting with code 0")
+        final_test_status = "PASS"
     else:
         print pretty.FAIL(str(status) + " / " + str(test_count) + " tests failed ")
+        final_test_status = "FAIL"
+
+    # Save stats
+    if args.stats:
+        test_results.save_stats_csv() # should only be called after all tests are over.
+    # test time
+        end_time = time_now()
+        final_duration = "{0:5.0f}s".format(end_time - start_time)
+        #final_time = statOps("test", final_duration, final_test_status)
+        fail_count = status
+        test_results.register_final_stats(final_duration, test_description, skipped,  final_test_status, fail_count)
 
     # Create Junit output
     if args.junit:

--- a/test/update.py
+++ b/test/update.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+
+import pygsheets
+import sys
+import csv
+
+def read_csv(in_filename):
+
+    with open(in_filename) as file:
+        reader = csv.reader(file, delimiter=',', quotechar='|')
+
+        rows = []
+        for row in reader:
+            rows.append(row)
+        return rows
+
+def main(in_filename, out_filename):
+
+    gc = pygsheets.authorize(
+        outh_file="client_secret.json",
+        outh_nonlocal=True)
+
+    all_sheets = gc.list_ssheets()
+    all_names = [sheet['name'] for sheet in all_sheets]
+
+    sheet_name = None
+
+    if sheet_name is not None:
+        gc.create(sheet_name)
+        print sheet_name
+    elif out_filename is not None and sheet_name is None:
+        sheet_name = out_filename
+    else:
+        while True:
+            sys.stdout.write("Name of Google Sheet: ")
+            sheet_name = input().lower()
+            if sheet_name != "" and sheet_name in all_names:
+                break
+            else:
+                sys.stdout.write(
+                    "Please respond with the name of the Google Sheet.\n")
+    sh = gc.open(sheet_name)
+    wks = sh.sheet1
+
+    read_from_file = read_csv(in_filename)
+    for row in read_from_file:
+        rows = len(wks.get_col(2, returnas='cell', include_empty=False))
+        wks.append_table(start=("A" + str(rows + 1)), end=None, values=row)
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) < 2:
+        print("Error: Wrong number of arguments\nUsage: python auth.py <CSV filename> <Google spreadsheet name>")
+    elif len(sys.argv) == 2:
+        # Input file: filename.csv, Output file: gsheet name
+        main(sys.argv[1], None)
+    else:
+        # Input file: filename.csv, Output file: gsheet name
+        main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
An initiative to store test statistics over time to track performance, memory usage based a number of circumstances.

**NEW FILES:**

1. `get_testStats.py` : for collecting/handling statistics and saving to csv files.

2.`update.py`: for updating statistics to gsheets, written in python3

**CHANGES:**

The `testrunner.py` has been updated with a number of things:
1. A new argument `-S` and/or `--save-stats` has been added for a choice to save stats

2. A few new python libraries have been imported for collecting certain stats: 
  ex. `putil`, `re`

3. The new module called `get_testStats` has been imported

4. A number of new variables have been added for time, memory, os details collection.

**Note:**

The stat option requires some secret keys to be able to write to gsheets.
The secret keys would have to be copied to the test directory.

_current example usage:_ `./testrunner.py -s intrusive -t fs -p 1 -S`

Current filenames are already specified in the `update.py`, thus running with `-S` and including the keys with allow write permissions to the file.

_In Jenkins, the secret files can be stored and copied to the directory during testing._

**NEW dependencies:**
- python3
- pygsheets