### PR TITLE
Code coverage report generation

### DIFF
--- a/conan/http-parser/conanfile.py
+++ b/conan/http-parser/conanfile.py
@@ -14,6 +14,9 @@ class HttpParserConan(ConanFile):
         repo = tools.Git(folder="http_parser")
         repo.clone("https://github.com/nodejs/http-parser.git",branch="v{}".format(self.version))
     #TODO handle target flags
+    def configure(self):
+        #doesnt matter what stdc++ lib you have
+        del self.settings.compiler.libcxx
     def build(self):
         self.run("make http_parser.o",cwd="http_parser")
 

--- a/conan/uzlib/2.1.1/conanfile.py
+++ b/conan/uzlib/2.1.1/conanfile.py
@@ -13,6 +13,9 @@ class UzlibConan(ConanFile):
         git = tools.Git(folder="uzlib")
         git.clone("https://github.com/pfalcon/uzlib",branch=str(self.version))
     ##hmm can i move this in configure..
+    def configure(self):
+        #this isnt c++ 
+        del self.settings.compiler.libcxx
     def build(self):
         #a symlink would also do the trick
         shutil.copy("Makefile.ios","uzlib/src/Makefile")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ add_library(os STATIC ${SRCS} ${OBJECTS})
 if (NOT CMAKE_TESTING_ENABLED)
   add_dependencies(os version )
   add_subdirectory(arch/${ARCH})
-  if (NOT CORE_OS AND )
+  if (NOT CORE_OS)
 
     add_subdirectory(platform/x86_pc)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,16 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.1.0)
+
 project(unittests C CXX)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # IncludeOS install location
-if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
-  set(ENV{INCLUDEOS_PREFIX} /usr/local)
-endif()
+#if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+#  set(ENV{INCLUDEOS_PREFIX} /usr/local)
+#endif()
 
 option(COVERAGE "Build with coverage generation" OFF)
+option(CPPCHECK "Enable cppcheck when building" OFF)
 option(SILENT_BUILD "Build with some warnings turned off" ON)
 
 option(INFO "Print INFO macro output" OFF)
@@ -24,10 +27,11 @@ message(STATUS "Building for arch ${ARCH}")
 add_definitions(-DARCH_${ARCH})
 add_definitions(-DARCH="${ARCH}")
 add_definitions(-DPLATFORM_UNITTEST)
-#add_definitions(-DOS_VERSION="v0.0.0.1")
+
 FILE(WRITE ${CMAKE_BINARY_DIR}/version.h
-"#define OS_VERSION \"v0.0.0.1\"\n"
+  "#define OS_VERSION \"v0.0.0.1\"\n"
 )
+
 include_directories(${CMAKE_BINARY_DIR})
 set(CMAKE_C_FLAGS "-g -O0 -std=c11 -Wall -Wextra")
 
@@ -41,8 +45,13 @@ if (DEBUG_INFO)
   set(NO_DEBUG "")
 endif()
 
-set(CMAKE_CXX_FLAGS "-g -O0 -march=native -std=c++17 -Wall -Wextra -Wno-unused-function -D__id_t_defined -DUNITTESTS -DURI_THROW_ON_ERROR ${NO_INFO} ${NO_DEBUG} -DGSL_THROW_ON_CONTRACT_VIOLATION -Dlest_FEATURE_AUTO_REGISTER=1 -DHAVE_LEST_MAIN")
-
+if (COVERAGE)
+  #IF clang do A if gcc do B
+  set(CMAKE_CXX_FLAGS "-g -O0 -march=native -std=c++17 --coverage -fprofile-arcs -ftest-coverage -Wall -Wextra -Wno-unused-function -D__id_t_defined -DUNITTESTS -DURI_THROW_ON_ERROR ${NO_INFO} ${NO_DEBUG} -DGSL_THROW_ON_CONTRACT_VIOLATION -Dlest_FEATURE_AUTO_REGISTER=1 -DHAVE_LEST_MAIN")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+else()
+  set(CMAKE_CXX_FLAGS "-g -O0 -march=native -std=c++17 -Wall -Wextra -Wno-unused-function -D__id_t_defined -DUNITTESTS -DURI_THROW_ON_ERROR ${NO_INFO} ${NO_DEBUG} -DGSL_THROW_ON_CONTRACT_VIOLATION -Dlest_FEATURE_AUTO_REGISTER=1 -DHAVE_LEST_MAIN")
+endif()
 if (APPLE)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     message(STATUS "Including brew bundled libc++")
@@ -61,8 +70,8 @@ if(NOT DEFINED ${INCLUDEOS_ROOT})
   set(INCLUDEOS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 endif()
 
-set(SRC ${INCLUDEOS_ROOT}/src)
-set(TEST ${INCLUDEOS_ROOT}/test)
+#set(SRC ${INCLUDEOS_ROOT}/src)
+set(TEST ${CMAKE_CURRENT_SOURCE_DIR})
 
 #TODO get a released version ? or put one into root/cmake/ ?
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
@@ -71,7 +80,7 @@ if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
                   "${CMAKE_BINARY_DIR}/conan.cmake")
 endif()
 ##needed by conaningans
-set(CMAKE_BUILD_TYPE "Release")
+set(CMAKE_BUILD_TYPE "Debug")
 include(${CMAKE_BINARY_DIR}/conan.cmake)
 #include conan cmake
 conan_cmake_run(
@@ -85,15 +94,11 @@ conan_cmake_run(
 
 include_directories(
   ${TEST}/lest_util
-  ${INCLUDEOS_ROOT}/api
-  ${INCLUDEOS_ROOT}/src/
-  ${INCLUDEOS_ROOT}/src/include
-  ${INCLUDEOS_ROOT}/mod/
-  ${INCLUDEOS_ROOT}/mod/GSL
-  ${INCLUDEOS_ROOT}/mod/uzlib/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/../api
+  #TODO move to the right place
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib/LiveUpdate
   ${INCLUDEOS_ROOT}/lib/LiveUpdate
   ${TEST}/lest/include
-  $ENV{INCLUDEOS_PREFIX}/include
 )
 
 set(LEST_UTIL
@@ -183,94 +188,18 @@ set(TEST_SOURCES
   ${TEST}/util/unit/lstack/test_lstack_nomerge.cpp
   ${TEST}/util/unit/buddy_alloc_test.cpp
 )
+if (COVERAGE)
+  list(REMOVE_ITEM TEST_SOURCES ${TEST}/util/unit/path_to_regex_no_options.cpp)
+endif()
 
+if(EXTRA_TESTS)
+  set(GENERATE_SUPPORT_FILES ON)
+  message(STATUS "Adding some extra tests")
+  list(APPEND TEST_SOURCES ${TEST}/kernel/unit/rdrand_test.cpp)
+  list(APPEND TEST_SOURCES ${TEST}/util/unit/tar_test.cpp)
+endif()
 
-
-
-set(OS_SOURCES
-  ${SRC}/version.cpp
-  ${SRC}/arch/x86_64/paging.cpp
-  ${SRC}/fs/disk.cpp
-  ${SRC}/fs/dirent.cpp
-  ${SRC}/fs/fat.cpp
-  ${SRC}/fs/fat_async.cpp
-  ${SRC}/fs/fat_sync.cpp
-  ${SRC}/fs/filesystem.cpp
-  ${SRC}/fs/mbr.cpp
-  ${SRC}/fs/memdisk.cpp
-  ${SRC}/fs/path.cpp
-  ${SRC}/hw/nic.cpp
-  ${SRC}/hw/msi.cpp
-  ${SRC}/hw/pci_device.cpp
-  ${SRC}/hw/pci_msi.cpp
-  ${SRC}/hw/ps2.cpp
-  ${SRC}/kernel/cpuid.cpp
-  ${SRC}/kernel/elf.cpp
-  ${SRC}/kernel/events.cpp
-  ${SRC}/kernel/memmap.cpp
-  ${SRC}/kernel/os.cpp
-  ${SRC}/kernel/pci_manager.cpp
-  ${SRC}/kernel/rng.cpp
-  ${SRC}/kernel/service_stub.cpp
-  ${SRC}/kernel/syscalls.cpp
-  ${SRC}/kernel/timers.cpp
-  ${SRC}/musl/brk.cpp
-  ${SRC}/net/buffer_store.cpp
-  ${SRC}/net/conntrack.cpp
-  ${SRC}/net/dns/client.cpp
-  ${SRC}/net/dns/dns.cpp
-  ${SRC}/net/ethernet/ethernet.cpp
-  ${SRC}/net/http/basic_client.cpp
-  ${SRC}/net/http/client_connection.cpp
-  ${SRC}/net/http/cookie.cpp
-  ${SRC}/net/http/header.cpp
-  ${SRC}/net/http/header_fields.cpp
-  ${SRC}/net/http/message.cpp
-  ${SRC}/net/http/mime_types.cpp
-  ${SRC}/net/http/request.cpp
-  ${SRC}/net/http/response.cpp
-  ${SRC}/net/http/status_codes.cpp
-  ${SRC}/net/http/time.cpp
-  ${SRC}/net/http/version.cpp
-  ${SRC}/net/checksum.cpp
-  ${SRC}/net/inet.cpp
-  ${SRC}/net/interfaces.cpp
-  ${SRC}/net/ip4/arp.cpp
-  ${SRC}/net/ip4/icmp4.cpp
-  ${SRC}/net/ip4/ip4.cpp
-  ${SRC}/net/ip4/reassembly.cpp
-  ${SRC}/net/ip4/udp.cpp
-  ${SRC}/net/ip4/udp_socket.cpp
-  ${SRC}/net/ip6/icmp6.cpp
-  ${SRC}/net/ip6/ndp.cpp
-  ${SRC}/net/ip6/ip6.cpp
-  ${SRC}/net/dhcp/dh4client.cpp
-  ${SRC}/net/nat/nat.cpp
-  ${SRC}/net/nat/napt.cpp
-  ${SRC}/net/tcp/connection.cpp
-  ${SRC}/net/tcp/connection_states.cpp
-  ${SRC}/net/tcp/listener.cpp
-  ${SRC}/net/tcp/rttm.cpp
-  ${SRC}/net/tcp/tcp.cpp
-  ${SRC}/net/tcp/read_buffer.cpp
-  ${SRC}/net/tcp/read_request.cpp
-  ${SRC}/net/tcp/stream.cpp
-  ${SRC}/net/tcp/write_queue.cpp
-  ${SRC}/posix/fd.cpp
-  ${SRC}/util/async.cpp
-  ${SRC}/util/crc32.cpp
-  ${SRC}/util/logger.cpp
-  ${SRC}/util/path_to_regex.cpp
-  ${SRC}/util/percent_encoding.cpp
-  ${SRC}/util/sha1.cpp
-  ${SRC}/util/statman.cpp
-  ${SRC}/util/syslog_facility.cpp
-  ${SRC}/util/syslogd.cpp
-  ${SRC}/util/tar.cpp
-  ${SRC}/util/uri.cpp
-  ${SRC}/virtio/virtio_queue.cpp
-)
-
+#TODO get from conan!!! or should the test be in liveupdate and not vise versa?
 set(MOD_OBJECTS
   #${INCLUDEOS_ROOT}/lib/LiveUpdate/hotswap.cpp
   ${INCLUDEOS_ROOT}/lib/LiveUpdate/partition.cpp
@@ -287,41 +216,50 @@ set(MOD_OBJECTS
 #TODO investigate
 
 enable_testing()
+if (CPPCHECK)
+  find_program(CMAKE_CXX_CPPCHECK NAMES cppcheck)
+  if (NOT CMAKE_CXX_CPPCHECK)
+    message(WARNING "cppcheck not found")
+  else()
+      list(
+          APPEND CMAKE_CXX_CPPCHECK
+              "--enable=warning"
+              "--inconclusive"
+              "--force"
+              "--inline-suppr"
+            #TODO   "--suppressions-list=${CMAKE_SOURCE_DIR}/CppCheckSuppressions.txt"
+      )
+  endif()
+endif()
 
 add_subdirectory(../src os)
 
+#TODO add_subdirectory would be nicer
 add_library(lest_util ${LEST_UTIL})
+#TODO add_subdirectory would be nicer
 add_library(liveupdate ${MOD_OBJECTS})
 
 file(COPY memdisk.fat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 
-
 foreach(T ${TEST_SOURCES})
   #CTest style
+  #get the filename witout extension
   get_filename_component(NAME ${T} NAME_WE)
   add_executable(${NAME} ${T})
   target_link_libraries(${NAME} liveupdate os lest_util  m stdc++ ${CONAN_LIB_DIRS_HTTP-PARSER}/http_parser.o)
   add_test(${NAME} bin/${NAME})
 endforeach()
 
-
-if(EXTRA_TESTS)
-  set(GENERATE_SUPPORT_FILES ON)
-  message(STATUS "Adding some extra tests")
-  list(APPEND TEST_SOURCES ${TEST}/kernel/unit/rdrand_test.cpp)
-  list(APPEND TEST_SOURCES ${TEST}/util/unit/tar_test.cpp)
-
-endif()
-
 if(COVERAGE)
-  message(STATUS "Coverage")
-  list(REMOVE_ITEM TEST_SOURCES ${TEST}/util/unit/path_to_regex_no_options.cpp)
+#  message(STATUS "Coverage")
+#  list(REMOVE_ITEM TEST_SOURCES ${TEST}/util/unit/path_to_regex_no_options.cpp)
+#wouldnt a --coverage on a general level do it ?
   set_property(SOURCE ${OS_SOURCES} PROPERTY COMPILE_FLAGS --coverage)
   set_property(SOURCE ${TEST_SOURCES} PROPERTY COMPILE_FLAGS --coverage)
   set_property(SOURCE ${MOD_OBJECTS} PROPERTY COMPILE_FLAGS --coverage)
   set_property(SOURCE ${LEST_UTIL} PROPERTY COMPILE_FLAGS --coverage)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  #set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 
 if(TRAVIS)
@@ -356,15 +294,33 @@ if(SILENT_BUILD)
   " -Wno-unused-variable -Wno-unused-parameter -Wno-sign-compare -Wno-format")
 endif()
 
-add_executable(unittests ${SOURCES})
-target_link_libraries(unittests os lest_util ${CONAN_LIB_DIRS_HTTP-PARSER}/http_parser.o ${CONAN_LIBS} m stdc++)
+#disabled old DUNITTESTS
+if (COVERAGE)
+  if (NOT DEFINED CODECOV_OUTPUTFILE )
+      set( CODECOV_OUTPUTFILE coverage.info )
+  endif()
 
-install(TARGETS unittests DESTINATION ${TEST})
+  if (NOT DEFINED CODECOV_HTMLOUTPUTDIR )
+      set( CODECOV_HTMLOUTPUTDIR ${CMAKE_CURRENT_BINARY_DIR}/html )
+  endif()
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    find_program(CODECOV_LCOV lcov)
+    find_program(CODECOV_GENHTML genhtml)
+    add_custom_target(coverage_init ALL
+      COMMAND ${CODECOV_LCOV} --base-directory . --directory ${CMAKE_CURRENT_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial
+    )
+    add_custom_target(coverage
+      COMMAND ${CODECOV_LCOV} --base-directory . --directory ${CMAKE_CURRENT_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture
+      COMMAND ${CODECOV_LCOV} --remove ${CODECOV_OUTPUTFILE} '/usr/lib/*' '/usr/include/*' -o ${CODECOV_OUTPUTFILE}
+      COMMAND ${CODECOV_GENHTML} -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE}
+    )
+  endif()
+endif()
 
 if (GENERATE_SUPPORT_FILES)
 
-  add_custom_command(
-    TARGET unittests PRE_BUILD
+  add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/test-tar-gz-inside.tar
+    PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E tar cf ${CMAKE_CURRENT_BINARY_DIR}/test-single.tar ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
     COMMAND ${CMAKE_COMMAND} -E tar cf ${CMAKE_CURRENT_BINARY_DIR}/test-multiple.tar ${CMAKE_CURRENT_SOURCE_DIR}/*.py
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt ${CMAKE_CURRENT_BINARY_DIR}/test-invalid.tar
@@ -375,27 +331,11 @@ if (GENERATE_SUPPORT_FILES)
     )
 endif()
 
-add_custom_target(
-  cppcheck
-  COMMAND cppcheck
-  --enable=warning,style,performance,portability
-  --force
-  --platform=unix32
-  --std=c++11
-  --verbose
-  --quiet
-  -I ${INCLUDEOS_ROOT}/api
-  -I ${INCLUDEOS_ROOT}/src/include
-  -I ${INCLUDEOS_ROOT}/mod/
-  -I ${INCLUDEOS_ROOT}/mod/GSL
-  -I ${INCLUDEOS_ROOT}/mod/uzlib/src
-  ${OS_SOURCES}
-)
-
+#TODO fix clang tidy target ?
 add_custom_target(
   clang-tidy
   COMMAND clang-tidy-3.8
   -checks=clang-analyzer-core.*,clang-analyzer-cplusplus.*,clang-analyzer-deadcode.*,clang-analyzer-nullability,cppcoreguidelines*,modernize*,performance*,misc*,-misc-virtual-near-miss
   -p=compile_commands.json
-  ${OS_SOURCES}
+  #${OS_SOURCES}
 )

--- a/test/fs/unit/memdisk_test.cpp
+++ b/test/fs/unit/memdisk_test.cpp
@@ -27,8 +27,8 @@ CASE("memdisk properties")
   EXPECT(disk.fs_ready() == false);
   EXPECT(disk.name() == "memdisk0");
   EXPECT(disk.dev().size() == 0ull);
-  EXPECT(disk.dev().device_type() == "Block device");
-  EXPECT(disk.dev().driver_name() == "MemDisk");
+  EXPECT(disk.dev().device_type() ==  std::string("Block device"));
+  EXPECT(disk.dev().driver_name() == std::string("MemDisk"));
   bool enumerated_partitions {false};
 
   disk.partitions(

--- a/test/kernel/unit/service_stub_test.cpp
+++ b/test/kernel/unit/service_stub_test.cpp
@@ -20,10 +20,10 @@
 
 CASE("Service::binary_name() returns name of binary")
 {
-  EXPECT(Service::binary_name() == "Service binary name");
+  EXPECT(Service::binary_name() == std::string("Service binary name"));
 }
 
 CASE("Service::name() returns name of service")
 {
-  EXPECT(Service::name() == "Service name");
+  EXPECT(Service::name() == std::string("Service name"));
 }


### PR DESCRIPTION
Fixed code coverage
#run cmake
cmake -DCOVERAGE=ON <path>/test
#run tests
make test run
#generate coverage
make coverage
#open the html/index.html in a browser to view the code coveage

Need lcov and genhtml installed.