### PR TITLE
Added install script for installation on a vagrant box with setting e…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision "shell",
                         inline: "echo cd /IncludeOS >> /home/ubuntu/.bashrc"
 
-    config.vm.synced_folder "~/IncludeOS_install",
-                            "/home/vagrant/IncludeOS_install", create: true
+    config.vm.synced_folder ".",
+                            "/home/vagrant/IncludeOS", create: true
 
     config.vm.provision "shell", inline: "apt-get update && apt-get install -qq git"
   end

--- a/install_on_vagrant.sh
+++ b/install_on_vagrant.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+locale-gen "en_US.UTF-8"
+export LC_ALL="en_US.UTF-8"
+cat <<EOT > /etc/environment
+LC_ALL="en_US.UTF-8"
+EOT
+cd /IncludeOS
+echo "Y" | ./install.sh
+export INCLUDEOS_PREFIX=/usr/local
+export PATH=$PATH:$INCLUDEOS_PREFIX/includeos/bin
+export CC="clang-5.0"
+export CXX="clang++-5.0"
+cat <<EOT > /etc/environment
+INCLUDEOS_PREFIX=/usr/local
+CC="clang-5.0"
+CXX="clang++-5.0"
+EOT
+
+cat <<EOT > /etc/profile
+
+PATH=$PATH:$INCLUDEOS_PREFIX/includeos/bin
+EOT


### PR DESCRIPTION
…nvironment for IncludeOS. This changed setup is, IMHO, easier for the user to use. It has the pre-condition that the vagrant box is started from the directory in which the Vagranfile is stored. This way users can clone the IncludeOS repo anywhere they like. The documentation needs to be updated. I couldn't find the repo with documentation. I'm willing to change the documentation, can you send me a link to the repo for the documentation? The change to the documentation is simple. The line that says: vagrant ssh --command=/IncludeOS/etc/install_from_bundle.sh should be changed to vagrant ssh --command='sudo /IncludeOS/install_on_vagrant.sh'