### PR TITLE
Jenkins: Upload code coverage HTML output and comment with link

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     CHAN = 'test'
     MOD_VER= '0.13.0'
     REMOTE = 'includeos-test'
+    COVERAGE_DIR = "${env.COVERAGE_DIR}/${env.JOB_NAME}"
   }
 
   stages {
@@ -110,8 +111,8 @@ pipeline {
         }
         stage('Code coverage') {
           steps {
-            sh script: "mkdir -p coverage", label: "Setup"
-            sh script: "cd coverage; env CC=gcc CXX=g++ cmake -DCOVERAGE=ON ../test", label: "Cmake"
+            sh script: "mkdir -p coverage; rm -r $COVERAGE_DIR || :", label: "Setup"
+            sh script: "cd coverage; env CC=gcc CXX=g++ cmake -DCOVERAGE=ON -DCODECOV_HTMLOUTPUTDIR=$COVERAGE_DIR ../test", label: "Cmake"
             sh script: "cd coverage; make -j $CPUS", label: "Make"
             sh script: "cd coverage; make coverage", label: "Make coverage"
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,6 +116,15 @@ pipeline {
             sh script: "cd coverage; make -j $CPUS", label: "Make"
             sh script: "cd coverage; make coverage", label: "Make coverage"
           }
+          post {
+            success {
+              script {
+                if (env.CHANGE_ID) {
+                  pullRequest.comment("Code coverage: ${env.COVERAGE_ADDRESS}/${env.JOB_NAME}")
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Will leave a link to the coverage reports in every PR.

http://vaskemaskin.includeos.org:8080/coverage_includeos/
Here are the currently uploaded coverage reports. 