### PR TITLE
install: add net-tools to dependencies

### DIFF
--- a/etc/install_dependencies_linux.sh
+++ b/etc/install_dependencies_linux.sh
@@ -6,7 +6,7 @@
 # OPTIONS:
 ############################################################
 
-BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils qemu jq python-pip gcc g++-multilib"
+BUILD_DEPENDENCIES="curl make cmake nasm bridge-utils net-tools qemu jq python-pip gcc g++-multilib"
 CLANG_VERSION_MIN_REQUIRED="5.0"
 [ ! -z "$CC" ] && { CLANG_VERSION=${CC: -3}; } || CLANG_VERSION=$CLANG_VERSION_MIN_REQUIRED
 [[ $CLANG_VERSION < $CLANG_VERSION_MIN_REQUIRED ]] && CLANG_VERSION=$CLANG_VERSION_MIN_REQUIRED


### PR DESCRIPTION
I wasn't sure in which place this should be, so I added it after bridge-utils since they're both related.

This happened for me on Ubuntu 18.04 - net-tools wasn't installed:
```
-- Installing: /home/muttley/includeos/includeos/include/micro_lb/balancer.hpp
-- Installing: /home/muttley/includeos/includeos/include/microLB
~/git/IncludeOS


>>> Done! IncludeOS bundle downloaded and installed


>>> Installing network bridge
    Creating network bridge for IncludeOS 
    Using default settings 
    Creating bridge bridge43, netmask 255.255.255.0, gateway 10.0.0.1 
    ipv6 netmask 64, gateway fe80::e823:fcff:fef4:83e7 
    Creating network bridge (requires sudo):
[sudo] password for muttley: 
sudo: ifconfig: command not found
    Configuring network bridge (requires sudo):
sudo: ifconfig: command not found
>>> Sorry <<<
Could not create or configure bridge.

```