### PR TITLE
Dockerfile: Simplified dockerfile that works for conan workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,1 @@
-build_*
-IncludeOS_install/
-**/build
-Dockerfile
+*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update
 RUN apt-get -y install \
     clang-6.0 \
     cmake \
+    nasm \
     curl \
     git \
     && rm -rf /var/lib/apt/lists/*
@@ -20,3 +21,9 @@ ENV CC=clang-6.0 \
     CXX=clang++-6.0
 RUN mkdir service
 WORKDIR service
+
+CMD mkdir -p build && \
+    cd build && \
+    conan install .. -pr clang-6.0-linux-x86_64 && \
+    cmake .. && \
+    make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,31 @@
-from ubuntu:18.04
+FROM ubuntu:18.04
 
-RUN apt-get update
-RUN apt-get -y install \
-    clang-6.0 \
+ARG clang_version=6.0
+RUN apt-get update && \
+    apt-get -y install \
+    clang-$clang_version \
     cmake \
     nasm \
     curl \
-    git \
-    && rm -rf /var/lib/apt/lists/*
+    git && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install and configure Conan
-ENV conan_version=1_12_3
-RUN curl -Lo conan.deb https://dl.bintray.com/conan/installers/conan-ubuntu-64_$conan_version.deb \
-    && dpkg --install conan.deb \
-    && rm conan.deb
-RUN conan config install https://github.com/includeos/conan_config.git
+ARG conan_version=1_12_3
+RUN curl -Lo conan.deb https://dl.bintray.com/conan/installers/conan-ubuntu-64_$conan_version.deb && \
+    dpkg --install conan.deb && \
+    rm conan.deb
+RUN conan config install https://github.com/includeos/conan_config.git && \
+    conan config set general.default_profile=clang-$clang_version-linux-x86_64
 
 # Configure build environment
-ENV CC=clang-6.0 \
-    CXX=clang++-6.0
-RUN mkdir service
-WORKDIR service
+ENV CC=clang-$clang_version \
+    CXX=clang++-$clang_version
 
-CMD mkdir -p build && \
-    cd build && \
-    conan install .. -pr clang-6.0-linux-x86_64 && \
+# The files to be built must be hosted in a catalog called /service
+# Default is to install conan dependencies and build
+CMD mkdir -p /service/build && \
+    cd /service/build && \
+    conan install .. && \
     cmake .. && \
-    make
+    cmake --build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,111 +1,22 @@
-FROM ubuntu:xenial as base
+from ubuntu:18.04
 
-RUN apt-get update && apt-get -y install \
-    sudo \
-    curl \
-    locales \
-    && rm -rf /var/lib/apt/lists/*
-RUN locale-gen en_US.UTF-8
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
-RUN echo "LANG=C.UTF-8" > /etc/default/locale
-
-# Add fixuid to change permissions for bind-mounts. Set uid to same as host with -u <uid>:<guid>
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/sh --disabled-password --gecos "" docker && \
-    usermod -aG sudo docker && \
-    sed -i.bkp -e \
-      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
-      /etc/sudoers
-RUN USER=docker && \
-    GROUP=docker && \
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.3/fixuid-0.3-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
-    chown root:root /usr/local/bin/fixuid && \
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /service\n" > /etc/fixuid/config.yml
-
-ARG VCSREF
-ARG VERSION
-
-LABEL org.label-schema.schema-version="1.0" \
-      org.label-schema.vcs-url="https://github.com/hioa-cs/includeos" \
-      org.label-schema.vendor="IncludeOS" \
-      org.label-schema.vcs-ref=$VCSREF \
-      org.label-schema.version=$VERSION
-
-#########################
-FROM base as source-build
-
-RUN apt-get update && apt-get -y install \
-    git \
-    lsb-release \
-    net-tools \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /root/IncludeOS
-WORKDIR /root/IncludeOS
-COPY . .
-
-# Ability to specify custom tag that overwrites any existing tag. This will then match what IncludeOS reports itself.
-ARG VERSION
-RUN git describe --tags --dirty > /ios_version.txt
-RUN echo ${VERSION:=$(git describe --tags --dirty)} && git tag -d $(git describe --tags); git tag $VERSION && git describe --tags --dirty > /version.txt
-
-# Installation
-RUN ./install.sh -n
-
-#############################
-FROM base as grubify
-
-RUN apt-get update && apt-get -y install \
-  dosfstools \
-  grub-pc
-
-LABEL org.label-schema.description="Add a grub bootloader to any binary" \
-      org.label-schema.name="IncludeOS_grubify"
-
-COPY --from=source-build /usr/local/includeos/scripts/grubify.sh /home/ubuntu/IncludeOS_install/includeos/scripts/grubify.sh
-
-ENTRYPOINT ["fixuid", "/home/ubuntu/IncludeOS_install/includeos/scripts/grubify.sh"]
-
-###########################
-FROM base as build
-
-RUN apt-get update && apt-get -y install \
-    git \
-    clang-5.0 \
+RUN apt-get update
+RUN apt-get -y install \
+    clang-6.0 \
     cmake \
-    nasm \
-    python-pip \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install pystache antlr4-python2-runtime && \
-    apt-get remove -y python-pip && \
-    apt autoremove -y
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
 
-# Metadata used for labels
-ARG BUILDDATE
+# Install and configure Conan
+ENV conan_version=1_12_3
+RUN curl -Lo conan.deb https://dl.bintray.com/conan/installers/conan-ubuntu-64_$conan_version.deb \
+    && dpkg --install conan.deb \
+    && rm conan.deb
+RUN conan config install https://github.com/includeos/conan_config.git
 
-LABEL org.label-schema.description="Build a service using IncludeOS" \
-      org.label-schema.name="IncludeOS_builder" \
-      org.label-schema.docker.cmd="docker run -v $PWD:/service <container>" \
-      org.label-schema.build-date=$BUILDDATE
-
-WORKDIR /service
-
-COPY --from=source-build  /usr/local/includeos /usr/local/includeos/
-COPY --from=source-build  /root/IncludeOS/etc/use_clang_version.sh /
-COPY --from=source-build  /root/IncludeOS/lib/uplink/starbase /root/IncludeOS/lib/uplink/starbase/
-COPY --from=source-build  /ios_version.txt /
-COPY --from=source-build  /version.txt /
-COPY --from=source-build  /root/IncludeOS/etc/docker_entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-
-CMD mkdir -p build && \
-  cd build && \
-  cp $(find /usr/local/includeos -name chainloader) /service/build/chainloader && \
-  echo "IncludeOS reported version:" $(cat /ios_version.txt) "label Version:" $(cat /version.txt) && \
-  cmake .. && \
-  make
+# Configure build environment
+ENV CC=clang-6.0 \
+    CXX=clang++-6.0
+RUN mkdir service
+WORKDIR service


### PR DESCRIPTION
Does not cache any IncludeOS version, but inits conan with our config and contains the build tools (clang and nasm) required for building. 