### PR TITLE
build: removed ARCH as part of the path to libraries/drivers/plugins/etc

### DIFF
--- a/src/arch/i686/linker.ld
+++ b/src/arch/i686/linker.ld
@@ -67,9 +67,9 @@ SECTIONS
   .init_array :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
-    */x86_64/lib/lib*.a:*(.init_array* .ctors*)
-    */x86_64/platform/lib*.a:*(.init_array* .ctors*)
-    */x86_64/drivers/lib*.a:*(.init_array* .ctors*)
+    */lib/lib*.a:*(.init_array* .ctors*)
+    */platform/lib*.a:*(.init_array* .ctors*)
+    */drivers/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__init_array_end = .);
   }
 
@@ -77,7 +77,7 @@ SECTIONS
   .stdout_ctors :
   {
     PROVIDE_HIDDEN (__stdout_ctors_start = .);
-    */x86_64/drivers/stdout/lib*.a:*(.init_array* .ctors*)
+    */drivers/stdout/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__stdout_ctors_end = .);
   }
 
@@ -85,7 +85,7 @@ SECTIONS
   .driver_ctors :
   {
     PROVIDE_HIDDEN (__driver_ctors_start = .);
-    */x86_64/drivers/lib*.a:*(.init_array* .ctors*)
+    */drivers/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__driver_ctors_end = .);
   }
 
@@ -93,7 +93,7 @@ SECTIONS
   .plugin_ctors :
   {
     PROVIDE_HIDDEN (__plugin_ctors_start = .);
-    */x86_64/plugins/lib*.a:*(.init_array* .ctors*)
+    */plugins/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__plugin_ctors_end = .);
   }
 

--- a/src/arch/x86_64/linker.ld
+++ b/src/arch/x86_64/linker.ld
@@ -71,8 +71,8 @@ SECTIONS
   .init_array :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
-    */x86_64/lib/lib*.a:*(.init_array* .ctors*)
-    */x86_64/platform/lib*.a:*(.init_array* .ctors*)
+    */lib/lib*.a:*(.init_array* .ctors*)
+    */platform/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__init_array_end = .);
   }
 
@@ -80,7 +80,7 @@ SECTIONS
   .stdout_ctors :
   {
     PROVIDE_HIDDEN (__stdout_ctors_start = .);
-    */x86_64/drivers/stdout/lib*.a:*(.init_array* .ctors*)
+    */drivers/stdout/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__stdout_ctors_end = .);
   }
 
@@ -88,7 +88,7 @@ SECTIONS
   .driver_ctors :
   {
     PROVIDE_HIDDEN (__driver_ctors_start = .);
-    */x86_64/drivers/lib*.a:*(.init_array* .ctors*)
+    */drivers/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__driver_ctors_end = .);
   }
 
@@ -96,7 +96,7 @@ SECTIONS
   .plugin_ctors :
   {
     PROVIDE_HIDDEN (__plugin_ctors_start = .);
-    */x86_64/plugins/lib*.a:*(.init_array* .ctors*)
+    */plugins/lib*.a:*(.init_array* .ctors*)
     PROVIDE_HIDDEN (__plugin_ctors_end = .);
   }
 


### PR DESCRIPTION
Removed the need to have the ARCH in path to libraries. This makes it easier to create custom drivers/plugins/etc in conan for multiarch